### PR TITLE
避免后台历史读取阻塞运行时心跳

### DIFF
--- a/plugins/markdown_memory/message_plugin.py
+++ b/plugins/markdown_memory/message_plugin.py
@@ -465,7 +465,7 @@ async def profile_lock(path: Path, *, create: bool = True) -> AsyncGenerator[Non
             fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
-def _unapplied_messages(record: StoredSummary, lookup: SummaryLookup, reader: MessageReader,
+async def _unapplied_messages(record: StoredSummary, lookup: SummaryLookup, reader: MessageReader,
                         store: MarkdownProfileStore, sources: tuple[str, ...],
                         projection: TurnProjection) -> tuple[Message, ...] | None:
     """从最近已写入的祖先之后取原文，跳过未使用的摘要不会漏掉它覆盖的事实。"""
@@ -485,7 +485,8 @@ def _unapplied_messages(record: StoredSummary, lookup: SummaryLookup, reader: Me
         if record.generation <= generation:
             return None
         start = len(newer.source_message_ids)
-    snapshot = reader.snapshot()
+    # 归档 lookup 依赖当前 task 的 lease；只把独立 reader 的解码移出事件循环。
+    snapshot = await asyncio.to_thread(reader.snapshot)
     covered = summary_range(snapshot, record.source_message_ids)
     # 历史 suppress 是整个工作单元的资格，不能只删用户行后继续学习其回答。
     by_id = {message.message_id: message for message in snapshot[:covered.stop]}
@@ -523,7 +524,7 @@ async def project(message: Message, *, reader: MessageReader, bindings: Bindings
             if store.is_applied(record.reference):
                 return
             draft = store.read_draft(record.reference)
-            selected = _unapplied_messages(record, lookup, reader, store, sources, projection)
+            selected = await _unapplied_messages(record, lookup, reader, store, sources, projection)
             if not selected:
                 return
         # 模型属于当前 Markdown 作用域；先关闭旧摘要的只读归档 scope。
@@ -579,7 +580,13 @@ async def apply(ctx: Context, config: Config) -> None:
                 async with ctx.runtime_scope():
                     assert store is not None
                     reader = catalog.reader(session)
-                    for message in reader.snapshot():
+                    if reader.attributes.learning != "eligible":
+                        cursor[session] = head
+                        continue
+                    messages = await asyncio.to_thread(
+                        reader.snapshot, after_seq=cursor.get(session, -1), through_seq=head,
+                    )
+                    for message in messages:
                         if cursor.get(session, -1) < message.seq <= head:
                             await project(message, reader=reader, bindings=ctx.require(BINDINGS),
                                           store=store, models=ctx.require(CHAT_MODELS), lock_path=lock_path,

--- a/plugins/tools/abandon.py
+++ b/plugins/tools/abandon.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Awaitable, Callable, Hashable, Mapping
 from dataclasses import replace
 from typing import cast
@@ -89,10 +90,10 @@ async def follow_abandon(
             if head == previous:
                 continue
             reader = catalog.reader(session_id)
-            changed = reader.snapshot(after_seq=previous, through_seq=head)
+            changed = await asyncio.to_thread(reader.snapshot, after_seq=previous, through_seq=head)
             controls = [message for message in changed
                         if isinstance(message.body, Control) and message.body.action == "abandon"]
-            messages = reader.snapshot(through_seq=head) if controls else ()
+            messages = await asyncio.to_thread(reader.snapshot, through_seq=head) if controls else ()
             for control in controls:
                 for ref in abandoned_calls(messages, control):
                     target = await reply(reader, control.source, ref)

--- a/tests/test_message_markdown_memory.py
+++ b/tests/test_message_markdown_memory.py
@@ -522,3 +522,43 @@ def test_moving_an_operation_note_into_user_facts_requires_new_evidence():
              "self_before": "", "self": "", "evidence": {"memory": {}, "self": {}}}
     with pytest.raises(ValueError, match="实际消息"):
         check_evidence(draft, ())
+
+
+@pytest.mark.asyncio
+async def test_background_discovery_reads_only_new_eligible_messages(tmp_path, monkeypatch):
+    from session.log import MessageCatalog, MessageReader
+
+    first_done, next_head, finished, hold = (asyncio.Event() for _ in range(4))
+    calls = []
+    original = MessageReader.snapshot
+
+    def snapshot(reader, **kwargs):
+        assert reader.session_id != "excluded", "excluded history must not be decoded"
+        calls.append((reader.session_id, kwargs))
+        return original(reader, **kwargs)
+
+    async def heads(_catalog):
+        yield {"excluded": 0, "eligible": 0}
+        first_done.set()
+        await next_head.wait()
+        yield {"excluded": 0, "eligible": 1}
+        finished.set()
+        await hold.wait()
+
+    async with application(tmp_path) as (log, host):
+        for name, learning in (("excluded", "excluded"), ("eligible", "eligible")):
+            log.ensure_session(name, SessionAttributes("internal", learning))
+            log.writer(name, author="user", source="conversation", body_types=(Input,),
+                       content={"text": check_text}).append(name, Input((ContentPart("text", name),)))
+        monkeypatch.setattr(MessageReader, "snapshot", snapshot)
+        monkeypatch.setattr(MessageCatalog, "follow", heads)
+        await host.start_runtime()
+        await asyncio.wait_for(first_done.wait(), 2)
+        log.writer("eligible", author="user", source="conversation", body_types=(Input,),
+                   content={"text": check_text}).append("next", Input((ContentPart("text", "next"),)))
+        next_head.set()
+        await asyncio.wait_for(finished.wait(), 2)
+        assert calls == [
+            ("eligible", {"after_seq": -1, "through_seq": 0}),
+            ("eligible", {"after_seq": 0, "through_seq": 1}),
+        ]


### PR DESCRIPTION
正式运行采样定位到 Markdown 记忆在主事件循环同步解码完整历史，包含不参与学习的内部 Session；工具放弃消费者也有无界同步读取。大历史会拖住聊天及 Host Bridge Probe，导致运行时退出。

把这两处后台读取和 Markdown 原文读取放到线程，Markdown 在读取正文前检查学习资格，并只读取 cursor 后的固定区间。归档 lookup、消息/记忆写入和工具结算继续由原 task 与事务负责，没有持久化语义或 schema 变化。

验证：31 项 Markdown 记忆与工具放弃定向测试通过，新增消费者跳过 excluded 历史及只读新增区间的回归。遵照维护者本次指令，不扩展 Gate 或等待全量 CI。恢复点：本地 core-background-before.tar 和原提交 b89fdf2d；服务部署沿用已有备份。

Ownership: capability_owner 为两个后台消费者；consumer_scope 为所有消息来源；runtime_patch 用于消除 Core 事件循环阻塞，客户端无法修复；authoritative_state_owner 仍为 MessageLog、MarkdownProfileStore 和工具结算 owner。