### PR TITLE
修复重复召回和 Computer 工具发现提示 [skip ci]

### DIFF
--- a/docs/projectneed.md
+++ b/docs/projectneed.md
@@ -537,6 +537,8 @@ session compaction ledger 的派生 checkpoint，不替代上述记忆状态；�
 
 Akasha 按固定版本的 Turn 投影取得全部 Input 与唯一完成 Output，且为每个参与的非空 user/assistant Message 使用已持久化的固定 embedding，建立一个学习样本。多条 Input 按固定版本的规范化文本连接和向量聚合规则处理；Control、未完成工具和失败开放段只按 Akasha 明确的来源规则处理，不从相邻角色推断归属。在线提交和离线 builder 必须共用相同 Message IDs、规范化文本、向量和 digest 规则。旧数据只能走名称明确的 legacy 兼容路径。
 
+自动召回只由真实用户 Input（`author=user`）触发；同一输入首次准备后保存并复用实际 Recall，工具续步、system reminder、重试和重启不得重复检索。同 Turn 收到新的真实用户输入可以重新召回。主动调用 `recall_memory` 独立触发检索，并按原调用身份复用结果；后台 Input 不触发自动召回。查询记录只追加，不因复用而改写或删除历史记录。
+
 ### MEM-011 历史投影按完整 Turn 和 token tail 保留
 
 Session compaction、Markdown consolidation 的切点和 prompt history 必须使用同一版本的完整 Turn 投影。每条已送达 proactive、`message_push`、schedule fire 和 spawn completion assistant 若属于独立 source，则各自作为独立单元；任何窗口、retained tail 或 consolidation cursor 不得落入一个已关闭 Turn 内部。runtime 不再使用 `memory_window` 计数；compaction 反向累积至少 20,000 token，并允许因完整 Turn 跨过阈值。展开后可以超过 token target，但重建 provider payload 必须满足当前模型硬输入边界。

