### PR TITLE
[codex] 修复暂停过程、Akasha 卡片跳动和调用统计读取

### DIFF
--- a/docs/design/shared-chat-webui.md
+++ b/docs/design/shared-chat-webui.md
@@ -180,7 +180,7 @@ TypeScript 固定为 5.9.3，沿用现有 strict、ES2022 和 bundler 配置。
 
 ### 9.1 已确认的正文展示
 
-同一 source 的 `continue` 正文只是执行中的当前正文；新正文接替旧正文，`complete` 结束后只展示最终正文。思考与工具合为一条过程轨迹，仍沿原 `message_id + part_index` 查看，最后正文使用最终 Message 的复制、引用和时间。`abandon` 隔开前后回复；其他 source 的输出不替换本来源正文。分页和实时追加使用同一展示规则，不改写任何 Message。
+同一 source 的 `continue` 正文只是执行中的当前正文；新正文接替旧正文，`complete` 结束后只展示最终正文。思考与工具合为一条过程轨迹，仍沿原 `message_id + part_index` 查看，最后正文使用最终 Message 的复制、引用和时间。`pause`、`failure`、`abandon` 按 `through_seq` 隔开前后展示过程，停止前的过程保留在末条输出上；这不改变持久 Turn 的划分。其他 source 的输出不替换本来源正文。分页和实时追加使用同一展示规则，不改写任何 Message。
 
 ```text
 Input → 等待 → 思考 / 工具 + 当前正文 → 最终正文
@@ -228,3 +228,9 @@ Core Message 日志和附件保持 append-only，只有既有 adapter 的读协�
 验收覆盖尾页帧预算、旧/新表示摘要、完整数据库未变、部分窗口与实时追加、Room 接收范围/ACK 原子性、旧引用定位、阅读锚、断线和未下载正文。性能分别记录首屏 bytes、接收行数和发送时刻，不能把本地输入接受当成服务器已发送。
 
 参考：[Matrix limited timeline 与向前补页](https://spec.matrix.org/latest/client-server-api/#syncing)、[Stream 消息 ID 分页](https://getstream.io/chat/docs/javascript/channel-pagination/)；使用本项目已有 `message_id + seq`，不引入第三方 token 模型。
+
+### 9.3 回复过程与调用统计
+
+实时回复从等待首段起就把 `turn.before_reasoning` 插槽放在同一个思考面板内；思考到达后不移动插槽，避免 Akasha 卡片卸载重查。`model.selection` 是内部选择记录，不占正文布局，未知插件内容仍明确显示不可展示。
+
+统计由 models 的调用记录拥有。Web 通过公共 `/api/settings/model/calls/{call_id}` 读取；Android build 79 起用 `readModelCallStats` 转发已有 `model.call.get`，共享页面校验与计算数值。新 WebUI 的最低原生 build 为 79；没有数据或查询失败均不估算。

--- a/frontend/chat/src/message-process.test.mjs
+++ b/frontend/chat/src/message-process.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import test from "node:test";
+import { build } from "esbuild";
+import { JSDOM } from "jsdom";
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+
+const compiled = await build({
+  entryPoints: [new URL("./message-view.tsx", import.meta.url).pathname],
+  bundle: true, write: false, platform: "node", format: "cjs", packages: "external",
+  alias: { "@": new URL(".", import.meta.url).pathname },
+  loader: { ".css": "empty", ".svg": "dataurl" },
+  plugins: [{ name: "fixture-plugin", setup(builder) {
+    builder.onResolve({ filter: /(?:^|\/)message-response$/ }, () => ({ path: "fixture-markdown", namespace: "markdown" }));
+    builder.onLoad({ filter: /.*/, namespace: "markdown" }, () => ({ loader: "js", contents: "export function MessageResponse({ children }) { return children; }" }));
+    builder.onResolve({ filter: /mobile-plugin-runtime$/ }, () => ({ path: "fixture-plugin", namespace: "fixture" }));
+    builder.onLoad({ filter: /.*/, namespace: "fixture" }, () => ({ resolveDir: new URL(".", import.meta.url).pathname, loader: "js", contents: `
+      const React = require("react");
+      export function MobilePluginSlot() {
+        return React.createElement("div", { "data-recall": true }, "左脑 · 右脑");
+      }` }));
+  } }],
+});
+const module = { exports: {} };
+new Function("require", "module", "exports", compiled.outputFiles[0].text)(createRequire(import.meta.url), module, module.exports);
+const { ReplyActivityView } = module.exports;
+
+test("recall remains in the same thinking panel from waiting to the first thinking chunk", async () => {
+  const dom = new JSDOM("<div id='root'></div>", { url: "http://localhost/" });
+  const globals = { window: dom.window, document: dom.window.document, HTMLElement: dom.window.HTMLElement,
+    getComputedStyle: dom.window.getComputedStyle, requestAnimationFrame: (fn) => setTimeout(fn, 0),
+    cancelAnimationFrame: clearTimeout, IS_REACT_ACT_ENVIRONMENT: true };
+  const previous = new Map(Object.keys(globals).map((key) => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+  for (const [key, value] of Object.entries(globals)) Object.defineProperty(globalThis, key, { value, configurable: true });
+  const root = createRoot(document.getElementById("root"));
+  const activity = { handle: "h", session_id: "s", source: "conversation", active: true,
+    preview: { message_id: "draft", call_record_id: "call", text: "", thinking: "" } };
+  try {
+    const render = async (thinking) => act(async () => root.render(React.createElement(ReplyActivityView,
+      { activity: { ...activity, preview: { ...activity.preview, thinking } }, committed: new Set() })));
+    await render("");
+    const recall = document.querySelector("[data-recall]");
+    assert.ok(recall?.closest(".process-trace"));
+    assert.equal(document.querySelectorAll(".process-trace").length, 1);
+    await render("正在核对记忆");
+    assert.equal(document.querySelector("[data-recall]"), recall);
+    assert.equal(document.querySelectorAll("[data-recall]").length, 1);
+    assert.ok(recall.closest(".process-trace"));
+  } finally {
+    await act(async () => root.unmount());
+    dom.window.close();
+    for (const [key, descriptor] of previous) {
+      if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+      else delete globalThis[key];
+    }
+  }
+});

--- a/frontend/chat/src/message-timeline.test.mjs
+++ b/frontend/chat/src/message-timeline.test.mjs
@@ -209,3 +209,28 @@ test("工具结果回到原调用面板，分页缺少调用时仍可阅读和�
   assert.deepEqual(messages, original);
 
 });
+
+for (const action of ["pause", "failure", "abandon"]) test(`${action} keeps earlier process before the next input and active reply`, () => {
+  const first = row(1, { kind: "output", finish: "continue", parts: [text("old"),
+    { kind: "tool_call", name: "tool", binding_id: "b", arguments: {} }] });
+  const second = row(3, { kind: "output", finish: "continue", parts: [text("old end")] });
+  const stop = row(4, { kind: "control", action, through_seq: 3, reason: null });
+  const input = row(5, { kind: "input", parts: [text("new")] });
+  const next = row(6, { kind: "output", finish: "continue", parts: [text("new reply")] });
+  const messages = [first, second, stop, input, next];
+  const snapshot = structuredClone(messages);
+  const groups = timelineReplyGroups(messages, [{ handle: "h", session_id: first.session_id, source: first.source, active: true }]);
+  assert.deepEqual(groups.completed.get(second.id), [first, second]);
+  assert.deepEqual(groups.active.get("h"), [next]);
+  assert.equal(groups.hiddenBodies.has(second.id), false);
+  assert.deepEqual(timelineVisibleMessages(messages, groups), [second, stop, input]);
+  const anchors = timelineAnchorIndexes(messages, groups);
+  assert.equal(anchors.get(first.id), anchors.get(second.id));
+  assert.ok(anchors.get(first.id) < anchors.get(input.id));
+  assert.deepEqual(messages, snapshot);
+});
+
+test("internal model selection stays hidden while unknown plugin content remains visible", () => {
+  assert.equal(isTimelinePartVisible({ kind: "model.selection", display: "unavailable" }), false);
+  assert.equal(isTimelinePartVisible({ kind: "plugin.custom", display: "unavailable" }), true);
+});

--- a/frontend/chat/src/message-timeline.ts
+++ b/frontend/chat/src/message-timeline.ts
@@ -242,7 +242,7 @@ export function historyTranscript(archive: unknown): HistoryTranscriptGroup[] | 
 
 /** 聊天可见性只影响布局，原始 Message、part index 和同步 seq 不变。 */
 export function isTimelinePartVisible(part: TimelinePart): boolean {
-  if ("display" in part) return !["channel.origin", "context.summary", "tool.selection", "command.result", "akasha.recall", "akasha.feedback"].includes(part.kind);
+  if ("display" in part) return !["channel.origin", "context.summary", "tool.selection", "model.selection", "command.result", "akasha.recall", "akasha.feedback"].includes(part.kind);
   if ("archive" in part) {
     if (part.kind !== "history.transcript") return false;
     const groups = historyTranscript(part.archive);
@@ -295,7 +295,7 @@ export function timelineToolResults(messages: TimelineMessage[]): Map<string, Ti
     ? [[`${message.body.call_ref.message_id}:${message.body.call_ref.part_index}`, message] as const] : []));
 }
 
-/** 完成后把同来源的过程归到最终消息；成员只保存原消息引用。 */
+/** 完成或停止展示时，把同来源的过程归到末条输出；不改变 Turn。 */
 export function timelineReplyGroups(messages: TimelineMessage[], activities: ReplyActivity[] = []) {
   const pending = new Map<string, TimelineMessage[]>();
   const completed = new Map<string, TimelineMessage[]>();
@@ -313,10 +313,14 @@ export function timelineReplyGroups(messages: TimelineMessage[], activities: Rep
         if (members.length > 1) completed.set(message.id, members);
         pending.delete(key);
       }
-    } else if (body.kind === "control" && body.action === "abandon") {
+    } else if (body.kind === "control" && body.action !== "resume") {
       const members = pending.get(key) ?? [];
-      const closed = members.filter((item) => item.seq <= body.through_seq).at(-1);
-      if (closed) hiddenBodies.delete(closed.id);
+      const closed = members.filter((item) => item.seq <= body.through_seq);
+      const ending = closed.at(-1);
+      if (ending) {
+        hiddenBodies.delete(ending.id);
+        if (closed.length > 1) completed.set(ending.id, closed);
+      }
       pending.set(key, members.filter((item) => item.seq > body.through_seq));
     }
   }

--- a/frontend/chat/src/message-view.tsx
+++ b/frontend/chat/src/message-view.tsx
@@ -117,7 +117,7 @@ export function ReplyActivityView({ activity, committed, onError, processMessage
         beforePart={(part, index, message) => part.kind === "tool_call" && !("display" in part) ? <MobilePluginSlot
           name="turn.before_tool" sessionId={message.session_id} messageId={message.id}
           block={{ ...part, message_id: message.id, part_index: index }} /> : null} />
-      {!draft?.thinking && !text && !process.length ? <ThinkingPlaceholder /> : null}
+      {!draft && !text && !process.length ? <ThinkingPlaceholder /> : null}
       {text ? <MessageBody content={text} streaming={Boolean(draft?.text) && activity.active} deferRichContent onError={onError} /> : null}
     </div>
   </div>;
@@ -239,7 +239,7 @@ function TimelineProcess({ process, streaming = false, draftThinking = "", draft
 }) {
   const blocks: AgentBlock[] = process.map((item) => item.block);
   if (draftThinking) blocks.push({ kind: "thinking", content: draftThinking });
-  if (!blocks.length) return draftSlot;
+  if (!blocks.length && !draftSlot) return null;
   return <ProcessTrace blocks={blocks} streaming={streaming} interrupted={false}
     startContent={process.length ? beforeReasoning?.(process[0].origin) : draftSlot}
     beforeBlock={(_block, index) => {

--- a/frontend/chat/src/model-call-stats.test.mjs
+++ b/frontend/chat/src/model-call-stats.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { formatModelCallStats, loadMobileModelCallStats, readModelCallStats, receiveMobileModelCallStats, selectModelCall } from "./model-call-stats.ts";
+import { formatModelCallStats, loadWebModelCallStats, loadMobileModelCallStats, readModelCallStats, receiveMobileModelCallStats, selectModelCall } from "./model-call-stats.ts";
 
 const stats = {
   call_record_id: "call", model: "fixture", state: "success", first_token_ms: 400, duration_ms: 1400,
@@ -64,4 +64,16 @@ test("native read correlates by request and ignores late replies after a session
   } finally {
     globalThis.window = original;
   }
+});
+
+test("web stats use the public settings route and retain cancellation", async () => {
+  const original = globalThis.fetch;
+  const controller = new AbortController();
+  globalThis.fetch = async (url, options) => {
+    assert.equal(url, "/api/settings/model/calls/call");
+    assert.equal(options.signal, controller.signal);
+    return { ok: true, json: async () => stats };
+  };
+  try { assert.deepEqual(await loadWebModelCallStats("call", controller.signal), stats); }
+  finally { globalThis.fetch = original; }
 });

--- a/frontend/chat/src/model-call-stats.ts
+++ b/frontend/chat/src/model-call-stats.ts
@@ -71,7 +71,7 @@ export function formatModelCallStats(stats: ModelCallStats, active: boolean): st
 }
 
 export const loadWebModelCallStats: LoadModelCallStats = async (callId, signal) => {
-  const response = await fetch(`/api/chat/model-settings/calls/${encodeURIComponent(callId)}`, { signal });
+  const response = await fetch(`/api/settings/model/calls/${encodeURIComponent(callId)}`, { signal });
   if (!response.ok) throw new Error("统计暂不可用");
   return readModelCallStats(await response.json(), callId);
 };

--- a/infra/mobile_webui/manifest.py
+++ b/infra/mobile_webui/manifest.py
@@ -398,7 +398,7 @@ def manifest_from_directory(
     bridge_protocol_max: int = 2,
     snapshot_protocol_min: int = 10,
     snapshot_protocol_max: int = 10,
-    minimum_native_build: int = 47,
+    minimum_native_build: int = 79,
     platforms: tuple[str, ...] = ("android",),
     source_repository: str,
     source_commit: str,


### PR DESCRIPTION
## 问题与结果

暂停后开始新回复时，旧过程会被并入新回复；内部 model.selection 显示为“无法展示此内容”；统计使用被 Web Shell 拒绝的旧地址；Akasha 在首段思考到来时从框外搬进框内并重新查询。

本次按暂停/失败/放弃的 through_seq 结束展示分组，保留原消息引用；隐藏内部选择记录；使用公共统计路由；让实时插件插槽从等待阶段就位于同一思考面板。新 WebUI 最低 Android build 为 79，对应 Mobile 0.8.41 的统计桥。

## Change intent

- change_type: fix；semantic_delta: compatible；capability_owner: mixed；consumer_scope: Web / Android 共享 WebUI。
- runtime_patch: none；展示与只读查询修复；Model 调用记录、Message 日志继续由原 owner 拥有，客户端不能补写或估算统计。
- concept_gate: required，由用户指定 Terra xhigh 独立评审。
- 关联：CTX-003、MOB-001、持久化只追加约束；protected_state: sessions.db、模型记录、附件、workspace。
- 允许副作用：Git、构建、经批准的合并和部署。没有数据迁移、删除或历史改写。
- 已知 schema lineage/identity 不变；Android 协议消费固定 Core 7a4479b80911435e060dca31da37ee9318ae1c9d。
- 恢复：回退本 PR / 正式 release owner 切回 7a4479b；源码备份 /tmp/chat-turn-display-before-20260909.tar.gz、/tmp/message-view-before-akasha-20260909.tsx。

## 验证

- [x] 展示与统计 Node tests 22 passed；真实 React 过程面板连续性测试 1 passed。
- [x] Python 统计 / content / WebUI publication 56 passed。
- [x] TypeScript typecheck、chat build、固定源码 mobile-web package 成功。
- [ ] CI / change-impact Gate：用户明确要求不等待、不作为本次合并条件；sourceDigest / planDigest 不适用。
- 真机未运行；Android 在独立 PR 验证并发布 APK。
- Meme 专项：当前插件 6b0cd65 的真实 manager→content→artifact→Message 测试 9 passed；逐字符 SSE 保真 3 passed。线上两条保存的尾部分别是拼错和未完成的标签，无导入记录。未保存原始 provider 响应，不能进一步区分模型与上游服务；不猜测或重写历史。

## 正交性与工作手册

- 小范围 bug fix；没有新增领域概念，持久 Turn 语义不变。
- 正常链：Message / reply.status → 展示分组 → 原引用的过程与正文；统计失败明确不可用。
- 独立 reviewer: gpt-5.6-terra / xhigh，审查 head 411562fc9a56eba626fdd045c0031b5c87292ea9；五项结论均通过，无未解决 must-fix。Mobile 的旧 WebView 回执 P1 已在 25c904f 修复并复核。
- 已核对工作手册和状态边界，更新 shared-chat-webui；NOW 无对应未完成事项。