### PR TITLE
修复消息操作对齐与聊天就绪状态抖动

### DIFF
--- a/frontend/chat/src/desktop-chat-lifecycle.test.mjs
+++ b/frontend/chat/src/desktop-chat-lifecycle.test.mjs
@@ -52,6 +52,7 @@ async function mountChat(t, strict = false) {
       this.dispatchEvent(event);
     }
     send(text) { this.sent.push(text); }
+    receive(frame) { this.onmessage?.({ data: JSON.stringify(frame) }); }
   }
   t.mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
   dom.window.setTimeout = globalThis.setTimeout;
@@ -185,7 +186,7 @@ test("StrictMode 重挂载与重试等待中的卸载不留下连接或监听器
 });
 
 
-test("短暂健康失败不取消当前历史，重连成功清除连接提示", async (t) => {
+test("首次就绪后停止启动探测，断线重连不取消当前历史或要求重新配置模型", async (t) => {
   const chat = await mountChat(t);
   await act(async () => {
     chat.sockets[0].open();
@@ -195,15 +196,52 @@ test("短暂健康失败不取消当前历史，重连成功清除连接提示",
   const history = chat.requests.find((item) => item.url.includes("/messages?"));
   assert.ok(history);
   assert.equal(chat.controller().historyLoading, true);
-  await chat.tick(1200);
-  await act(async () => chat.requests.filter((item) => item.url === "/api/shell/state").at(-1)
-    .finish({ status: "starting", configured: true, chatReady: false }));
+  await chat.tick(60_000);
+  assert.equal(chat.requests.filter((item) => item.url === "/api/shell/state").length, 1);
+  assert.equal(chat.controller().chatReady, true);
   assert.equal(history.signal.aborted, false);
   await act(async () => history.finish({ version: 2, items: [], through_seq: -1, before_seq: null, has_more: false }));
   assert.equal(chat.controller().historyLoading, false, "空会话加载完成后不再显示读取提示");
   await act(async () => { chat.sockets.at(-1).open(); chat.sockets.at(-1).close(1006); });
   assert.match(chat.controller().error, /重新连接/u);
+  assert.equal(chat.controller().chatReady, true);
   await chat.tick(1200);
   await act(async () => chat.sockets.at(-1).open());
+  assert.equal(chat.controller().error, "");
+});
+
+test("生成中断线不保留假等待，重连读取完成消息后回到空闲", async (t) => {
+  const chat = await mountChat(t);
+  const sessionId = "akashic:test";
+  await act(async () => chat.controller().activateSession(sessionId));
+  await act(async () => chat.requests.find((item) => item.url.includes("/messages?"))
+    .finish({ version: 2, items: [], through_seq: -1, before_seq: null, has_more: false }));
+  const status = (items) => ({ type: "reply.status", version: 2, session_id: sessionId,
+    snapshot_id: "current", available: true, items });
+  await act(async () => {
+    chat.sockets.at(-1).open();
+    chat.sockets.at(-1).receive(status([{ session_id: sessionId, source: "conversation", handle: "reply",
+      active: true, preview: { message_id: "answer", text: "", thinking: "" } }]));
+  });
+  assert.equal(chat.controller().status, "streaming");
+  await act(async () => chat.sockets.at(-1).close(1006));
+  assert.equal(chat.controller().status, "idle");
+  assert.equal(chat.controller().replyAvailable, null);
+  assert.deepEqual(chat.controller().replyActivities, []);
+  await chat.tick(30_000);
+  await act(async () => {
+    const socket = chat.sockets.at(-1);
+    socket.open();
+    socket.receive({ type: "messages.appended", version: 2, session_id: sessionId, after_seq: -1,
+      through_seq: 0, next_after_seq: 0, has_more: false, items: [{
+        id: "answer", session_id: sessionId, seq: 0, timestamp: "2026-09-08T15:35:14Z",
+        author: "assistant", source: "conversation", metadata: {}, attachments: [],
+        body: { kind: "output", finish: "complete", parts: [{ kind: "text", value: "你好" }] },
+      }] });
+    socket.receive(status([]));
+  });
+  assert.equal(chat.controller().status, "idle");
+  assert.equal(chat.controller().replyAvailable, true);
+  assert.deepEqual(chat.controller().timelineMessages.map((item) => item.id), ["answer"]);
   assert.equal(chat.controller().error, "");
 });

--- a/frontend/chat/src/desktop-conversation.tsx
+++ b/frontend/chat/src/desktop-conversation.tsx
@@ -297,7 +297,7 @@ export function DesktopTimelineMessages({ messages, status, messageElementsRef, 
         name="turn.before_tool" sessionId={message.session_id} messageId={message.id} block={{ ...part, message_id: message.id, part_index: index }} /> : null}
       afterBody={message.body.kind === "output" && message.body.finish === "complete" ? <MobilePluginSlot
         name="turn.after_answer" sessionId={message.session_id} messageId={message.id} /> : undefined} />
-    <div className="shared-message-meta timeline-meta">
+    <div className={`shared-message-meta timeline-meta ${message.body.kind === "input" ? "user" : "assistant"}`}>
       <time dateTime={message.timestamp}>{formatMessageTime(message.timestamp)}</time>
       <SharedMessageActions
         canReply={status === "idle" && (message.body.kind === "input" || message.body.kind === "output")}

--- a/frontend/chat/src/message-view.css
+++ b/frontend/chat/src/message-view.css
@@ -961,7 +961,6 @@ button.tool-step-summary:active {
 .timeline-meta { flex-wrap: wrap; overflow-wrap: anywhere; }
 .timeline-meta details { max-width: 100%; }
 .timeline-meta pre { white-space: pre-wrap; overflow-wrap: anywhere; }
-.timeline-input > .timeline-meta { justify-content: flex-end; }
 /* 首段内容到达前保持轻量反馈，不把网络等待伪装成推理内容。 */
 .thinking-placeholder {
   display: flex;

--- a/frontend/chat/src/mobile-native.css
+++ b/frontend/chat/src/mobile-native.css
@@ -2613,10 +2613,6 @@ button {
   flex-wrap: wrap;
   white-space: normal;
 }
-.mobile-message-anchor.timeline-input .mobile-message-meta {
-  margin-inline-start: auto;
-  justify-content: flex-end;
-}
 /* 两端阅读字号一致，输入框与触摸按钮保留移动端尺寸。 */
 .mobile-message-anchor .agent-content,
 .mobile-plain-message-view__content,

--- a/frontend/chat/src/mobile-native.tsx
+++ b/frontend/chat/src/mobile-native.tsx
@@ -1884,7 +1884,7 @@ const MobileMessageRow = React.memo(function MobileMessageRow({
               block={{ ...part, message_id: source.id, part_index: index }} /> : null}
           afterBody={!selectedSessionUnavailable && body.kind === "output" && body.finish === "complete" ? <MobilePluginSlot
             name="turn.after_answer" sessionId={source.session_id} messageId={source.id} /> : undefined} />
-        <div className="mobile-message-meta timeline-meta">
+        <div className={`mobile-message-meta timeline-meta ${body.kind === "input" ? "user" : "assistant"}`}>
           <div className="mobile-message-meta__text">
             <time dateTime={source.timestamp}>{formatMessageTime(Date.parse(source.timestamp))}</time>
           </div>

--- a/frontend/chat/src/use-desktop-chat-controller.ts
+++ b/frontend/chat/src/use-desktop-chat-controller.ts
@@ -344,6 +344,7 @@ export function useDesktopChatController() {
         replyActivitiesRef.current = [];
         setReplyActivities([]);
         setReplyAvailable(null);
+        setStatusLive(replyChatStatus([], messagesRef.current.length));
         if (event.code !== 1000 && event.code !== 1013) setConnectionError("连接已断开，正在重新连接…");
         yield* reconnect.next(undefined);
         socket = yield* Effect.sync(() => new WebSocket(url));
@@ -354,14 +355,14 @@ export function useDesktopChatController() {
   }, [closeConnection, loadMessagesSafely, loadSessionsSafely, reconnect, reportError, setMessages, setStatusLive, setTimelineMessages]);
 
   useEffect(() => {
-    // 请求结束后再等待下一次轮询；中断任务会把 AbortSignal 传给 fetch。
+    // 只等待首次启动就绪；此后的断线与恢复由聊天连接负责。
     const task = Effect.runFork(Effect.tryPromise({
       try: (signal) => fetchChatJson<unknown>("/api/shell/state", { signal }).then(webShellState),
       catch: (error) => error,
     }).pipe(
       Effect.tap((next) => Effect.sync(() => setShellState(next))),
       Effect.catchAll((error) => Effect.sync(() => reportError(error))),
-      Effect.repeat(Schedule.spaced("1200 millis")),
+      Effect.repeat({ schedule: Schedule.spaced("1200 millis"), until: (next) => next?.chatReady === true }),
     ));
     return () => { Effect.runFork(Fiber.interrupt(task)); };
   }, [reportError]);


### PR DESCRIPTION
用户消息的正文靠右，时间和复制、引用按钮却落在左侧；运行中一次短暂健康探测失败还会把输入框切回连接模型提示。两端的 Message 时间线现已复用原用户侧操作栏样式。启动探测在首次就绪后结束，后续断线与恢复由聊天连接负责；断线时同步清除旧生成指示，重连后读取当前回复状态。

- capability_owner: frontend/chat；consumer_scope: Web 和 Mobile；runtime_patch: false；authoritative_state_owner: Core Message log 和回复活动；client_only_alternative: 本次即客户端修复。
- change_type: bugfix；semantic_delta: 操作栏随消息侧对齐，启动状态不再覆盖连接状态；不改变消息接纳、模型配置或持久化语义。
- 状态与副作用：只改前端源码和既有测试；不改数据库、附件、插件数据或发送消息。消息继续由原 owner 正常追加，本次没有更新、逻辑失效或减少协议。
- 验证：19 项生命周期/时间线测试通过；TypeScript 通过；lint 0 errors、40 项既有 warnings；Chat 和 Mobile Lab 构建通过。真实 Chromium 在 Web/Mobile × 412/1440 四组检查中确认用户气泡与操作栏右缘一致、助手侧左缘一致、复制/引用可见、无横向溢出；Web 首次就绪后不继续探测，完成事件清除等待。
- 按维护者要求跳过 CI。恢复点为基线 969f80ab；源码与浏览器证据保存在 `akashic-chat-layout-backup-20260908`。独立只读评审：chat_layout_review / gpt-5.6-terra / xhigh，head `2741cc0fe0ea17706cf23160826b96103225fcad`，PASS，must-fix 0；独立重跑生命周期 6/6。旧版浏览器负对照在用户操作栏对齐断言处失败，新版四组通过。
