### PR TITLE
恢复聊天思考与 Akasha 卡片，修复断线恢复 [skip ci]

### DIFF
--- a/frontend/chat/src/desktop-chat-lifecycle.test.mjs
+++ b/frontend/chat/src/desktop-chat-lifecycle.test.mjs
@@ -64,9 +64,9 @@ async function mountChat(t, strict = false) {
     WebSocket: Socket,
     IS_REACT_ACT_ENVIRONMENT: true,
     fetch(url, options = {}) {
-      assert.equal(url, "/api/shell/state");
       return new Promise((resolve, reject) => {
         const request = {
+          url,
           signal: options.signal,
           finish: (body) => resolve(new Response(JSON.stringify(body))),
         };
@@ -162,7 +162,7 @@ test("断线重试保留十二次上限，成功连接后重新计数", async (t
   }
   await fail();
   assert.equal(chat.sockets.length, 18);
-  assert.equal(chat.controller().error, "聊天连接已断开，请刷新页面重试");
+  assert.equal(chat.controller().error, "暂时无法连接，请重试");
   await chat.tick(60_000);
   assert.equal(chat.sockets.length, 18);
 });
@@ -182,4 +182,26 @@ test("StrictMode 重挂载与重试等待中的卸载不留下连接或监听器
     assert.equal(socket.onopen, null);
     assert.equal(socket.onclose, null);
   }
+});
+
+
+test("短暂健康失败不取消当前历史，重连成功清除连接提示", async (t) => {
+  const chat = await mountChat(t);
+  await act(async () => {
+    chat.sockets[0].open();
+    chat.requests[0].finish({ status: "ready", configured: true, chatReady: true });
+  });
+  await act(async () => chat.controller().activateSession("akashic:test"));
+  const history = chat.requests.find((item) => item.url.includes("/messages?"));
+  assert.ok(history);
+  await chat.tick(1200);
+  await act(async () => chat.requests.filter((item) => item.url === "/api/shell/state").at(-1)
+    .finish({ status: "starting", configured: true, chatReady: false }));
+  assert.equal(history.signal.aborted, false);
+  await act(async () => history.finish({ version: 2, items: [], through_seq: -1, before_seq: null, has_more: false }));
+  await act(async () => { chat.sockets.at(-1).open(); chat.sockets.at(-1).close(1006); });
+  assert.match(chat.controller().error, /重新连接/u);
+  await chat.tick(1200);
+  await act(async () => chat.sockets.at(-1).open());
+  assert.equal(chat.controller().error, "");
 });

--- a/frontend/chat/src/desktop-chat-lifecycle.test.mjs
+++ b/frontend/chat/src/desktop-chat-lifecycle.test.mjs
@@ -194,11 +194,13 @@ test("短暂健康失败不取消当前历史，重连成功清除连接提示",
   await act(async () => chat.controller().activateSession("akashic:test"));
   const history = chat.requests.find((item) => item.url.includes("/messages?"));
   assert.ok(history);
+  assert.equal(chat.controller().historyLoading, true);
   await chat.tick(1200);
   await act(async () => chat.requests.filter((item) => item.url === "/api/shell/state").at(-1)
     .finish({ status: "starting", configured: true, chatReady: false }));
   assert.equal(history.signal.aborted, false);
   await act(async () => history.finish({ version: 2, items: [], through_seq: -1, before_seq: null, has_more: false }));
+  assert.equal(chat.controller().historyLoading, false, "空会话加载完成后不再显示读取提示");
   await act(async () => { chat.sockets.at(-1).open(); chat.sockets.at(-1).close(1006); });
   assert.match(chat.controller().error, /重新连接/u);
   await chat.tick(1200);

--- a/frontend/chat/src/desktop-chat-view.tsx
+++ b/frontend/chat/src/desktop-chat-view.tsx
@@ -91,7 +91,7 @@ export function DesktopChatView({ embeddedShell, embeddedRuntime, controller }: 
         </header>
         <Conversation className="conversation" resize="instant">
           <ConversationContent className={hasMessages ? "conversation-content" : "conversation-content empty"}>
-            {!hasMessages ? <DesktopEmptyState shellStatus={shellState?.status ?? null} /> : (
+            {!hasMessages ? <DesktopEmptyState shellStatus={shellState?.status ?? null} loadingSession={Boolean(activeSessionId)} /> : (
               <MessageRendererErrorBoundary>
                 <DesktopHistoryLoader
                   firstMessageId={timelineMessages[0]?.id ?? messages[0]?.id}
@@ -177,9 +177,9 @@ function DesktopHistoryLoader({
   >{loading ? "正在加载更早消息…" : "加载更早消息"}</button>;
 }
 
-function DesktopEmptyState({ shellStatus }: { shellStatus: string | null }) {
+function DesktopEmptyState({ shellStatus, loadingSession }: { shellStatus: string | null; loadingSession: boolean }) {
   return <ConversationEmptyState className="home-state">
-    {shellStatus === "needs_setup" ? <div className="model-connection-state">
+    {loadingSession ? <div className="home-state__ready" role="status"><strong>正在读取消息</strong></div> : shellStatus === "needs_setup" ? <div className="model-connection-state">
       <span>首次使用</span><h1>先连接一个模型</h1>
       <p>绑定 Codex、OpenCode 或自己的 API Key 后，就可以在这里直接对话。</p>
       <a href="/#models">连接模型</a>

--- a/frontend/chat/src/desktop-chat-view.tsx
+++ b/frontend/chat/src/desktop-chat-view.tsx
@@ -38,7 +38,7 @@ export function DesktopChatView({ embeddedShell, embeddedRuntime, controller }: 
     surface, sidebarSessions, activeSessionId, pendingSessionId, chatReady, messages, timelineMessages, replyActivities, replyAvailable, status,
     streamStore, messageElementsRef, copiedMessageId, shellState, stopPending, modelState,
     selectedRuntimeId, selectedReasoningEffort, replyTarget, error, mobilePairingOpen,
-    historyHasMore, historyLoadingOlder, loadOlderMessages,
+    historyHasMore, historyLoading, historyLoadingOlder, loadOlderMessages,
     activateSession, openRuntime, startNewChat, handleReplyMessage, handleCopiedMessage,
     reportError, handleModelChange, cancelReply, sendMessage, stopTurn, retry,
     setMobilePairingOpen,
@@ -91,7 +91,7 @@ export function DesktopChatView({ embeddedShell, embeddedRuntime, controller }: 
         </header>
         <Conversation className="conversation" resize="instant">
           <ConversationContent className={hasMessages ? "conversation-content" : "conversation-content empty"}>
-            {!hasMessages ? <DesktopEmptyState shellStatus={shellState?.status ?? null} loadingSession={Boolean(activeSessionId)} /> : (
+            {!hasMessages ? <DesktopEmptyState shellStatus={shellState?.status ?? null} loadingSession={historyLoading} /> : (
               <MessageRendererErrorBoundary>
                 <DesktopHistoryLoader
                   firstMessageId={timelineMessages[0]?.id ?? messages[0]?.id}

--- a/frontend/chat/src/desktop-conversation.tsx
+++ b/frontend/chat/src/desktop-conversation.tsx
@@ -1,4 +1,4 @@
-import { isTimelineMessageVisible } from "./message-timeline";
+import { timelineVisibleMessages, timelineToolResults } from "./message-timeline";
 import { timelineReply, timelineText, type TimelineMessage, type TimelineReply } from "./message-timeline";
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { useStickToBottomContext } from "use-stick-to-bottom";
@@ -275,6 +275,7 @@ export function DesktopTimelineMessages({ messages, status, messageElementsRef, 
   const { stopScroll } = useStickToBottomContext();
   const byId = useMemo(() => new Map(messages.map((message) => [message.id, message])), [messages]);
   const lookupMessage = useCallback((id: string) => byId.get(id), [byId]);
+  const toolResults = useMemo(() => timelineToolResults(messages), [messages]);
   const onNavigate = useCallback((id: string, partIndex?: number) => {
     stopScroll();
     const row = messageElementsRef.current.get(id);
@@ -282,14 +283,14 @@ export function DesktopTimelineMessages({ messages, status, messageElementsRef, 
     target?.focus({ preventScroll: true });
     target?.scrollIntoView({ behavior: "instant", block: "center" });
   }, [messageElementsRef, stopScroll]);
-  return <>{messages.filter(isTimelineMessageVisible).map((message) => <div key={message.id}
+  return <>{timelineVisibleMessages(messages).map((message) => <div key={message.id}
     className={`web-message-anchor history-isolated timeline-${message.body.kind}`}
     tabIndex={-1} data-message-id={message.id} data-message-kind={message.body.kind} data-message-seq={message.seq}
     ref={(element) => {
       if (element) messageElementsRef.current.set(message.id, element);
       else messageElementsRef.current.delete(message.id);
     }}>
-    <TimelineMessageView message={message} lookupMessage={lookupMessage} onNavigate={onNavigate} onError={onError}
+    <TimelineMessageView message={message} lookupMessage={lookupMessage} toolResults={toolResults} onNavigate={onNavigate} onError={onError}
       leadingContent={message.body.kind === "output" ? <MobilePluginSlot name="turn.before_reasoning"
         sessionId={message.session_id} messageId={message.id} /> : undefined}
       beforePart={(part, index) => part.kind === "tool_call" && !("display" in part) ? <MobilePluginSlot

--- a/frontend/chat/src/message-timeline.test.mjs
+++ b/frontend/chat/src/message-timeline.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { chatHistoryPage, sessionPage } from "./web-chat-data.ts";
-import { timelineAnchorIndexes, historyTranscript, isTimelineMessageVisible, isTimelinePartVisible, mergeTimelineMessages, readMessageLogFrame, readTimelineMessage, timelineReply, timelineText } from "./message-timeline.ts";
+import { timelineVisibleMessages, timelineToolResults, timelineAnchorIndexes, historyTranscript, isTimelineMessageVisible, isTimelinePartVisible, mergeTimelineMessages, readMessageLogFrame, readTimelineMessage, timelineReply, timelineText } from "./message-timeline.ts";
 
 const row = (seq, body, changes = {}) => ({
   id: `message-${seq}`, session_id: "akashic:fixture", seq,
@@ -152,4 +152,32 @@ test("hidden history anchors resolve to nearby visible rows without changing raw
   assert.equal(timelineAnchorIndexes([hidden(0)]).size, 0);
   assert.equal(timelineAnchorIndexes(messages).get("missing"), undefined);
   assert.deepEqual(messages, before);
+});
+
+
+test("内部来源与索引信息不显示成正文，未知内容仍明确提示", () => {
+  const parts = ["channel.origin", "context.summary", "command.result", "tool.selection", "akasha.recall", "akasha.feedback"]
+    .map((kind) => ({ kind, display: "unavailable" }));
+  const message = row(2, { kind: "input", parts: [...parts, text("晚上好")] });
+  const before = structuredClone(message);
+  assert.equal(isTimelineMessageVisible(message), true);
+  assert.deepEqual(message.body.parts.filter(isTimelinePartVisible), [text("晚上好")]);
+  assert.equal(isTimelinePartVisible({ kind: "future.content", display: "unavailable" }), true);
+  assert.deepEqual(message, before);
+});
+
+
+test("工具结果回到原调用面板，分页缺少调用时仍可阅读和定位", () => {
+  const call = row(3, { kind: "output", finish: "continue", parts: [
+    { kind: "tool_call", binding_id: "read", name: "read", arguments: {} },
+  ] });
+  const result = row(4, { kind: "tool_result", call_ref: { message_id: call.id, part_index: 0 },
+    outcome: "success", parts: [text("文件内容")] });
+  const answer = row(5, { kind: "output", finish: "complete", parts: [text("答案")] });
+  const messages = [call, result, answer];
+  assert.deepEqual(timelineVisibleMessages(messages), [call, answer]);
+  assert.equal(timelineToolResults(messages).get(`${call.id}:0`), result);
+  assert.equal(timelineAnchorIndexes(messages).get(result.id), 0);
+  assert.deepEqual(timelineVisibleMessages([result, answer]), [result, answer]);
+  assert.deepEqual(messages, [call, result, answer]);
 });

--- a/frontend/chat/src/message-timeline.ts
+++ b/frontend/chat/src/message-timeline.ts
@@ -242,7 +242,7 @@ export function historyTranscript(archive: unknown): HistoryTranscriptGroup[] | 
 
 /** 聊天可见性只影响布局，原始 Message、part index 和同步 seq 不变。 */
 export function isTimelinePartVisible(part: TimelinePart): boolean {
-  if ("display" in part) return true;
+  if ("display" in part) return !["channel.origin", "context.summary", "tool.selection", "command.result", "akasha.recall", "akasha.feedback"].includes(part.kind);
   if ("archive" in part) {
     if (part.kind !== "history.transcript") return false;
     const groups = historyTranscript(part.archive);
@@ -260,16 +260,40 @@ export function isTimelineMessageVisible(message: TimelineMessage): boolean {
 
 /** 隐藏行沿原始顺序定位后续可见行；末尾隐藏行使用前一可见行。 */
 export function timelineAnchorIndexes(messages: TimelineMessage[]): Map<string, number> {
+  const visibleIds = new Set(timelineVisibleMessages(messages).map((message) => message.id));
   const indexes = new Map<string, number>();
   const pending: string[] = [];
   let index = -1;
   for (const message of messages) {
     pending.push(message.id);
-    if (!isTimelineMessageVisible(message)) continue;
+    if (!visibleIds.has(message.id)) continue;
     index += 1;
     for (const id of pending) indexes.set(id, index);
     pending.length = 0;
   }
   if (index >= 0) for (const id of pending) indexes.set(id, index);
+  for (const message of messages) {
+    if (message.body.kind !== "tool_result" || visibleIds.has(message.id)) continue;
+    const callIndex = indexes.get(message.body.call_ref.message_id);
+    if (callIndex !== undefined) indexes.set(message.id, callIndex);
+  }
   return indexes;
+}
+
+/** 结果按原调用引用索引，展示层不推测工具是否完成。 */
+export function timelineToolResults(messages: TimelineMessage[]): Map<string, TimelineMessage> {
+  return new Map(messages.flatMap((message) => message.body.kind === "tool_result"
+    ? [[`${message.body.call_ref.message_id}:${message.body.call_ref.part_index}`, message] as const] : []));
+}
+
+/** 已加载的工具结果在原调用面板中展示；缺少调用的分页仍保留结果行。 */
+export function timelineVisibleMessages(messages: TimelineMessage[]): TimelineMessage[] {
+  const byId = new Map(messages.map((message) => [message.id, message]));
+  return messages.filter((message) => {
+    if (!isTimelineMessageVisible(message)) return false;
+    if (message.body.kind !== "tool_result" || message.attachments.length) return true;
+    if (message.body.parts.some((part) => isTimelinePartVisible(part) && part.kind !== "text")) return true;
+    const call = byId.get(message.body.call_ref.message_id);
+    return call?.body.kind !== "output" || call.body.parts[message.body.call_ref.part_index]?.kind !== "tool_call";
+  });
 }

--- a/frontend/chat/src/message-view.tsx
+++ b/frontend/chat/src/message-view.tsx
@@ -1,3 +1,4 @@
+import { MobilePluginSlot } from "./mobile-plugin-runtime";
 import { ThinkingPlaceholder } from "./thinking-placeholder";
 import {
   Attachment,
@@ -47,7 +48,7 @@ import type {
   ToolBlock,
 } from "./chat-message";
 import type { ReplyActivity, TimelineAttachment, TimelineMessage, TimelinePart } from "./message-timeline";
-import { timelineReply, historyTranscript, isTimelinePartVisible } from "./message-timeline";
+import { timelineReply, timelineText, historyTranscript, isTimelinePartVisible } from "./message-timeline";
 import { MessageReplyReference } from "./message-actions";
 import { StaticMessageResponse } from "./static-message-response";
 
@@ -87,24 +88,26 @@ const MessageBody = memo(function MessageBody({
   );
 });
 
-/** 草稿是当前活动的预览；没有 Message 的作者、时间、seq 或插件槽。 */
+/** 草稿复用聊天的等待和思考组件，提交后由相同样式的历史行接替。 */
 export function ReplyActivityView({ activity, committed, onError }: {
   activity: ReplyActivity;
   committed: ReadonlySet<string>;
   onError?: (error: unknown) => void;
 }) {
   const draft = activity.preview && !committed.has(activity.preview.message_id) ? activity.preview : null;
-  return <div className="reply-activity" data-reply-handle={activity.handle}
+  if (activity.preview && !draft) return null;
+  return <div className="message-row agent-row reply-activity" data-reply-handle={activity.handle}
     data-preview-message-id={draft?.message_id} aria-busy={activity.active}>
-    <div className="reply-activity-label" role="status">
-      {activity.active ? draft ? "正在生成" : "正在处理" : "正在结束"}
-      <span>{activity.source}</span>
+    <div className="agent-content">
+      {draft && !draft.thinking ? <MobilePluginSlot name="turn.before_reasoning" sessionId={activity.session_id}
+        messageId={draft.message_id} block={{ source: activity.source }} /> : null}
+      {draft?.thinking ? <ProcessTrace blocks={[{ kind: "thinking", content: draft.thinking }]}
+        streaming={activity.active} interrupted={false}
+        startContent={<MobilePluginSlot name="turn.before_reasoning" sessionId={activity.session_id}
+          messageId={draft.message_id} block={{ source: activity.source }} />} /> : null}
+      {!draft?.thinking && !draft?.text ? <ThinkingPlaceholder /> : null}
+      {draft?.text ? <MessageBody content={draft.text} streaming={activity.active} deferRichContent onError={onError} /> : null}
     </div>
-    {draft?.thinking ? <details className="timeline-details">
-      <summary>思考</summary><p className="plain-message-response">{draft.thinking}</p>
-    </details> : null}
-    {draft?.text ? <MessageBody content={draft.text} streaming deferRichContent onError={onError} /> : null}
-    {draft?.truncated ? <p className="reply-activity-label">预览仅显示部分内容，完整内容将在提交后显示</p> : null}
   </div>;
 }
 
@@ -186,9 +189,10 @@ export function ChatMessageView({
   );
 }
 
-/** 按持久顺序展示每个内容块，结果和控制记录各占一行。 */
-export function TimelineMessageView({ message, lookupMessage, onNavigate, onError, leadingContent, beforePart, afterBody, renderAttachment }: {
+/** 保留消息引用与 part 位置，复用原聊天的过程和正文组件。 */
+export function TimelineMessageView({ message, lookupMessage, toolResults, onNavigate, onError, leadingContent, beforePart, afterBody, renderAttachment }: {
   message: TimelineMessage;
+  toolResults: ReadonlyMap<string, TimelineMessage>;
   renderAttachment?: (attachment: TimelineAttachment) => ReactNode;
   leadingContent?: ReactNode;
   beforePart?: (part: TimelinePart, index: number) => ReactNode;
@@ -198,6 +202,22 @@ export function TimelineMessageView({ message, lookupMessage, onNavigate, onErro
   onError?: (error: unknown) => void;
 }) {
   const body = message.body;
+  const process = body.kind !== "output" ? [] : body.parts.map((part, index) => ({ part, index }))
+    .sort((left, right) => Number(right.part.kind === "model.facts") - Number(left.part.kind === "model.facts"))
+    .flatMap(({ part, index }): { block: AgentBlock; index: number }[] => {
+    if ("display" in part) return [];
+    if (part.kind === "model.facts" && part.value.thinking) return [{ index, block: { kind: "thinking", content: part.value.thinking } }];
+    if ("archive" in part && part.kind === "history.transcript") {
+      return historyBlocks(part.archive).map((block) => ({ index, block }));
+    }
+    if (part.kind !== "tool_call") return [];
+    const result = toolResults.get(`${message.id}:${index}`);
+    const outcome = result?.body.kind === "tool_result" ? result.body.outcome : null;
+    return [{ index, block: { kind: "tool", callId: `${message.id}:${index}`, name: part.name,
+      input: part.arguments, output: result ? timelineText(result) : undefined,
+      status: outcome === null ? "input-available" : outcome === "success" ? "output-available" : "output-error",
+      errorText: outcome && outcome !== "success" ? outcomeLabels[outcome] : undefined } }];
+  });
   const referencedArtifacts = new Set(body.kind === "control" ? [] : body.parts.flatMap((part) =>
     !("display" in part) && part.kind === "artifact_ref" ? [part.value] : []));
   const attachment = (id: string) => {
@@ -209,7 +229,11 @@ export function TimelineMessageView({ message, lookupMessage, onNavigate, onErro
   };
   return <div className={`message-row timeline-message timeline-${body.kind}`}>
     <div className={body.kind === "input" ? "user-bubble" : "agent-content"}>
-      {leadingContent}
+      {process.length === 0 ? leadingContent : null}
+      {body.kind === "output" && process.length ? <ProcessTrace blocks={process.map((item) => item.block)} streaming={false}
+        interrupted={false} startContent={leadingContent} beforeBlock={(_block, index) => <div
+          data-part-index={process[index].index} tabIndex={-1}>{beforePart?.(
+            body.parts[process[index].index], process[index].index)}</div>} /> : null}
       {body.kind === "control" ? <div className="timeline-control-summary">
         <strong>{controlLabels[body.action]}</strong>
         {body.reason !== null ? <p className="plain-message-response">{body.reason}</p> : null}
@@ -221,10 +245,13 @@ export function TimelineMessageView({ message, lookupMessage, onNavigate, onErro
             {lookupMessage(body.call_ref.message_id) ? "查看调用" : "调用不在当前记录中"}
           </button>
         </div> : null}
-        {body.parts.map((part, index) => isTimelinePartVisible(part) ? <div key={index} data-part-index={index} tabIndex={-1}>
+        {body.parts.map((part, index) => ({ part, index })).sort((left, right) =>
+          Number(right.part.kind === "model.facts" || right.part.kind === "history.transcript")
+          - Number(left.part.kind === "model.facts" || left.part.kind === "history.transcript"))
+          .map(({ part, index }) => isTimelinePartVisible(part) && !process.some((item) => item.index === index) ? <div key={index} data-part-index={index} tabIndex={-1}>
           {beforePart?.(part, index)}
           <TimelinePartView part={part} attachment={attachment} lookupMessage={lookupMessage}
-            onNavigate={onNavigate} onError={onError} />
+            onNavigate={onNavigate} onError={onError} processStartContent={leadingContent} />
         </div> : null)}
       </>}
       {afterBody}
@@ -234,7 +261,8 @@ export function TimelineMessageView({ message, lookupMessage, onNavigate, onErro
   </div>;
 }
 
-function TimelinePartView({ part, attachment, lookupMessage, onNavigate, onError }: {
+function TimelinePartView({ part, attachment, lookupMessage, onNavigate, onError, processStartContent }: {
+  processStartContent?: ReactNode;
   part: TimelinePart;
   attachment: (id: string) => ReactNode;
   lookupMessage: (id: string) => TimelineMessage | undefined;
@@ -242,7 +270,7 @@ function TimelinePartView({ part, attachment, lookupMessage, onNavigate, onError
   onError?: (error: unknown) => void;
 }) {
   if ("display" in part) return <p className="timeline-state">无法展示此内容</p>;
-  if ("archive" in part) return part.kind === "history.transcript" ? <TimelineTranscript archive={part.archive} onError={onError} /> : null;
+  if ("archive" in part) return part.kind === "history.transcript" ? <TimelineTranscript archive={part.archive} startContent={processStartContent} onError={onError} /> : null;
   switch (part.kind) {
     case "text": return <MessageBody content={part.value} streaming={false} deferRichContent onError={onError} />;
     case "artifact_ref": return attachment(part.value);
@@ -252,11 +280,9 @@ function TimelinePartView({ part, attachment, lookupMessage, onNavigate, onError
         preview={source ? timelineReply(source).preview : ""} unavailable={!source}
         onNavigate={() => onNavigate(part.value)} />;
     }
-    case "model.facts": return <details className="timeline-details">
-      <summary>思考记录</summary>
-      {part.value.thinking === null ? <p>没有思考文本</p> : <MessageBody
-        content={part.value.thinking} streaming={false} deferRichContent onError={onError} />}
-    </details>;
+    case "model.facts": return part.value.thinking ? <ProcessTrace
+      blocks={[{ kind: "thinking", content: part.value.thinking }]} streaming={false}
+      interrupted={false} startContent={processStartContent} /> : null;
     case "tool_call": return <details className="timeline-details timeline-tool-call">
       <summary>工具调用 · {part.name}</summary>
       <pre tabIndex={0}>{JSON.stringify(part.arguments, null, 2)}</pre>
@@ -264,20 +290,22 @@ function TimelinePartView({ part, attachment, lookupMessage, onNavigate, onError
   }
 }
 
-function TimelineTranscript({ archive, onError }: { archive: unknown; onError?: (error: unknown) => void }) {
+/** 将归档转换成既有过程组件的展示块，原日志不变。 */
+function historyBlocks(archive: unknown): AgentBlock[] {
   const groups = historyTranscript(archive);
-  return <details className="timeline-details">
-    <summary>思考与工具记录</summary>
-    {groups === null ? <p>这段历史过程暂无法展示。</p> : groups.map((group, index) => <div key={index}>
-      {group.thinking ? <MessageBody content={group.thinking} streaming={false} deferRichContent onError={onError} /> : null}
-      {group.text ? <MessageBody content={group.text} streaming={false} deferRichContent onError={onError} /> : null}
-      {group.calls.map((call, callIndex) => <details className="timeline-details" key={callIndex}>
-        <summary>工具 · {call.name}</summary>
-        {call.arguments !== undefined ? <pre tabIndex={0}>{JSON.stringify(call.arguments, null, 2)}</pre> : null}
-        {call.result !== undefined ? <pre tabIndex={0}>{typeof call.result === "string" ? call.result : JSON.stringify(call.result, null, 2)}</pre> : null}
-      </details>)}
-    </div>)}
-  </details>;
+  return groups?.flatMap((group, index): AgentBlock[] => [
+    ...(group.thinking ? [{ kind: "thinking" as const, content: group.thinking }] : []),
+    ...(group.text ? [{ kind: "thinking" as const, content: group.text }] : []),
+    ...group.calls.map((call, callIndex) => ({ kind: "tool" as const,
+      callId: `history-${index}-${callIndex}`, name: call.name, input: call.arguments,
+      output: call.result, status: "output-available" as const, errorText: undefined })),
+  ]) ?? [];
+}
+
+function TimelineTranscript({ archive }: { archive: unknown; startContent?: ReactNode; onError?: (error: unknown) => void }) {
+  if (historyTranscript(archive) === null) return <p>这段历史过程暂无法展示。</p>;
+  const blocks = historyBlocks(archive);
+  return blocks.length ? <ProcessTrace blocks={blocks} streaming={false} interrupted={false} /> : null;
 }
 
 const controlLabels = { pause: "已暂停", resume: "已恢复", abandon: "已放弃", failure: "执行失败" };

--- a/frontend/chat/src/mobile-native.tsx
+++ b/frontend/chat/src/mobile-native.tsx
@@ -1,4 +1,5 @@
-import { isTimelineMessageVisible, timelineAnchorIndexes } from "./message-timeline";
+import { timelineVisibleMessages, timelineToolResults } from "./message-timeline";
+import { timelineAnchorIndexes } from "./message-timeline";
 import { TimelineMessageView, ReplyActivityView } from "./message-view";
 import { timelineReply, timelineText, type TimelineMessage, type TimelineAttachment } from "./message-timeline";
 import { applyMobileMessageEvent, mergeMobileMessageSnapshot, readMobileMessageLog, readMobileDownloads, readMobileStateSnapshot, type MobileMessageLog, type MobileDownload } from "./mobile-message-log";
@@ -1836,7 +1837,7 @@ export function MobileNativeApp() {
 const MobileMessageRow = React.memo(function MobileMessageRow({
   source, startsDay, followsSameRole, unreadCount, highlighted, selected, selectionActive,
   canReply, copied, selectedSessionUnavailable, messageElementsRef, onEnterSelection,
-  onToggleSelection, onReplyToMessage, onNavigateToReply, onCopyMessage, lookupMessage, downloads,
+  onToggleSelection, onReplyToMessage, onNavigateToReply, onCopyMessage, lookupMessage, toolResults, downloads,
 }: {
   source: MobileMessage;
   startsDay: boolean; followsSameRole: boolean; unreadCount: number; highlighted: boolean;
@@ -1848,6 +1849,7 @@ const MobileMessageRow = React.memo(function MobileMessageRow({
   onNavigateToReply: (sourceId: string, targetId: string, partIndex?: number) => void;
   onCopyMessage: (message: MobileMessage) => void;
   lookupMessage: (id: string) => MobileMessage | undefined;
+  toolResults: ReadonlyMap<string, MobileMessage>;
   downloads: ReadonlyMap<string, MobileDownload>;
 }) {
   const body = source.body;
@@ -1873,7 +1875,7 @@ const MobileMessageRow = React.memo(function MobileMessageRow({
       selectable selectionActive={selectionActive} selected={selected}
       onEnterSelection={() => onEnterSelection(source.id)} onToggleSelection={() => onToggleSelection(source.id)}>
       <div className="message-interaction-surface">
-        <TimelineMessageView message={source} lookupMessage={lookupMessage}
+        <TimelineMessageView message={source} lookupMessage={lookupMessage} toolResults={toolResults}
           onNavigate={(id, index) => onNavigateToReply(source.id, id, index)} renderAttachment={renderAttachment}
           leadingContent={!selectedSessionUnavailable && body.kind === "output" ? <MobilePluginSlot
             name="turn.before_reasoning" sessionId={source.session_id} messageId={source.id} /> : undefined}
@@ -3509,8 +3511,9 @@ const MobileVirtualConversation = React.forwardRef<MobileConversationHandle, Mob
     const scrollRef = useRef<HTMLDivElement>(null);
     const byId = useMemo(() => new Map(snapshot.messages.map((message) => [message.id, message])), [snapshot.messages]);
     const lookupMessage = useCallback((id: string) => byId.get(id), [byId]);
+    const toolResults = useMemo(() => timelineToolResults(snapshot.messages), [snapshot.messages]);
     const downloads = useMemo(() => new Map(snapshot.downloads.map((download) => [download.artifactId, download])), [snapshot.downloads]);
-    const visibleMessages = useMemo(() => snapshot.messages.filter(isTimelineMessageVisible), [snapshot.messages]);
+    const visibleMessages = useMemo(() => timelineVisibleMessages(snapshot.messages), [snapshot.messages]);
     const sourceMessagesRef = useRef(visibleMessages);
     sourceMessagesRef.current = visibleMessages;
     const activities = snapshot.replyStatus?.items ?? [];
@@ -3715,7 +3718,7 @@ const MobileVirtualConversation = React.forwardRef<MobileConversationHandle, Mob
                   >
                     <MobileMessageRow
                       source={source}
-                      lookupMessage={lookupMessage}
+                      lookupMessage={lookupMessage} toolResults={toolResults}
                       downloads={downloads}
                                 startsDay={!previous || !sameLocalDay(Date.parse(previous.timestamp), Date.parse(source.timestamp))}
                       followsSameRole={previous?.author === source.author}

--- a/frontend/chat/src/use-desktop-chat-controller.ts
+++ b/frontend/chat/src/use-desktop-chat-controller.ts
@@ -67,6 +67,7 @@ export function useDesktopChatController() {
   const [historyBeforeSeq, setHistoryBeforeSeq] = useState<number | null>(null);
   const [historyHasMore, setHistoryHasMore] = useState(false);
   const [historyLoadingOlder, setHistoryLoadingOlder] = useState(false);
+  const [historyLoading, setHistoryLoading] = useState(false);
   const messagesRef = useRef<ChatMessage[]>([]);
   const commitMessages = useCallback((action: SetStateAction<ChatMessage[]>) => {
     // 1. Resolve every WebSocket mutation against a synchronous immutable baseline.
@@ -170,6 +171,7 @@ export function useDesktopChatController() {
     olderMessagesRequestRef.current?.abort();
     const controller = new AbortController();
     messagesRequestRef.current = controller;
+    setHistoryLoading(true);
     const endpoint = `/api/chat/sessions/${encodeURIComponent(sessionId)}/messages`;
     try {
       const page = chatHistoryPage(
@@ -190,7 +192,10 @@ export function useDesktopChatController() {
       setHistoryHasMore(page.hasMore);
       followSession(socketRef.current ?? connectRef.current?.() ?? null, sessionId, page.throughSeq);
     } finally {
-      if (messagesRequestRef.current === controller) messagesRequestRef.current = null;
+      if (messagesRequestRef.current === controller) {
+        messagesRequestRef.current = null;
+        setHistoryLoading(false);
+      }
     }
   }, [setMessages, setTimelineMessages, streamStore]);
 
@@ -605,7 +610,7 @@ export function useDesktopChatController() {
   return {
     surface, sidebarSessions, activeSessionId, pendingSessionId, chatReady, messages, timelineMessages, replyActivities, replyAvailable, status,
     streamStore, messageElementsRef, copiedMessageId, shellState, stopPending, modelState,
-    historyHasMore, historyLoadingOlder, loadOlderMessages,
+    historyHasMore, historyLoading, historyLoadingOlder, loadOlderMessages,
     selectedRuntimeId, selectedReasoningEffort, replyTarget, error: error || connectionError, mobilePairingOpen,
     activateSession, openRuntime, startNewChat, handleReplyMessage, handleCopiedMessage,
     reportError, handleModelChange, cancelReply, sendMessage, stopTurn, retry,

--- a/frontend/chat/src/use-desktop-chat-controller.ts
+++ b/frontend/chat/src/use-desktop-chat-controller.ts
@@ -98,6 +98,7 @@ export function useDesktopChatController() {
   }, [setStatus]);
   const [stopPending, setStopPending] = useState(false);
   const [error, setError] = useState("");
+  const [connectionError, setConnectionError] = useState("");
   const [mobilePairingOpen, setMobilePairingOpen] = useState(false);
   const [shellState, setShellState] = useState<WebShellState | null>(null);
   const [replyTarget, setReplyTarget] = useState<TimelineReply | null>(null);
@@ -319,6 +320,7 @@ export function useDesktopChatController() {
           current.onopen = () => {
             if (socketRef.current !== current) return;
             Effect.runSync(reconnect.reset);
+            setConnectionError("");
             console.info("[chat-ui] ws connected", current.url);
             const sessionId = activeSessionRef.current;
             if (sessionId) {
@@ -337,12 +339,12 @@ export function useDesktopChatController() {
         replyActivitiesRef.current = [];
         setReplyActivities([]);
         setReplyAvailable(null);
-        if (event.code !== 1000 && event.code !== 1013) reportError(new Error("聊天连接已关闭"), "error");
+        if (event.code !== 1000 && event.code !== 1013) setConnectionError("连接已断开，正在重新连接…");
         yield* reconnect.next(undefined);
         socket = yield* Effect.sync(() => new WebSocket(url));
         socketRef.current = socket;
       }
-    }).pipe(Effect.catchAll(() => Effect.sync(() => reportError(new Error("聊天连接已断开，请刷新页面重试"), "error")))));
+    }).pipe(Effect.catchAll(() => Effect.sync(() => setConnectionError("暂时无法连接，请重试")))));
     return first;
   }, [closeConnection, loadMessagesSafely, loadSessionsSafely, reconnect, reportError, setMessages, setStatusLive, setTimelineMessages]);
 
@@ -371,16 +373,21 @@ export function useDesktopChatController() {
   useEffect(() => {
     if (!chatReady) return;
     void loadSessionsSafely();
-    void loadModels("").catch((error: unknown) => reportError(error));
-    return () => {
+    void loadModels(activeSessionRef.current).catch((error: unknown) => reportError(error));
+    if (activeSessionRef.current && timelineRef.current.length === 0) {
+      void loadMessagesSafely(activeSessionRef.current);
+    }
+  }, [chatReady, loadModels, loadMessagesSafely, loadSessionsSafely, reportError]);
+
+  // 健康探测暂时失败不取消用户已经发送的请求或正在读取的历史。
+  useEffect(() => () => {
       sessionsRequestRef.current?.abort();
       messagesRequestRef.current?.abort();
       olderMessagesRequestRef.current?.abort();
       modelsRequestRef.current?.abort();
       sendRequestRef.current?.abort();
       stopRequestRef.current?.abort();
-    };
-  }, [chatReady, loadModels, loadSessionsSafely, reportError]);
+  }, []);
 
   useEffect(() => {
     if (!chatReady) return;
@@ -599,7 +606,7 @@ export function useDesktopChatController() {
     surface, sidebarSessions, activeSessionId, pendingSessionId, chatReady, messages, timelineMessages, replyActivities, replyAvailable, status,
     streamStore, messageElementsRef, copiedMessageId, shellState, stopPending, modelState,
     historyHasMore, historyLoadingOlder, loadOlderMessages,
-    selectedRuntimeId, selectedReasoningEffort, replyTarget, error, mobilePairingOpen,
+    selectedRuntimeId, selectedReasoningEffort, replyTarget, error: error || connectionError, mobilePairingOpen,
     activateSession, openRuntime, startNewChat, handleReplyMessage, handleCopiedMessage,
     reportError, handleModelChange, cancelReply, sendMessage, stopTurn, retry,
     setMobilePairingOpen,

--- a/frontend/plugins/akasha/src/mobile.js
+++ b/frontend/plugins/akasha/src/mobile.js
@@ -93,4 +93,34 @@ export function mount(host, context) {
   return () => { active = false; };
 }
 
-export default { slots: {}, dashboard: { mount } };
+/** 在原思考面板展示本轮真实查询，两条记忆通道保持原来的折叠卡片。 */
+export function mountRecall(host, context) {
+  let active = true;
+  let timer;
+  const load = async () => {
+    const result = await context.query("recall.turn", {
+      message_id: context.messageId, source: context.block?.source ?? "",
+    }, { cache: "none", transport: "https" });
+    if (!active) return;
+    const opened = new Set(Array.from(host.querySelectorAll("details[open]"), (item) => item.dataset.lane));
+    host.innerHTML = result.items.length ? `<div class="akasha-mobile-recall-group">${[
+      ["dense", "左脑 · 精确回忆", "precise"], ["completion", "右脑 · 模式补全", "completion"],
+    ].map(([lane, title, style]) => {
+      const hits = result.items.flatMap((item) => item.hits.filter((hit) => hit.lane === lane));
+      return `<details data-lane="${lane}" class="akasha-mobile-recall akasha-mobile-recall--${style}">
+        <summary><span>${title}</span><b>${hits.length}</b></summary>
+        <ol class="akasha-mobile-memories">${hits.map((hit) => `<li><div>${hit.messages.map((message) =>
+          `<p>${escapeHtml(message.preview || "（非文本消息）")}${message.truncated ? "…" : ""}</p>`).join("")}</div></li>`).join("")
+          || '<li class="akasha-mobile-empty">本次没有命中</li>'}</ol></details>`;
+    }).join("")}</div>` : "";
+    host.querySelectorAll("details").forEach((item) => { item.open = opened.has(item.dataset.lane); });
+    if (result.pending) timer = setTimeout(() => { void load().catch(failed); }, 1000);
+  };
+  const failed = (error) => {
+    if (active) host.innerHTML = `<p class="akasha-mobile-error">${escapeHtml(error.message)}</p>`;
+  };
+  void load().catch(failed);
+  return () => { active = false; clearTimeout(timer); };
+}
+
+export default { slots: { "turn.before_reasoning": { mount: mountRecall } }, dashboard: { mount } };

--- a/plugins/akasha/inspector.py
+++ b/plugins/akasha/inspector.py
@@ -17,6 +17,7 @@ from zoneinfo import ZoneInfo
 import numpy as np
 
 from agent.plugin_composition import MobileUiRpcInvalidRequest
+from plugins.turn_projection.plugin import Turn as MessageTurn, TurnProjection
 from session.log import MessageCatalog
 from session.message import ContentPart, Input, Output
 from .recalls import ContextSource, ProgramSource, Recall, ToolSource
@@ -1015,6 +1016,7 @@ class RecallInspector:
         self._read = read
         self._list = list_records
         self._catalog = catalog
+        self._turns: tuple[tuple[str, str, int], tuple[MessageTurn, ...]] | None = None
 
     def recent(self, *, page: int = 1, page_size: int = 30, session_id: str = "") -> dict[str, object]:
         rows = tuple((identity, recall) for identity, recall in self._list()
@@ -1023,6 +1025,55 @@ class RecallInspector:
         start = (page - 1) * page_size
         return self._mobile_result({"items": [self._summary(identity, recall) for identity, recall in rows[start:start + page_size]],
                                     "total": len(rows), "page": page, "page_size": page_size})
+
+    def for_turn(self, session_id: str, message_id: str, source: str,
+                 projection: TurnProjection) -> dict[str, object]:
+        """按既有 Turn 区间展示真实检索，不把查询记录解释为模型使用证明。"""
+        # 1. 已提交消息从日志取得来源；草稿只能读取该来源仍未闭合的 Turn。
+        reader = self._catalog.reader(session_id)
+        message = reader.get(message_id)
+        if message is not None:
+            source = message.source
+        if not source:
+            return {"items": [], "pending": False}
+        # 只缓存最近一个来源的 Turn 引用；同一前缀轮询不再读取消息正文。
+        source_head = reader.head(source=source)
+        key = (session_id, source, source_head)
+        cached = self._turns
+        if cached is None or cached[0] != key:
+            messages = []
+            cursor = -1
+            while cursor < source_head:
+                page = reader.read(after_seq=cursor, through_seq=source_head, source=source)
+                messages.extend(page)
+                cursor = page[-1].seq
+            cached = (key, projection.project(messages, source))
+            self._turns = cached
+        turns = cached[1]
+        turn = next((item for item in turns if message_id in item.message_ids), None)
+        if message is None:
+            turn = next((item for item in reversed(turns) if item.status == "open"), None)
+        if turn is None:
+            return {"items": [], "pending": message is None}
+        # 2. 查询的上下文上界或工具引用必须属于同一来源的这个区间。
+        through_seq = reader.head() if turn.status == "open" else turn.through_seq
+        if turn.status in {"complete", "quiet"}:
+            through_seq -= 1
+        identities: list[str] = []
+        for identity, recall in reversed(self._list()):
+            origin = recall.source
+            if isinstance(origin, ContextSource):
+                matches = (origin.session_id == session_id and origin.source == source
+                           and turn.after_seq < origin.through_seq <= through_seq)
+            elif isinstance(origin, ToolSource):
+                matches = (origin.session_id == session_id
+                           and origin.call_ref.message_id in turn.message_ids)
+            else:
+                matches = False
+            if matches:
+                identities.append(identity)
+        return {"items": [self.mobile_detail(identity) for identity in identities],
+                "pending": turn.status == "open"}
 
     @staticmethod
     def _summary(identity: str, recall: Recall) -> dict[str, object]:

--- a/plugins/akasha/message_plugin.py
+++ b/plugins/akasha/message_plugin.py
@@ -146,6 +146,13 @@ async def apply(ctx: Context, config: Config) -> None:
     def query(method: str, payload: dict[str, object], *, session_id: str | None,
               turn_id: str | None) -> dict[str, object]:
         inspector = get_inspector()
+        if method == "recall.turn":
+            if (not session_id or set(payload) != {"message_id", "source"}
+                or not isinstance(payload["message_id"], str) or not payload["message_id"]
+                or not isinstance(payload["source"], str)):
+                raise MobileUiRpcInvalidRequest("检索卡片缺少消息或会话")
+            return inspector.for_turn(session_id, payload["message_id"], payload["source"],
+                                      ctx.require(TURN_PROJECTION))
         if method == "inspector.recent":
             try:
                 page = InspectorPage.model_validate(payload)
@@ -163,6 +170,7 @@ async def apply(ctx: Context, config: Config) -> None:
 
     _ = await ctx.require(UI_SLOTS).register_mobile(
         ctx, MobileUiDefinition(module="message_ui.js", stylesheet="message_ui.css",
+                                slots=("turn.before_reasoning",),
                                 navigation=MobileUiNavigation(label="Akasha Inspector",
                                     description="查看实际检索及呈现的原消息")), query=query,
     )

--- a/tests/test_akasha_message_ui.mjs
+++ b/tests/test_akasha_message_ui.mjs
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { mount, renderDetail } from "../plugins/akasha/message_ui.js";
+import { JSDOM } from "jsdom";
+import { build } from "esbuild";
+const compiled = await build({ entryPoints: [new URL("../frontend/plugins/akasha/src/mobile.js", import.meta.url).pathname],
+  bundle: true, write: false, format: "esm", loader: { ".css": "empty" } });
+const { mountRecall, mount, renderDetail } = await import(
+  `data:text/javascript;base64,${Buffer.from(compiled.outputFiles[0].text).toString("base64")}`);
+
 
 const detail = {
   schema: "akasha.queries.v1", query_text: "Context", query_text_truncated: false,
@@ -36,4 +42,23 @@ test("closing Inspector prevents a late page response from replacing its host", 
   resolve({ schema: "akasha.queries.v1", items: [], total: 0, page: 1, page_size: 30 });
   await new Promise((done) => setImmediate(done));
   assert.equal(host.innerHTML, "another page");
+});
+
+
+test("chat recall mounts the old two lanes, escapes memory text and stops after unmount", async () => {
+  const dom = new JSDOM("<div id='host'></div>");
+  const host = dom.window.document.getElementById("host");
+  const calls = [];
+  const close = mountRecall(host, { messageId: "draft", block: { source: "conversation" },
+    query: async (...args) => { calls.push(args); return { items: [detail], pending: false }; } });
+  await new Promise((done) => setImmediate(done));
+  assert.equal(host.querySelectorAll(".akasha-mobile-recall").length, 2);
+  assert.match(host.textContent, /左脑 · 精确回忆/);
+  assert.match(host.textContent, /右脑 · 模式补全/);
+  assert.equal(host.querySelector("img"), null);
+  assert.doesNotMatch(host.textContent, /conversation/);
+  assert.deepEqual(calls[0], ["recall.turn", { message_id: "draft", source: "conversation" },
+    { cache: "none", transport: "https" }]);
+  close();
+  dom.window.close();
 });

--- a/tests/test_akasha_recall_records.py
+++ b/tests/test_akasha_recall_records.py
@@ -6,7 +6,7 @@ from plugins.akasha.domain.model import Turn
 from plugins.akasha.infrastructure.consumption import Applied
 from plugins.akasha.recalls import ContextSource, Hit, Recall, RecallRecords
 from session.log import MessageConflict, MessageLog, OwnerTransaction
-from session.message import ContentPart, ContentReferences, Input, Message, Output
+from session.message import ContentPart, ContentReferences, Control, Input, Message, Output
 
 
 def record(head):
@@ -209,3 +209,91 @@ def test_mobile_inspector_rejects_oversized_complete_references_without_trimming
         with pytest.raises(MobileUiRpcInvalidRequest, match="查询记录仍完整保留"):
             inspector.mobile_detail("query")
         assert records.read("query") == original
+
+
+def test_chat_recall_cards_follow_existing_turns_without_crossing_sources(tmp_path):
+    from contextlib import closing
+    from plugins.akasha.inspector import RecallInspector
+    from plugins.turn_projection.plugin import TurnProjection
+
+    with closing(MessageLog(tmp_path / "sessions.db")) as log:
+        inputs = log.writer("s", author="user", source="chat", body_types=(Input,),
+                            content={"text": lambda part: ContentReferences()})
+        outputs = log.writer("s", author="assistant", source="chat", body_types=(Output,),
+                             content={"text": lambda part: ContentReferences()})
+        inputs.append("u1", Input((ContentPart("text", "first"),)))
+        inputs.append("u2", Input((ContentPart("text", "second"),)))
+        outputs.append("a", Output((ContentPart("text", "answer"),), "complete"))
+        inputs.append("next", Input((ContentPart("text", "new question"),)))
+        records = RecallRecords(log.owner("akasha"))
+        records.save("old", record(1))
+        records.save("active", record(3))
+        records.save("other", record(3).model_copy(update={
+            "source": ContextSource(session_id="s", source="background", through_seq=3),
+        }))
+        inspector = RecallInspector(read=records.read, list_records=records.list, catalog=log.catalog())
+        before = log.reader("s").snapshot()
+        completed = inspector.for_turn("s", "a", "ignored", TurnProjection())
+        active = inspector.for_turn("s", "draft", "chat", TurnProjection())
+        assert [item["query_id"] for item in completed["items"]] == ["old"]
+        assert completed["pending"] is False
+        assert [item["query_id"] for item in active["items"]] == ["active"]
+        assert active["pending"] is True
+        assert log.reader("s").snapshot() == before
+
+
+def test_abandoned_turn_keeps_recall_at_its_closed_input_head(tmp_path):
+    from contextlib import closing
+    from plugins.akasha.inspector import RecallInspector
+    from plugins.turn_projection.plugin import TurnProjection
+
+    with closing(MessageLog(tmp_path / "sessions.db")) as log:
+        writer = log.writer("s", author="user", source="chat", body_types=(Input, Control),
+                            content={"text": lambda part: ContentReferences()})
+        writer.append("u1", Input((ContentPart("text", "question"),)))
+        records = RecallRecords(log.owner("akasha"))
+        records.save("last", record(0).model_copy(update={"hits": ()}))
+        writer.append("stop", Control("abandon", 0, None))
+        inspector = RecallInspector(read=records.read, list_records=records.list, catalog=log.catalog())
+        result = inspector.for_turn("s", "u1", "", TurnProjection())
+        assert [item["query_id"] for item in result["items"]] == ["last"]
+        assert result["pending"] is False
+
+
+def test_recall_turn_cache_tracks_source_head_and_keeps_global_query_head(tmp_path):
+    from contextlib import closing
+    from plugins.akasha.inspector import RecallInspector
+    from plugins.turn_projection.plugin import TurnProjection
+
+    class CountProjection(TurnProjection):
+        calls = 0
+
+        def project(self, messages, source):
+            self.calls += 1
+            return super().project(messages, source)
+
+    with closing(MessageLog(tmp_path / "sessions.db")) as log:
+        inputs = log.writer("s", author="user", source="chat", body_types=(Input,),
+                            content={"text": lambda part: ContentReferences()})
+        outputs = log.writer("s", author="assistant", source="chat", body_types=(Output,),
+                             content={"text": lambda part: ContentReferences()})
+        inputs.append("u1", Input((ContentPart("text", "question"),)))
+        records = RecallRecords(log.owner("akasha"))
+        inspector = RecallInspector(read=records.read, list_records=records.list, catalog=log.catalog())
+        projection = CountProjection()
+        inspector.for_turn("s", "draft", "chat", projection)
+        inspector.for_turn("s", "draft", "chat", projection)
+        assert projection.calls == 1
+        log.writer("s", author="other", source="other", body_types=(Input,),
+                   content={"text": lambda part: ContentReferences()}).append(
+            "other", Input((ContentPart("text", "background"),)))
+        records.save("global-head", record(1).model_copy(update={"hits": ()}))
+        result = inspector.for_turn("s", "draft", "chat", projection)
+        assert [item["query_id"] for item in result["items"]] == ["global-head"]
+        assert projection.calls == 1
+        outputs.append("a", Output((ContentPart("text", "answer"),), "complete"))
+        assert inspector.for_turn("s", "a", "", projection)["pending"] is False
+        assert projection.calls == 2
+        inputs.append("new", Input((ContentPart("text", "next"),)))
+        assert inspector.for_turn("s", "draft-next", "chat", projection)["pending"] is True
+        assert projection.calls == 3


### PR DESCRIPTION
Message 改写后，聊天把原有思考面板替换为简易折叠文本，Akasha 未注册聊天插槽，内部来源也出现在界面。恢复等待、流式思考、完成后收起和左右脑检索卡片，并将已加载工具结果放回原调用面板。消息 ID、seq、正文和分页保留不变。

短暂健康探测失败不再取消历史读取与用户发送；恢复连接会清除连接提示，并补读尚未加载的当前会话。已有会话加载期间不再误显示首次模型配置提示。

验证：22 项 Web 回归、8 项 Akasha Python 回归、TypeScript 与 lint（0 error）通过。412px/1440px 真实 Chromium 验证等待、流式思考、完成收起、再次展开/收起、内部字段隐藏和无横向溢出。完整 Mobile Lab 在既有附件动作提示检查超时；本次独立浏览器场景均通过。

change_type: bugfix；semantic_delta: 恢复改写前聊天展示与连接恢复；capability_owner: 共享 WebUI / Akasha；consumer_scope: Web + Mobile；runtime_patch: false。Akasha 只读既有消息与检索记录，Turn 仍由既有插件投影，缓存仅保存一个来源的派生引用。

按维护者明确要求跳过 CI，直接合并并部署。恢复点：a1b386b7；本地源备份 /mnt/data/coding/akashic-chat-restore-backup-20260908；服务端既有已验证备份 pre-mobile-artifact-20260908-1002。正式镜像通过 npm run build 重建插件 bundle，不提交生成物。同步性能另行处理。

独立概念 Gate：gpt-5.6-terra / xhigh，review head a98b72b4ec30f68bbd59f5504d7ff49a9ef2ac94；PASS，must-fix 0。已修无思考时卡片缺失、归档卡片重复、放弃边界漏查询和空会话假加载四处问题；Node 22/22 由 reviewer 独立复跑。
