### PR TITLE
修复移动端 MCP 能力查询导致的断线

### DIFF
--- a/infra/mobile_realtime/runtime_inspection.py
+++ b/infra/mobile_realtime/runtime_inspection.py
@@ -369,8 +369,6 @@ def _mcp_items(snapshot: RuntimeSnapshot) -> list[dict[str, object]]:
     items: list[dict[str, object]] = []
     registry = snapshot.mcp_server_registry
     if registry is not None:
-        if snapshot.tool_registry is None:
-            raise RuntimeError("stable v3 MCP registry 缺少 exact ToolRegistry")
         for descriptor in registry.descriptors:
             tools = _mcp_tools_from_registry(snapshot, descriptor.name)
             items.append(
@@ -393,7 +391,11 @@ def _mcp_tools_from_registry(
 
     registry = snapshot.tool_registry
     if registry is None:
-        raise RuntimeError("stable v3 MCP registry 缺少 exact ToolRegistry")
+        # 按需 MCP 尚无快照工具目录；查询失败不能中断同一连接上的聊天。
+        raise RuntimeInspectionError(
+            "mcp_catalog_unavailable",
+            "MCP 工具目录暂不可用，声明的服务按需启动",
+        )
     prefix = f"mcp_{server_name}__"
     tools: list[dict[str, object]] = []
     for name in registry.get_registered_order(

--- a/tests/mobile_realtime/test_channel.py
+++ b/tests/mobile_realtime/test_channel.py
@@ -1116,6 +1116,39 @@ def _register_device(storage: MobileRealtimeStorage, device_id: str) -> None:
 
 
 @pytest.mark.asyncio
+async def test_lazy_mcp_catalog_error_does_not_abort_next_command(tmp_path: Path) -> None:
+    from agent.plugins.snapshot import RuntimeSnapshot
+    from infra.mobile_realtime.runtime_inspection import _mcp_items
+
+    snapshot = RuntimeSnapshot("lazy-mcp", {}, None)
+    snapshot.mcp_server_registry = cast(Any, SimpleNamespace(
+        descriptors=(SimpleNamespace(owner="computer", name="computer"),),
+    ))
+
+    class Inspection(_RuntimeInspection):
+        async def list_capabilities(self) -> dict[str, object]:
+            return {"mcp_servers": _mcp_items(snapshot)}
+
+    storage = MobileRealtimeStorage(tmp_path / "mobile.db")
+    device_id = uuid4().hex
+    _register_device(storage, device_id)
+    channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, _Runtime(storage)))
+    channel.bind_runtime_inspection(cast(RuntimeInspectionService, Inspection()))
+    try:
+        failed = await channel.handle_command(device_id=device_id, frame=_generic_frame(
+            frame_id="01ARZ3NDEKTSV4RRFFQ69G5FAV", command_type="runtime.capability.list",
+        ))
+        assert failed.type == "runtime.capability.list.error"
+        assert failed.payload["code"] == "mcp_catalog_unavailable"
+        following = await channel.handle_command(device_id=device_id, frame=_generic_frame(
+            frame_id="01ARZ3NDEKTSV4RRFFQ69G5FAW", command_type="runtime.document.list",
+        ))
+        assert following.type == "runtime.document.list.ok"
+    finally:
+        storage.close()
+
+
+@pytest.mark.asyncio
 async def test_runtime_document_commands_use_bound_read_service(tmp_path: Path) -> None:
     storage = MobileRealtimeStorage(tmp_path / "mobile.db")
     device_id = uuid4().hex


### PR DESCRIPTION
移动端连接后查询 runtime.capability.list，按需 MCP 没有旧 ToolRegistry 时会抛出未处理 RuntimeError，断开整条 WebSocket，反复重连也阻塞 WebUI 更新。

将这个已知查询失败返回为 mcp_catalog_unavailable 命令错误；不伪造工具列表，不启动 MCP，也不影响同连接后续命令。空 MCP 声明目录不再要求 ToolRegistry。实时 MCP 目录仍明确显示暂不可用。

验证：针对性的目录失败/后续命令与文档查询回归。按维护者要求直接合并部署，不运行额外 Gate 或等待 CI。恢复沿用部署前已有版本与备份；无数据库或协议变更。
