### PR TITLE
修复工具调用后重复插入召回卡片

### DIFF
--- a/docs/design/shared-chat-webui.md
+++ b/docs/design/shared-chat-webui.md
@@ -231,7 +231,7 @@ Core Message 日志和附件保持 append-only，只有既有 adapter 的读协�
 
 ### 9.3 回复过程与调用统计
 
-实时回复从等待首段起就把 `turn.before_reasoning` 插槽放在同一个思考面板内；思考到达后不移动插槽，避免 Akasha 卡片卸载重查。`model.selection` 是内部选择记录，不占正文布局，未知插件内容仍明确显示不可展示。
+每条过程轨迹只在开头挂载一次 `turn.before_reasoning`，工具调用后的消息和后续草稿不重复挂载。实时回复从等待首段起就把插槽放在同一个思考面板内；思考到达后不移动插槽，避免 Akasha 卡片卸载重查。`model.selection` 是内部选择记录，不占正文布局，未知插件内容仍明确显示不可展示。
 
 统计由 models 的调用记录拥有。Web 通过公共 `/api/settings/model/calls/{call_id}` 读取；Android build 79 起用 `readModelCallStats` 转发已有 `model.call.get`，共享页面校验与计算数值；没有数据或查询失败均不估算。
 

--- a/frontend/chat/src/message-view.tsx
+++ b/frontend/chat/src/message-view.tsx
@@ -248,9 +248,8 @@ function TimelineProcess({ process, streaming = false, draftThinking = "", draft
     startContent={process.length ? beforeReasoning?.(process[0].origin) : draftSlot}
     beforeBlock={(_block, index) => {
       const item = process[index];
-      if (!item) return process.length ? draftSlot : null;
+      if (!item) return null;
       return <div data-process-message-id={item.origin.id} data-part-index={item.index} tabIndex={-1}>
-        {index > 0 && process[index - 1].origin.id !== item.origin.id ? beforeReasoning?.(item.origin) : null}
         {beforePart?.(item.part, item.index, item.origin)}
       </div>;
     }} />

--- a/scripts/mobile-web-lab/verify-recall-once.mjs
+++ b/scripts/mobile-web-lab/verify-recall-once.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { build } from "esbuild";
+import { chromium } from "playwright-core";
+import { startMobileWebLabServer } from "./server.mjs";
+
+const fixture = await build({ entryPoints: ["frontend/chat/src/mobile-lab-fixtures.ts"],
+  bundle: true, write: false, format: "esm" });
+const { createLabSnapshot } = await import(`data:text/javascript;base64,${Buffer.from(fixture.outputFiles[0].text).toString("base64")}`);
+const plugin = await build({ entryPoints: ["frontend/plugins/akasha/src/mobile.js"],
+  bundle: true, write: false, format: "esm", loader: { ".css": "empty" } });
+const lab = await startMobileWebLabServer({ root: process.env.AKASHIC_MOBILE_WEB_LAB_ROOT });
+const browser = await chromium.launch({ executablePath: process.env.AKASHIC_PERF_CHROMIUM || "/usr/bin/chromium", headless: true });
+try {
+  for (const width of [320, 412]) {
+    // Lab 只允许 self；这里模拟 Android 的 appassets 资源，并加载真实 Akasha renderer。
+    const page = await browser.newPage({ viewport: { width, height: 860 }, bypassCSP: true });
+    const errors = [];
+    page.on("pageerror", error => errors.push(error.message));
+    await page.route("https://appassets.androidplatform.net/plugin-ui/**", route => route.fulfill({
+      body: plugin.outputFiles[0].text, contentType: "text/javascript", headers: { "access-control-allow-origin": "*" },
+    }));
+    await page.goto(`${lab.origin}/mobile-lab-frame.html?generation_id=browser-lab&nonce=browser-lab`);
+    await page.waitForFunction(() => Boolean(window.AkashicMobile));
+    await page.evaluate(() => {
+      window.AkashicNative.queryPluginUi = requestId => queueMicrotask(() =>
+        window.AkashicMobile.receivePluginUiResult({ requestId, resultJson: JSON.stringify({ pending: false,
+          items: [{ hits: [{ lane: "dense", messages: [{ preview: "召回内容" }] }] }],
+        }) }));
+      window.AkashicMobile.receivePluginCatalog({ catalogRevision: "a".repeat(64), updating: false,
+        plugins: [{ id: "akasha", revision: "b".repeat(64), slots: ["turn.before_reasoning"],
+          navigation: { label: "Akasha Inspector", description: "召回记录" },
+          moduleUrl: "https://appassets.androidplatform.net/plugin-ui/akasha/module.js" }] });
+    });
+    const base = createLabSnapshot("stream");
+    const [input, call, result] = base.messages.slice(2, 5);
+    const second = { ...structuredClone(call), id: "second-call", seq: 5 };
+    second.body.parts[0].value.thinking = "第二次调用前的思考";
+    const secondResult = { ...structuredClone(result), id: "second-result", seq: 6 };
+    secondResult.body.call_ref.message_id = second.id;
+    const final = { ...structuredClone(base.messages.at(-1)), id: "final-answer", seq: 7 };
+    final.body.parts.unshift({ kind: "model.facts", value: { call_record_id: "final-call-record", thinking: "最终思考" } });
+    const phases = [
+      { messages: [input], draft: call.id, thinking: "" },
+      { messages: [input], draft: call.id, thinking: "第一次思考" },
+      { messages: [input, call, result], draft: second.id, thinking: "第二次调用前的思考" },
+      { messages: [input, call, result, second, secondResult], draft: final.id, thinking: "最终思考" },
+      { messages: [input, call, result, second, secondResult, final] },
+    ];
+    for (const [index, phase] of phases.entries()) {
+      const snapshot = structuredClone(base);
+      snapshot.messages = phase.messages;
+      snapshot.throughSeq = phase.messages.at(-1).seq;
+      snapshot.projectionGeneration += index;
+      snapshot.history = { hasOlder: false, isLatest: true, loading: false };
+      snapshot.sessions[0].isRunning = Boolean(phase.draft);
+      snapshot.composer.isStreaming = Boolean(phase.draft);
+      snapshot.composer.canStop = Boolean(phase.draft);
+      snapshot.composer.canSend = !phase.draft;
+      snapshot.replyStatus.items = phase.draft ? [{ ...snapshot.replyStatus.items[0],
+        preview: { message_id: phase.draft, text: "", thinking: phase.thinking } }] : [];
+      await page.evaluate(snapshot => window.AkashicMobile.receiveSnapshot(snapshot), snapshot);
+      if (!phase.draft) {
+        await page.waitForFunction(() => document.body.innerText.includes("已思考")).catch(async error => { console.log(await page.locator("body").innerText()); throw error; });
+        await page.getByRole("button", { name: /已思考/ }).click();
+      }
+      await page.locator(".akasha-mobile-recall-group").first().waitFor();
+      await page.evaluate(() => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve))));
+      assert.equal(await page.locator(".akasha-mobile-recall-group").count(), 1, `${width}px phase ${index}`);
+      if (index >= 2) assert.equal(await page.locator(".tool-step-title").filter({ hasText: "read" }).count() > 0, true);
+    }
+    assert.deepEqual(errors, []);
+    await page.close();
+  }
+  console.log("Recall stays single through waiting, thinking, two tool calls and final history at 320/412px");
+} finally {
+  await browser.close();
+  await lab.close();
+}