--- a/frontend/plugins/akasha/src/mobile.js
+++ b/frontend/plugins/akasha/src/mobile.js
@@ -128,7 +128,7 @@ export function mountRecall(host, context) {
     loading = true;
     clearTimeout(timer);
     status.hidden = true;
-    loadingTimer = setTimeout(() => {
+    if (!content.hasChildNodes()) loadingTimer = setTimeout(() => {
       status.textContent = "正在读取召回记录…";
       status.hidden = false;
     }, 150);
@@ -139,7 +139,9 @@ export function mountRecall(host, context) {
       content.innerHTML = result.items.length ? `<div class="akasha-mobile-recall-group">${[
         ["dense", "左脑 · 精确回忆", "precise"], ["completion", "右脑 · 模式补全", "completion"],
       ].map(([lane, title, style]) => {
-        const hits = result.items.flatMap((item) => item.hits.filter((hit) => hit.lane === lane));
+        // 多次真实查询可以命中同一回忆；卡片按消息成员展示一次，原查询留在 Inspector。
+        const hits = [...new Map(result.items.flatMap((item) => item.hits.filter((hit) => hit.lane === lane))
+          .map((hit) => [JSON.stringify(hit.messages.map((message) => message.message_id)), hit])).values()];
         return `<details data-lane="${lane}" class="akasha-mobile-recall akasha-mobile-recall--${style}">
           <summary><span>${title}</span><b>${hits.length}</b></summary>
           <ol class="akasha-mobile-memories">${hits.map((hit) => `<li><div>${hit.messages.map((message) =>

--- a/frontend/plugins/akasha/src/mobile.test.mjs
+++ b/frontend/plugins/akasha/src/mobile.test.mjs
@@ -48,11 +48,16 @@ test("refresh failure keeps visible recall and open lane, retry settles without 
     assert.equal(host.textContent, "");
     await advance(150);
     assert.match(host.textContent, /正在读取召回记录/);
-    calls[0].resolve(result(true));
+    const duplicate = result(true);
+    duplicate.items.push(duplicate.items[0]);
+    calls[0].resolve(duplicate);
     await Promise.resolve();
+    assert.equal(host.querySelector("details b").textContent, "1");
     host.querySelector("details").open = true;
     await advance(1000);
     assert.equal(calls.length, 2);
+    await advance(200);
+    assert.equal(host.querySelector("[role='status']").hidden, true);
     calls[1].reject(new Error("插件请求超时"));
     await Promise.resolve();
     assert.match(host.textContent, /已召回的原消息/);

--- a/plugins/akasha/runtime.py
+++ b/plugins/akasha/runtime.py
@@ -5,7 +5,8 @@ import asyncio
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from dataclasses import replace
-from uuid import uuid4
+import hashlib
+import json
 
 from agent.plugin_composition.bindings import Bindings
 from plugins.context.api import Materials
@@ -110,10 +111,51 @@ async def prepare_materials(
         return Materials("")
     members = set(projected[-1].message_ids)
     inputs = tuple(message for message in snapshot
-                   if message.message_id in members and isinstance(message.body, Input))
-    if not any(learning.text(message).strip() for message in inputs):
-        return Materials("")
-    # 2. 空间身份必须在嵌入和写向量之前核对；历史向量只读取。
+                   if message.message_id in members and isinstance(message.body, Input)
+                   and message.author == "user")
+    material = Materials("")
+    if any(learning.text(message).strip() for message in inputs):
+        # 同一真实输入使用稳定身份；工具续步、Reminder 和重启只读原记录。
+        identity = "context:" + hashlib.sha256(json.dumps(
+            [session_id, source, inputs[-1].message_id], ensure_ascii=False,
+        ).encode()).hexdigest()
+        recall = records.read(identity)
+        if recall is None:
+            # 升级前的随机身份仍是实际查询证据；复用同一用户输入后的首次记录。
+            previous = next(((key, item) for key, item in reversed(records.list())
+                if isinstance(item.source, ContextSource)
+                and item.source.session_id == session_id and item.source.source == source
+                and inputs[-1].seq <= item.source.through_seq <= snapshot[-1].seq), None)
+            if previous is not None:
+                identity, recall = previous
+        if recall is not None:
+            async with bindings.open(recall.learning_binding, AKASHA_LEARNING) as (original, _):
+                material = render_materials(identity, recall, original, catalog, max_chars=recall.max_chars)
+        else:
+            material = await query_inputs(
+                inputs, snapshot, source, identity=identity, cycle=cycle, state=state,
+                catalog=catalog, embeddings=embeddings, learning_binding=learning_binding,
+                learning=learning, rule=rule, records=records, embed_batch=embed_batch,
+                limit=limit, max_chars=max_chars,
+            )
+    references = {ref.ref: ref for ref in material.references}
+    # 同一消息有多次真实查询时，当前工具结果的精确出处供后续 Citation 使用。
+    references.update((ref.ref, ref) for ref in tool_references(
+        snapshot, source, learning, bindings, records,
+    ))
+    return replace(material, references=tuple(references.values()))
+
+
+async def query_inputs(
+    inputs: tuple[Message, ...], snapshot: tuple[Message, ...], source: str, *, identity: str,
+    cycle: MemoryCycle, state: Consumption, catalog: MessageCatalog,
+    embeddings: MessageEmbeddings, learning_binding: str, learning: Learning,
+    rule: LearningConfig, records: RecallRecords,
+    embed_batch: Callable[[list[str]], Awaitable[list[list[float]]]], limit: int, max_chars: int,
+) -> Materials:
+    """真实用户输入首次准备时检索并保存结果，包括未命中。"""
+    session_id = snapshot[0].session_id
+    # 1. 空间身份必须在嵌入和写向量之前核对；历史向量只读取。
     vectors = embeddings.bind(learning.text)
     missing = [message for message in inputs if learning.text(message).strip()
                and vectors.read(message, model=rule.embedding_model, dimension=rule.dimension) is None]
@@ -125,23 +167,17 @@ async def prepare_materials(
             vectors.save(message, model=rule.embedding_model, embedding=value)
     text, dense = input_features(inputs, text=learning.text, embeddings=vectors,
                                  embedding_model=rule.embedding_model, dimension=rule.dimension)
-    # 3. 图读取移出事件循环；取消仍先排空，再释放 binding 与串行锁。
+    # 2. 图读取移出事件循环；取消仍先排空，再释放 binding 与串行锁。
     stamp = datetime.now(UTC)
     origin = ContextSource(session_id=session_id, source=source, through_seq=snapshot[-1].seq)
     recall = await run_memory_job(lambda: query_memory(
         cycle, state, learning_binding=learning_binding,
         text=text, dense=dense, stamp=stamp, source=origin, limit=limit,
     ))
-    identity = uuid4().hex
     material = render_materials(identity, recall, learning, catalog, max_chars=max_chars)
     recall = recall.model_copy(update={
         "max_chars": max_chars,
         "presented_message_ids": tuple(dict.fromkeys(ref.ref for ref in material.references)),
     })
     _ = records.save(identity, recall)
-    references = {ref.ref: ref for ref in material.references}
-    # 同一消息有多次真实查询时，当前工具结果的精确出处供后续 Citation 使用。
-    references.update((ref.ref, ref) for ref in tool_references(
-        snapshot, source, learning, bindings, records,
-    ))
-    return replace(material, references=tuple(references.values()))
+    return material

--- a/plugins/computer/skills/computer/SKILL.md
+++ b/plugins/computer/skills/computer/SKILL.md
@@ -13,6 +13,10 @@ skill, connector, API, or CLI when available. Respect an explicit user request t
 
 Use the `computer` tool for browser and desktop work. It runs JavaScript inside the existing Computer
 container, using its logged-in Chromium profile. `browser`, `agent`, `sky`, and `nodeRepl` are ready.
+If the tool is not visible, call `tool_search` with `{"query":"select:computer"}`.
+Omit `allowed_risk`: Computer is marked `external-side-effect` because it can operate UI,
+even when this call only reads a page. Its exact tool name is `computer`.
+
 Bindings persist within this Akashic Session; a timeout, error, reset, or workload restart invalidates them.
 
 ```js

--- a/plugins/tool_search/plugin.py
+++ b/plugins/tool_search/plugin.py
@@ -25,7 +25,9 @@ class Query(BaseModel):
     model_config = ConfigDict(extra="forbid", strict=True)
     query: str = Field(min_length=1)
     top_k: int = Field(default=5, ge=1, le=10)
-    allowed_risk: list[Literal["read-only", "read-write", "external-side-effect"]] | None = None
+    allowed_risk: list[Literal["read-only", "read-write", "external-side-effect"]] | None = Field(
+        default=None, description="按工具整体能力过滤，通常省略。浏览器等通用工具即使只读页面也可能标为 external-side-effect；此字段不是本次操作的授权。",
+    )
 
 
 def search(candidates: Mapping[str, Mapping[str, object]], query: Query) -> tuple[str, ...]:
@@ -87,9 +89,19 @@ class SearchTool:
         query = Query.model_validate(json_value(arguments))
         selected = search(self._candidates, query)
         rows = [self._candidates[name] for name in selected]
+        excluded = []
+        if query.allowed_risk is not None:
+            unrestricted = query.model_copy(update={"allowed_risk": None})
+            excluded = [
+                {"name": name, "risk": self._candidates[name]["tool"]["risk"]}
+                for name in search(self._candidates, unrestricted)
+                if self._candidates[name]["tool"]["risk"] not in query.allowed_risk
+            ]
         text = json.dumps({
             "matched": [json_value(row["tool"]) for row in rows],
             "selected": selected,
+            "excluded_by_risk": excluded,
+            "risk_tip": "部分匹配工具被 allowed_risk 排除。若符合任务需要，省略该过滤重搜；执行仍须通过当前授权。" if excluded else "",
             "tip": "菜单按容量载入选中工具，优先保留最相关项；载入后可直接调用。" if selected else "没有匹配工具，请调整关键词或用 select:工具名。",
         }, ensure_ascii=False)
         return Result("success", (

--- a/tests/test_akasha_message_queries.py
+++ b/tests/test_akasha_message_queries.py
@@ -53,7 +53,7 @@ async def memory_runtime(tmp_path, *, max_chars=12000):
             parts = (ContentPart("text", text),)
             if kind is Input:
                 return log.writer(
-                    "s", author="test", source=source, body_types=(Input,),
+                    "s", author="user", source=source, body_types=(Input,),
                     content={"text": lambda part: ContentReferences()},
                 ).append(identity, Input(parts))
             return log.writer(
@@ -215,3 +215,45 @@ async def test_budget_records_exact_presented_members_without_losing_learning_me
         assert [hit.message_ids for hit in record.hits] == [("u2", "a2"), ("u1", "a1")]
         assert record.presented_message_ids == tuple(ref.ref for ref in material.references)
         assert record.presented_message_ids == ("u2",)
+
+
+@pytest.mark.asyncio
+async def test_real_input_recall_is_reused_after_continuation_reminder_and_restart(tmp_path, monkeypatch):
+    async with memory_runtime(tmp_path) as (runtime, consumer, log, records, calls, write):
+        write("old-u", "remember this")
+        write("old-a", "original answer", Output)
+        await runtime.consume()
+        write("q", "remember")
+        original = await runtime.prepare(log.reader("s").snapshot(), "chat")
+        saved = records.list()
+        count = len(calls)
+        log.writer("s", author="assistant", source="chat", body_types=(Output,), content={}).append(
+            "continue", Output((), "continue"))
+        log.writer("s", author="system", source="chat", body_types=(Input,),
+                   content={"text": lambda part: ContentReferences()}).append(
+            "reminder", Input((ContentPart("text", "system reminder must not query"),)))
+        # 新 runtime 对象只从持久记录恢复，不依赖内存缓存。
+        restored = MessageMemory(consumer, catalog=log.catalog(), embeddings=runtime._embeddings,
+            bindings=runtime._bindings, learning_binding=runtime._learning_binding,
+            records=RecallRecords(log.owner("plugin:akasha")), embed_batch=runtime._embed_batch)
+        def no_retrieve(*args, **kwargs):
+            raise AssertionError("same user input queried the graph again")
+        with monkeypatch.context() as patch:
+            patch.setattr(consumer.cycle, "retrieve", no_retrieve)
+            assert await restored.prepare(log.reader("s").snapshot(), "chat") == original
+        assert records.list() == saved and len(calls) == count
+        write("q2", "new user correction")
+        await runtime.prepare(log.reader("s").snapshot(), "chat")
+        assert len(records.list()) == len(saved) + 1
+        assert calls[-1] == ["new user correction"]
+
+
+@pytest.mark.asyncio
+async def test_background_input_never_triggers_automatic_recall(tmp_path):
+    async with memory_runtime(tmp_path) as (runtime, consumer, log, records, calls, write):
+        log.writer("s", author="system", source="chat", body_types=(Input,),
+                   content={"text": lambda part: ContentReferences()}).append(
+            "reminder", Input((ContentPart("text", "background task"),)))
+        material = await runtime.prepare(log.reader("s").snapshot(), "chat")
+        assert material.references == material.reminders == ()
+        assert calls == [] and records.list() == ()

--- a/tests/test_tool_discovery.py
+++ b/tests/test_tool_discovery.py
@@ -447,3 +447,22 @@ async def test_fixed_menu_uses_original_directory_after_targets_are_uninstalled(
     finally:
         await host.terminate_all()
         log.close()
+
+
+@pytest.mark.asyncio
+async def test_risk_filtered_computer_reports_why_and_exact_name_can_be_selected():
+    import json
+    from plugins.tool_search.plugin import SearchTool
+    tool = SearchTool({"computer": {"binding_id": "computer-binding", "tool": {
+        "name": "computer", "risk": "external-side-effect", "search_hint": None,
+        "description": "Read or operate browser and desktop UI",
+    }}})
+    filtered = await tool.invoke("filtered", await tool.prepare({
+        "query": "computer browser", "allowed_risk": ["read-only", "read-write"],
+    }))
+    payload = json.loads(filtered.parts[0].value)
+    assert payload["selected"] == []
+    assert payload["excluded_by_risk"] == [{"name": "computer", "risk": "external-side-effect"}]
+    assert filtered.parts[-1].value == ()
+    selected = await tool.invoke("exact", await tool.prepare({"query": "select:computer"}))
+    assert selected.parts[-1].value == ("computer-binding",)


### PR DESCRIPTION
工具续步重复准备上下文时，Akasha 原先每次都检索并新增记录；现在仅真实用户 Input 触发自动召回，同一输入复用已保存结果，后台输入不触发。主动 recall 保持独立且幂等。卡片刷新保留已有内容，重复命中的回忆只展示一次。

线上 Computer 已在工具目录中，实际搜索因 allowed_risk 排除 external-side-effect 而未命中。现在结果明确列出被过滤的工具和原因，Computer 技能给出 select:computer 的准确调用方式。

## Change intent
- change_type: fix；semantic_delta: compatible；capability_owner: plugin；consumer_scope: conversation and shared WebUI。
- runtime_patch: none；权威 owner: MessageLog 与 Akasha RecallRecords。客户端无法阻止服务端重复检索。
- 受保护状态: 原消息、学习图、历史查询和工具执行授权；只追加新查询，不迁移或删除旧记录。
- 允许副作用: 用户授权的提交、合并、Core 更新和 Stable WebUI 发布。
- 回滚: 前一 Core 875628e6 与 Stable WebUI 发布备份，部署前保存并验证原生 SQLite 快照。

## 验证
- 24 项 Python targeted tests 通过：召回复用、后台输入、归档主动 recall、工具发现。
- 2 项 Web renderer 测试通过：加载提示、失败重试、命中去重。
- Chromium 320/412px：等待、思考、两次工具调用、最终历史只挂载一组召回卡片。
- git diff --check 通过。
- 用户明确要求不跑 CI 和 Gate；本次均跳过，不作已通过声明。无真机安装。

## 工作手册与审查
已更新 projectneed 的召回触发合同；无新增状态 owner，无 schema 迁移，完整 diff 已本地审查。