### PR TITLE
[codex] 减少回复链历史读取与模型回执连接开销

### DIFF
--- a/plugins/conversation/program.py
+++ b/plugins/conversation/program.py
@@ -38,8 +38,7 @@ def check_source(task: Task, reader: MessageReader, source: str, through_seq: in
 
     if not task.active or any(
         message.source == source and isinstance(message.body, (Input, Control))
-        for message in reader.snapshot()
-        if message.seq > through_seq
+        for message in reader.snapshot(after_seq=through_seq)
     ):
         raise asyncio.CancelledError
 

--- a/plugins/delivery_policy/plugin.py
+++ b/plugins/delivery_policy/plugin.py
@@ -57,18 +57,18 @@ def origin(reader: MessageReader, message: Message, sources: tuple[str, ...]) ->
 
 def input_origin(reader: MessageReader, source: str, *, through_seq: int) -> tuple[str, str] | None:
     """只从原输入的已验证渠道事实读取目的地。"""
-    for previous in reversed(reader.snapshot(through_seq=through_seq)):
-        if previous.source != source or not isinstance(previous.body, Input):
-            continue
-        parts = [part for part in previous.body.parts if part.kind == "channel.origin"]
-        if not parts:
-            return None
-        if len(parts) != 1:
-            raise ValueError("输入必须只有一个渠道来源")
-        _ = check_origin(parts[0])
-        value = cast(Mapping[str, str], parts[0].value)
-        return value["channel"], value["chat_id"]
-    return None
+    previous = reader.latest_input(source, through_seq=through_seq)
+    if previous is None:
+        return None
+    assert isinstance(previous.body, Input)
+    parts = [part for part in previous.body.parts if part.kind == "channel.origin"]
+    if not parts:
+        return None
+    if len(parts) != 1:
+        raise ValueError("输入必须只有一个渠道来源")
+    _ = check_origin(parts[0])
+    value = cast(Mapping[str, str], parts[0].value)
+    return value["channel"], value["chat_id"]
 
 
 class DeliveryFinalOutput:
@@ -168,9 +168,7 @@ async def apply(ctx: Context, config: Config) -> None:
                 try:
                     yield
                 finally:
-                    for message in reader.snapshot():
-                        if message.seq <= head:
-                            continue
+                    for message in reader.snapshot(after_seq=head):
                         if message.source != source or origin(reader, message, config.sources) is None:
                             continue
                         try:

--- a/plugins/models/projection.py
+++ b/plugins/models/projection.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 from collections.abc import Callable, Mapping, Sequence
+from contextlib import nullcontext
 from typing import Any, cast
 
 from agent.plugin_composition import ServiceKey
@@ -25,6 +26,7 @@ from session.message import (
 )
 from session.message_codec import json_value
 from plugins.context.api import check_summary
+from .store import ModelCallReader
 
 ContentRenderer = Callable[[ContentPart], Sequence[Mapping[str, Any]]]
 CallReader = Callable[[str], Mapping[str, Any]]
@@ -194,63 +196,67 @@ class MessageProjection:
         continuation_summary: str | None = None
         continuation_seq = -1
         results: dict[CallRef, Message] = {}
-        for message in messages:
-            body = message.body
-            if isinstance(body, Control) and body.action == "abandon" and message.source == self._source:
-                continuation = None
-            if isinstance(body, ToolResult):
-                if body.call_ref in abandoned_calls:
+        # models 的读取器提供连接范围；既有插件传入的普通 callable 仍逐条读取。
+        reads = (self._read_call.open() if isinstance(self._read_call, ModelCallReader)
+                 else nullcontext(self._read_call))
+        with reads as read_call:
+            for message in messages:
+                body = message.body
+                if isinstance(body, Control) and body.action == "abandon" and message.source == self._source:
+                    continuation = None
+                if isinstance(body, ToolResult):
+                    if body.call_ref in abandoned_calls:
+                        continue
+                    if body.call_ref in results:
+                        raise ValueError("同一工具调用出现多个结果")
+                    results[body.call_ref] = message
+                if not isinstance(body, Output) or message.message_id in abandoned:
                     continue
-                if body.call_ref in results:
-                    raise ValueError("同一工具调用出现多个结果")
-                results[body.call_ref] = message
-            if not isinstance(body, Output) or message.message_id in abandoned:
-                continue
-            recorded = [
-                part
-                for part in body.parts
-                if isinstance(part, ContentPart) and part.kind == "model.facts"
-            ]
-            if len(recorded) > 1:
-                raise ValueError("同一 Output 出现多个 model.facts")
-            if not recorded:
-                continue
-            _ = check_facts(recorded[0])
-            value = cast(Mapping[str, Any], recorded[0].value)
-            receipt = self._read_call(value["call_record_id"])
-            if receipt["state"] != "success":
-                raise ValueError("已提交模型事实必须引用成功结算的真实调用")
-            indices = {
-                str(index)
-                for index, part in enumerate(body.parts)
-                if isinstance(part, ToolCall)
-            }
-            if set(value["tool_ids"]) != indices:
-                raise ValueError("模型工具 ID 不匹配实际 Output 调用位置")
-            state = value["continuation"]
-            message_continuation = (
-                None
-                if state is None
-                else ModelContinuation(state["binding_id"], state["payload"])
-            )
-            if (
-                message_continuation is not None
-                and message_continuation.binding_id != receipt["binding"]["binding_id"]
-            ):
-                raise ValueError("continuation 不属于记录中的模型")
-            if message.source == self._source:
-                continuation = message_continuation
-                continuation_seq = message.seq
-                summaries = [
-                    part for part in body.parts
-                    if isinstance(part, ContentPart) and part.kind == "context.summary"
+                recorded = [
+                    part
+                    for part in body.parts
+                    if isinstance(part, ContentPart) and part.kind == "model.facts"
                 ]
-                if len(summaries) > 1:
-                    raise ValueError("同一模型 Output 只能使用一份摘要")
-                continuation_summary = (
-                    check_summary(summaries[0]).binding_ids[0] if summaries else None
+                if len(recorded) > 1:
+                    raise ValueError("同一 Output 出现多个 model.facts")
+                if not recorded:
+                    continue
+                _ = check_facts(recorded[0])
+                value = cast(Mapping[str, Any], recorded[0].value)
+                receipt = read_call(value["call_record_id"])
+                if receipt["state"] != "success":
+                    raise ValueError("已提交模型事实必须引用成功结算的真实调用")
+                indices = {
+                    str(index)
+                    for index, part in enumerate(body.parts)
+                    if isinstance(part, ToolCall)
+                }
+                if set(value["tool_ids"]) != indices:
+                    raise ValueError("模型工具 ID 不匹配实际 Output 调用位置")
+                state = value["continuation"]
+                message_continuation = (
+                    None
+                    if state is None
+                    else ModelContinuation(state["binding_id"], state["payload"])
                 )
-            facts[message.message_id] = value
+                if (
+                    message_continuation is not None
+                    and message_continuation.binding_id != receipt["binding"]["binding_id"]
+                ):
+                    raise ValueError("continuation 不属于记录中的模型")
+                if message.source == self._source:
+                    continuation = message_continuation
+                    continuation_seq = message.seq
+                    summaries = [
+                        part for part in body.parts
+                        if isinstance(part, ContentPart) and part.kind == "context.summary"
+                    ]
+                    if len(summaries) > 1:
+                        raise ValueError("同一模型 Output 只能使用一份摘要")
+                    continuation_summary = (
+                        check_summary(summaries[0]).binding_ids[0] if summaries else None
+                    )
+                facts[message.message_id] = value
         # 摘要明确开启新请求；原 opaque 保存在日志，只续接同一摘要后的响应。
         if fresh or summary_reference is not None and (
             continuation_summary != summary_reference or continuation_seq <= after_seq

--- a/plugins/models/store.py
+++ b/plugins/models/store.py
@@ -7,7 +7,7 @@ import os
 import sqlite3
 import uuid
 from collections.abc import Callable, Iterator, Mapping
-from contextlib import closing, contextmanager
+from contextlib import AbstractContextManager, closing, contextmanager
 from dataclasses import asdict, dataclass, fields
 from pathlib import Path
 from types import MappingProxyType
@@ -127,6 +127,37 @@ class StoredSnapshot:
         )
 
 
+class ModelCallReader:
+    """只读调用账；每个显式读取范围独占连接，不保存查询结果。"""
+
+    def __init__(self, connect: Callable[[], AbstractContextManager[sqlite3.Connection]]) -> None:
+        self._connect = connect
+
+    def __call__(self, call_id: str) -> Mapping[str, Any]:
+        with self.open() as read:
+            return read(call_id)
+
+    @contextmanager
+    def open(self) -> Iterator[Callable[[str], Mapping[str, Any]]]:
+        """在同步组装内复用连接；不开启跨查询事务，退出时关闭。"""
+        with self._connect() as connection:
+            def read(call_id: str) -> Mapping[str, Any]:
+                """逐条读取并解码，结算变化在下一次查询可见。"""
+                require_model_calls_schema(connection)
+                row = connection.execute(
+                    "SELECT * FROM model_calls WHERE id=?", (call_id,)
+                ).fetchone()
+                if row is None:
+                    raise KeyError(call_id)
+                record = dict(row)
+                record["binding"] = json.loads(record.pop("binding_json"))
+                usage = record.pop("usage_json")
+                record["usage"] = None if usage is None else json.loads(usage)
+                return _freeze_json(record)
+
+            yield read
+
+
 class ModelsStore:
     """Own the ordinary models plugin's durable registry and write protocol."""
 
@@ -134,6 +165,7 @@ class ModelsStore:
         self.path = path
         self.backup_dir = backup_dir
         self.writable = writable
+        self.read_call = ModelCallReader(lambda: self._connect(read_only=True))
 
     def initialize(self) -> None:
         """Create a new registry or expand the two approved additive columns."""
@@ -317,21 +349,6 @@ class ModelsStore:
             )
             if cursor.rowcount != 1:
                 raise RuntimeError("Model 调用不存在或已经结算")
-
-    def read_call(self, call_id: str) -> Mapping[str, Any]:
-        """读取一次调用的事实；started 无终态时仍表示可能发生了费用。"""
-        with self._connect(read_only=True) as connection:
-            require_model_calls_schema(connection)
-            row = connection.execute(
-                "SELECT * FROM model_calls WHERE id=?", (call_id,)
-            ).fetchone()
-        if row is None:
-            raise KeyError(call_id)
-        record = dict(row)
-        record["binding"] = json.loads(record.pop("binding_json"))
-        usage = record.pop("usage_json")
-        record["usage"] = None if usage is None else json.loads(usage)
-        return _freeze_json(record)
 
     def read_calls(self, after_id: str, limit: int) -> tuple[Mapping[str, Any], ...]:
         """按身份分页读取调用快照；每轮从头扫描，started 记录仍可能结算。"""

--- a/plugins/reply/follow.py
+++ b/plugins/reply/follow.py
@@ -71,7 +71,7 @@ async def follow(
             changed = [key for key, head in heads.items() if previous.get(key) != head]
             previous = dict(heads)
             for session_id in changed:
-                present = {message.source for message in catalog.reader(session_id).snapshot()}
+                present = catalog.reader(session_id).source_names()
                 for source in sources.entries():
                     if source.name not in present:
                         continue

--- a/plugins/tools/abandon.py
+++ b/plugins/tools/abandon.py
@@ -89,10 +89,11 @@ async def follow_abandon(
             if head == previous:
                 continue
             reader = catalog.reader(session_id)
-            messages = reader.snapshot(through_seq=head)
-            for control in messages:
-                if control.seq <= previous or not isinstance(control.body, Control) or control.body.action != "abandon":
-                    continue
+            changed = reader.snapshot(after_seq=previous, through_seq=head)
+            controls = [message for message in changed
+                        if isinstance(message.body, Control) and message.body.action == "abandon"]
+            messages = reader.snapshot(through_seq=head) if controls else ()
+            for control in controls:
                 for ref in abandoned_calls(messages, control):
                     target = await reply(reader, control.source, ref)
                     try:

--- a/plugins/tools/api.py
+++ b/plugins/tools/api.py
@@ -99,7 +99,7 @@ class MessageReply:
             raise ValueError("工具调用消息缺失")
         return any(message.source == call.source and isinstance(message.body, Control)
                    and message.body.action == "abandon" and message.body.through_seq >= call.seq
-                   for message in self.reader.snapshot())
+                   for message in self.reader.snapshot(after_seq=call.seq))
 
     def read(self, pointer: object) -> Result:
         """按持久指针读取正文，不在工具回执中保留第二份结果。"""

--- a/session/log.py
+++ b/session/log.py
@@ -474,9 +474,8 @@ class MessageCatalog:
         """单条查询取得同一数据库快照，不逐会话读取可能变化的 head。"""
         with self._log._lock:
             rows = self._log._connection.execute(
-                "SELECT s.key, COALESCE(MAX(m.seq), -1) AS head "
-                "FROM sessions s LEFT JOIN messages m ON m.session_key=s.key "
-                "GROUP BY s.key ORDER BY s.key"
+                "SELECT s.key, COALESCE((SELECT MAX(m.seq) FROM messages m "
+                "WHERE m.session_key=s.key), -1) AS head FROM sessions s ORDER BY s.key"
             ).fetchall()
         return MappingProxyType({row["key"]: row["head"] for row in rows})
 
@@ -621,11 +620,29 @@ class MessageReader:
             rows = self._log._connection.execute(sql, values).fetchall()
         return tuple(_message(row) for row in rows)
 
-    def snapshot(self, *, through_seq: int | None = None) -> tuple[Message, ...]:
-        """固定上界后分页读取完整前缀，供需要完整历史的只读投影消费。"""
+    def source_names(self) -> frozenset[str]:
+        """只读取本 Session 中出现过的来源，不解码消息正文。"""
+        with self._log._lock:
+            rows = self._log._connection.execute(
+                "SELECT DISTINCT source FROM messages WHERE session_key=?", (self._session_id,),
+            ).fetchall()
+        return frozenset(row[0] for row in rows)
+
+    def latest_input(self, source: str, *, through_seq: int) -> Message | None:
+        """读取指定前缀中最后一条同来源 Input，后来输入不改变旧回复的目的地。"""
+        with self._log._lock:
+            row = self._log._connection.execute(
+                "SELECT * FROM messages WHERE session_key=? AND source=? AND seq<=? "
+                "AND json_extract(body,'$.kind')='input' ORDER BY seq DESC LIMIT 1",
+                (self._session_id, source, through_seq),
+            ).fetchone()
+        return None if row is None else _message(row)
+
+    def snapshot(self, *, after_seq: int = -1, through_seq: int | None = None) -> tuple[Message, ...]:
+        """固定上界后分页读取消息区间，默认保留完整前缀。"""
         head = self.head() if through_seq is None else through_seq
         messages: list[Message] = []
-        cursor = -1
+        cursor = after_seq
         while cursor < head:
             page = self.read(after_seq=cursor, through_seq=head)
             if not page:

--- a/tests/test_message_log.py
+++ b/tests/test_message_log.py
@@ -378,3 +378,28 @@ async def test_catalog_follow_discovers_new_sessions_and_closes(log, monkeypatch
     log.close()
     with pytest.raises(StopAsyncIteration):
         await asyncio.wait_for(pending, 1)
+
+
+def test_reader_ranges_keep_prefix_source_and_page_boundaries(log):
+    inputs = writer(log)
+    first = inputs.append("first", Input(()))
+    other = writer(log, source="wake").append("wake", Input(()))
+    output = writer(log, author="agent", bodies=(Output,))
+    for index in range(1002):
+        output.append(f"output-{index}", Output((), "complete"))
+    reader = log.reader("s")
+    head = reader.head()
+    later = inputs.append("later", Input(()))
+    before = tuple(log._connection.iterdump())
+    assert reader.source_names() == frozenset({"conversation", "wake"})
+    assert reader.latest_input("conversation", through_seq=head) == first
+    assert reader.latest_input("conversation", through_seq=later.seq) == later
+    assert reader.latest_input("wake", through_seq=head) == other
+    assert reader.latest_input("missing", through_seq=head) is None
+    assert reader.latest_input("conversation", through_seq=-1) is None
+    bounded = reader.snapshot(after_seq=other.seq, through_seq=head)
+    assert len(bounded) == 1002
+    assert [message.seq for message in bounded] == list(range(other.seq + 1, head + 1))
+    assert reader.snapshot(after_seq=head) == (later,)
+    assert reader.snapshot(after_seq=head, through_seq=head) == ()
+    assert tuple(log._connection.iterdump()) == before

--- a/tests/test_model_call_records.py
+++ b/tests/test_model_call_records.py
@@ -774,3 +774,47 @@ def test_timing_migration_keeps_its_target_when_runtime_schema_evolves(store, mi
     with closing(sqlite3.connect(store.path)) as connection:
         columns = [row[1] for row in connection.execute('PRAGMA table_info(model_calls)')]
     assert columns[-2:] == ['first_token_ms', 'duration_ms']
+
+
+def test_grouped_call_reads_see_settlement_and_close(store, descriptor):
+    call_id = store.start_call(descriptor, ModelRequest(()))
+    with store.read_call.open() as read:
+        before = read(call_id)
+        assert before["state"] == "started"
+        store.finish_call(call_id, usage=None, failure=None)
+        assert read(call_id)["state"] == "success"
+        assert before["state"] == "started"
+        with store.read_call.open() as nested:
+            assert nested(call_id)["state"] == "success"
+        assert read(call_id)["state"] == "success"
+    with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+        read(call_id)
+    assert store.read_call(call_id)["state"] == "success"
+
+
+def test_grouped_call_reads_reuse_readonly_connection_and_close_on_error(store, descriptor):
+    from contextlib import contextmanager
+    from plugins.models.store import ModelCallReader
+
+    call_id = store.start_call(descriptor, ModelRequest(()))
+    connections = []
+
+    @contextmanager
+    def connect():
+        with store._connect(read_only=True) as connection:
+            connections.append(connection)
+            yield connection
+
+    reader = ModelCallReader(connect)
+    with pytest.raises(KeyError, match="missing"):
+        with reader.open() as read:
+            assert read(call_id)["state"] == "started"
+            assert read(call_id)["state"] == "started"
+            assert len(connections) == 1
+            assert not connections[0].in_transaction
+            with pytest.raises(sqlite3.OperationalError, match="readonly"):
+                connections[0].execute("DELETE FROM model_calls")
+            read("missing")
+    with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+        connections[0].execute("SELECT 1")
+    assert store.read_call(call_id)["state"] == "started"


### PR DESCRIPTION
## 问题与结果

长历史会话的每次新输入检查、工具中间轮和回复跟随反复解码完整历史；模型请求组装还为每条历史回执单独建立 SQLite 连接。本 PR 缩小消息读取范围，并在一次同步历史投影中复用只读连接，减少首次推理和中间轮的本地处理成本。

- 新输入、abandon 和完成检查按序号区间读取；Reply 查询来源列，出站按原 through_seq 查询最后一条同来源 Input；head 使用既有序号索引。
- 模型记录 owner 提供可调用的只读读取器；同步组装内逐条查询并验证，退出即关闭。没有跨轮缓存、跨 await 连接或额外长读事务。既有普通 callable 仍可作为投影读取器。
- Akasha、记忆锁、MCP 生命周期和实际推理逻辑不变。

## Change intent

- change_type: fix；semantic_delta: none；capability_owner: mixed（Session 日志与普通插件）。
- consumer_scope: 入站检查、Reply、Tools、Delivery policy、模型历史投影；runtime_patch: required，成本位于这些服务端读取路径，客户端无法消除。
- authoritative_state_owner: MessageLog 与 ModelsStore 不变；关联不变量：Message 正常只追加、固定序号前缀、撤销只作用于其声明前缀、模型事实必须引用成功回执。
- protected_state: sessions.db、模型调用账、正式 workspace、插件 generation。
- 允许副作用：源码、隔离测试数据、Git 分支、PR 与用户授权的合并；禁止正式数据迁移、删除、发送和部署。

## 改动范围与恢复

10 个文件：Session 日志、6 个插件实现文件及模型投影、2 个测试文件。无配置、schema、迁移或跨仓库协议变化。
基线为 main 的 166332c5；回滚可 revert 本 PR。源码修改前备份保存在本机 /tmp/akashic-latency-20260909/candidate-before.tgz 与 formal-before.tgz，完整补丁另存 formal-before-rebase.patch。

## 验证

- 141 项相关测试通过：message_catalog、message_log、reply_follow、tool_abandon、message_react、delivery_policy、default_reply、model_call_records、message_compaction_summary、reply_program、shell_abandon、standard_tools。
- 新增回归覆盖跨页序号区间、来源与旧输入边界、只读查询不改变数据库、读取范围内可见新结算、连接复用和异常关闭。
- 改动实现文件 Pyright：0 errors，74 warnings；git diff --check 通过。
- 按维护者明确要求不运行 Gate，不等待 CI，相关测试通过后直接合并；未验证线上性能、真实设备或部署。
- 先前受控性能试验仅作方向证据，不把夹具提速当作线上验收。

## 正交性与工作手册

普通读取性能修复，不改变既有领域状态、插件 hook 或生命周期语义。ModelCallReader 仅拥有一次只读连接范围；不暴露写入或任意 SQL 权限。
已按最终 diff 自审；无 must-fix。独立概念 Gate 未运行（维护者本次明确免除 Gate）。
已核对 projectneed、持久化状态地图和 NOW；无长期产品语义变化，无对应 NOW 待办。