### PR DESCRIPTION
## 问题与结果

工具调用后的每条 Message 和实时草稿都会再次挂载 turn.before_reasoning，而 Akasha 返回同一个 Turn 的召回，导致卡片越积越多。现在每条过程轨迹只在开头挂载一次；首段等待、思考、连续工具调用和最终历史共用这一位置，工具插槽和消息锚点保留。

## Change intent

fix / compatible；capability_owner=shared WebUI；consumer_scope=Desktop/Mobile；runtime_patch=none。权威 Message/Turn、缓存与 Native 协议不变；仅改变展示插槽调用次数，无数据库或运行 workspace 写入。回滚 revert 本 PR。

## 验证

TypeScript、25 项相关 Node 测试通过。新增 Chromium 脚本 scripts/mobile-web-lab/verify-recall-once.mjs 加载实际 Akasha renderer，320/412px 均验证等待、初次思考、连续两次工具调用及最终历史只有一组卡片。相同脚本在旧构建的第一次工具调用后失败 2 != 1，修复构建全部通过。

沿用用户授权的本地验证与独立评审交付方式，不等待 CI/change-impact Gate。独立 Terra (gpt-5.6-terra, xhigh) 已对 d3fe4cf7eba3d21106dbcb7517c59b856be92601 只读审查，0 must-fix，可合并。未进行本项正式手机展示实测。

## 工作手册

shared-chat-webui.md 已明确轨迹只挂载一次；无新产品语义、协议或持久化迁移。恢复点 /tmp/recall-once-before-20260909.tar.gz。
