### PR TITLE
工具搜索优先匹配完整工具名 [skip ci]

### DIFF
--- a/plugins/tool_search/plugin.py
+++ b/plugins/tool_search/plugin.py
@@ -51,7 +51,7 @@ def search(candidates: Mapping[str, Mapping[str, object]], query: Query) -> tupl
     tokens.discard("")
 
     # 2. 相同公开描述得到相同排序，不为内置或 MCP 来源额外加分。
-    ranked: list[tuple[int, str]] = []
+    ranked: list[tuple[int, int, str]] = []
     for name, tool in allowed.items():
         parts = name.lower().split("_")
         hint = cast(str | None, tool["search_hint"]) or ""
@@ -69,8 +69,9 @@ def search(candidates: Mapping[str, Mapping[str, object]], query: Query) -> tupl
             if token in description:
                 score += 2
         if score:
-            ranked.append((-score, name))
-    return tuple(name for _, name in sorted(ranked)[:query.top_k])
+            # 查询明确写出完整工具名时，不能被长描述的模糊词频挤出结果。
+            ranked.append((-int(name.lower() in tokens), -score, name))
+    return tuple(name for _, _, name in sorted(ranked)[:query.top_k])
 
 
 class SearchTool:

--- a/tests/test_tool_discovery.py
+++ b/tests/test_tool_discovery.py
@@ -453,16 +453,24 @@ async def test_fixed_menu_uses_original_directory_after_targets_are_uninstalled(
 async def test_risk_filtered_computer_reports_why_and_exact_name_can_be_selected():
     import json
     from plugins.tool_search.plugin import SearchTool
-    tool = SearchTool({"computer": {"binding_id": "computer-binding", "tool": {
+    candidates = {f"unrelated_{number}": {"binding_id": f"other-{number}", "tool": {
+        "name": f"unrelated_{number}", "risk": "read-only", "search_hint": "打开网页读取 computer browser tab playwright",
+        "description": "打开网页读取 computer browser tab playwright",
+    }} for number in range(12)}
+    candidates["computer"] = {"binding_id": "computer-binding", "tool": {
         "name": "computer", "risk": "external-side-effect", "search_hint": None,
         "description": "Read or operate browser and desktop UI",
-    }}})
+    }}
+    tool = SearchTool(candidates)
+    mixed = {"query": "computer browser tab playwright 打开网页 读取", "top_k": 10}
+    ranked = await tool.invoke("mixed", await tool.prepare(mixed))
+    assert json.loads(ranked.parts[0].value)["selected"][0] == "computer"
     filtered = await tool.invoke("filtered", await tool.prepare({
-        "query": "computer browser", "allowed_risk": ["read-only", "read-write"],
+        **mixed, "allowed_risk": ["read-only", "read-write"],
     }))
     payload = json.loads(filtered.parts[0].value)
-    assert payload["selected"] == []
+    assert "computer" not in payload["selected"]
     assert payload["excluded_by_risk"] == [{"name": "computer", "risk": "external-side-effect"}]
-    assert filtered.parts[-1].value == ()
+    assert "computer-binding" not in filtered.parts[-1].value
     selected = await tool.invoke("exact", await tool.prepare({"query": "select:computer"}))
     assert selected.parts[-1].value == ("computer-binding",)


### PR DESCRIPTION
用线上真实目录回放 `computer browser tab playwright 打开网页 读取` 时，无关长描述累计的模糊分数挤掉了 Computer，也遮住了风险过滤提示。现在完整工具名出现在查询词中时优先排序，其余结果保留原排序规则。

- change_type: fix；semantic_delta: compatible；capability_owner: plugin；runtime_patch: none。
- 只改变发现排序，不改变目录、固定 binding、权限或工具执行。无 schema 或持久数据变更。
- 26 项工具发现和标准工具 targeted tests 通过；真实线上 candidates 回放证明不加风险过滤时 Computer 排第一，加过滤时明确说明 Computer 被排除。
- git diff --check 通过；完整 diff 已本地审查。
- 用户明确要求跳过 CI/Gate，本次未运行。恢复点为 PR #578 / 8b496820，部署沿用本次任务已完整验证的 pre-pr578 备份。
- 这是 PR #578 实机验证发现的同一 Computer 问题补充修复；无需新增工作手册条款。