### PR TITLE
按真实输入召回并允许纠正 Computer 脚本错误 [skip ci]

### DIFF
--- a/docs/projectneed.md
+++ b/docs/projectneed.md
@@ -537,7 +537,7 @@ session compaction ledger 的派生 checkpoint，不替代上述记忆状态；�
 
 Akasha 按固定版本的 Turn 投影取得全部 Input 与唯一完成 Output，且为每个参与的非空 user/assistant Message 使用已持久化的固定 embedding，建立一个学习样本。多条 Input 按固定版本的规范化文本连接和向量聚合规则处理；Control、未完成工具和失败开放段只按 Akasha 明确的来源规则处理，不从相邻角色推断归属。在线提交和离线 builder 必须共用相同 Message IDs、规范化文本、向量和 digest 规则。旧数据只能走名称明确的 legacy 兼容路径。
 
-自动召回只由真实用户 Input（`author=user`）触发；同一输入首次准备后保存并复用实际 Recall，工具续步、system reminder、重试和重启不得重复检索。同 Turn 收到新的真实用户输入可以重新召回。主动调用 `recall_memory` 独立触发检索，并按原调用身份复用结果；后台 Input 不触发自动召回。查询记录只追加，不因复用而改写或删除历史记录。
+自动召回只由真实用户 Input（`author=user`）触发；同一输入首次准备后保存并复用实际 Recall，工具续步、system reminder、重试和重启不得重复检索。新的真实用户输入只以该条输入构造召回 cue，不混入同 Turn 的旧输入；聊天卡片按对应输入展示其自动与主动查询。主动调用 `recall_memory` 独立触发检索，并按原调用身份复用结果；后台 Input 不触发自动召回。查询记录只追加，不因复用而改写或删除历史记录。
 
 ### MEM-011 历史投影按完整 Turn 和 token tail 保留
 

--- a/frontend/chat/src/message-timeline.test.mjs
+++ b/frontend/chat/src/message-timeline.test.mjs
@@ -234,3 +234,18 @@ test("internal model selection stays hidden while unknown plugin content remains
   assert.equal(isTimelinePartVisible({ kind: "model.selection", display: "unavailable" }), false);
   assert.equal(isTimelinePartVisible({ kind: "plugin.custom", display: "unavailable" }), true);
 });
+
+test("真实追加输入分开前后思考，system reminder 仍留在当前过程", () => {
+  const first = row(0, { kind: "input", parts: [text("first")] }, { author: "user" });
+  const step1 = row(1, { kind: "output", finish: "continue", parts: [text("step one")] });
+  const second = row(2, { kind: "input", parts: [text("correction")] }, { author: "user" });
+  const step2 = row(3, { kind: "output", finish: "continue", parts: [text("step two")] });
+  const reminder = row(4, { kind: "input", parts: [text("reminder")] }, { author: "system" });
+  const answer = row(5, { kind: "output", finish: "complete", parts: [text("answer")] });
+  const messages = [first, step1, second, step2, reminder, answer];
+  const groups = timelineReplyGroups(messages);
+  assert.deepEqual(groups.completed.get(answer.id), [step2, answer]);
+  assert.equal(groups.moved.has(step1.id), false);
+  assert.equal(groups.hiddenBodies.has(step1.id), false);
+  assert.equal(timelineVisibleMessages(messages, groups).includes(step1), true);
+});

--- a/frontend/chat/src/message-timeline.ts
+++ b/frontend/chat/src/message-timeline.ts
@@ -313,15 +313,17 @@ export function timelineReplyGroups(messages: TimelineMessage[], activities: Rep
         if (members.length > 1) completed.set(message.id, members);
         pending.delete(key);
       }
-    } else if (body.kind === "control" && body.action !== "resume") {
+    } else if ((body.kind === "input" && message.author === "user")
+      || (body.kind === "control" && body.action !== "resume")) {
+      const throughSeq = body.kind === "control" ? body.through_seq : message.seq - 1;
       const members = pending.get(key) ?? [];
-      const closed = members.filter((item) => item.seq <= body.through_seq);
+      const closed = members.filter((item) => item.seq <= throughSeq);
       const ending = closed.at(-1);
       if (ending) {
         hiddenBodies.delete(ending.id);
         if (closed.length > 1) completed.set(ending.id, closed);
       }
-      pending.set(key, members.filter((item) => item.seq > body.through_seq));
+      pending.set(key, members.filter((item) => item.seq > throughSeq));
     }
   }
   const active = new Map<string, TimelineMessage[]>();

--- a/frontend/plugins/akasha/src/mobile.js
+++ b/frontend/plugins/akasha/src/mobile.js
@@ -94,14 +94,25 @@ export function mount(host, context) {
 }
 
 /** 页面缓存只保留服务端确认不再变化的查询结果。 */
-function readRecall(context) {
-  return context.query("recall.turn", {
-    message_id: context.messageId, source: context.block?.source ?? "",
+async function readRecall(context) {
+  const query = (messageId, offset) => context.query("recall.turn", {
+    message_id: messageId, source: context.block?.source ?? "", ...(offset ? { offset } : {}),
   }, {
     // 旧 OTA Host 仍能正确查询；新 Host 才接管页面缓存，不向旧 Native 发送新枚举。
     cache: context.capabilities?.queryCacheModes?.includes("memory") ? "memory" : "none",
     transport: "https",
   });
+  const result = await query(context.messageId, 0);
+  const items = [...result.items];
+  let pending = result.pending;
+  let offset = result.next_offset;
+  while (offset != null) {
+    const page = await query(result.input_message_id, offset);
+    items.push(...page.items);
+    pending = page.pending;
+    offset = page.next_offset;
+  }
+  return { ...result, items, pending };
 }
 
 /** 预取只读一次，进行中的结果留给展开后的可见面板继续读取。 */

--- a/plugins/akasha/inspector.py
+++ b/plugins/akasha/inspector.py
@@ -1016,7 +1016,7 @@ class RecallInspector:
         self._read = read
         self._list = list_records
         self._catalog = catalog
-        self._turns: tuple[tuple[str, str, int], tuple[MessageTurn, ...]] | None = None
+        self._turns: tuple[tuple[str, str, int], tuple[MessageTurn, ...], tuple[tuple[str, int, bool], ...]] | None = None
 
     def recent(self, *, page: int = 1, page_size: int = 30, session_id: str = "") -> dict[str, object]:
         rows = tuple((identity, recall) for identity, recall in self._list()
@@ -1027,8 +1027,8 @@ class RecallInspector:
                                     "total": len(rows), "page": page, "page_size": page_size})
 
     def for_turn(self, session_id: str, message_id: str, source: str,
-                 projection: TurnProjection) -> dict[str, object]:
-        """按既有 Turn 区间展示真实检索，不把查询记录解释为模型使用证明。"""
+                 projection: TurnProjection, *, offset: int = 0) -> dict[str, object]:
+        """按真实用户输入展示首次自动召回和主动查询，并分批返回完整记录。"""
         # 1. 已提交消息从日志取得来源；草稿只能读取该来源仍未闭合的 Turn。
         reader = self._catalog.reader(session_id)
         message = reader.get(message_id)
@@ -1047,7 +1047,9 @@ class RecallInspector:
                 page = reader.read(after_seq=cursor, through_seq=source_head, source=source)
                 messages.extend(page)
                 cursor = page[-1].seq
-            cached = (key, projection.project(messages, source))
+            cached = (key, projection.project(messages, source),
+                      tuple((item.message_id, item.seq, isinstance(item.body, Input) and item.author == "user")
+                            for item in messages))
             self._turns = cached
         turns = cached[1]
         turn = next((item for item in turns if message_id in item.message_ids), None)
@@ -1055,25 +1057,57 @@ class RecallInspector:
             turn = next((item for item in reversed(turns) if item.status == "open"), None)
         if turn is None:
             return {"items": [], "pending": message is None}
-        # 2. 查询的上下文上界或工具引用必须属于同一来源的这个区间。
+        # 2. 回复归属它之前最近的真实输入；下一条输入划开同 Turn 的卡片。
+        member_ids = set(turn.message_ids)
+        inputs = [(identity, seq) for identity, seq, user_input in cached[2]
+                  if identity in member_ids and user_input]
+        anchor_seq = message.seq if message is not None else source_head
+        target = next((item for item in reversed(inputs) if item[1] <= anchor_seq), None)
+        if target is None:
+            return {"items": [], "pending": False}
+        following = next((item for item in inputs if item[1] > target[1]), None)
         through_seq = reader.head() if turn.status == "open" else turn.through_seq
         if turn.status in {"complete", "quiet"}:
             through_seq -= 1
+        if following is not None:
+            through_seq = following[1] - 1
+        call_ids = {identity for identity, seq, _ in cached[2]
+                    if identity in member_ids and target[1] <= seq <= through_seq}
         identities: list[str] = []
+        automatic_found = False
         for identity, recall in reversed(self._list()):
             origin = recall.source
             if isinstance(origin, ContextSource):
-                matches = (origin.session_id == session_id and origin.source == source
-                           and turn.after_seq < origin.through_seq <= through_seq)
+                matches = (not automatic_found and origin.session_id == session_id
+                           and origin.source == source and target[1] <= origin.through_seq <= through_seq)
+                automatic_found = automatic_found or matches
             elif isinstance(origin, ToolSource):
-                matches = (origin.session_id == session_id
-                           and origin.call_ref.message_id in turn.message_ids)
+                matches = (origin.session_id == session_id and origin.call_ref.message_id in call_ids)
             else:
                 matches = False
             if matches:
                 identities.append(identity)
-        return {"items": [self.mobile_detail(identity) for identity in identities],
-                "pending": turn.status == "open"}
+        # 3. 历史重复自动查询留在 Inspector；主动查询分页，不突破 RPC 字节边界。
+        items: list[dict[str, object]] = []
+        pending = turn.status == "open" and following is None
+        size = len(json.dumps({"items": [], "pending": pending,
+            "input_message_id": target[0], "next_offset": len(identities)},
+            ensure_ascii=False, separators=(",", ":")).encode()) + 4
+        for identity in identities[offset:]:
+            detail = self.mobile_detail(identity)
+            if detail is None:
+                raise ValueError(f"召回记录缺失: {identity}")
+            encoded_size = len(json.dumps(detail, ensure_ascii=False, separators=(",", ":")).encode())
+            if size + encoded_size > 192 * 1024:
+                if not items:
+                    raise MobileUiRpcInvalidRequest("本条检索出处过多，超出移动页面容量；查询记录仍完整保留")
+                break
+            items.append(detail)
+            size += encoded_size + 1
+        end = offset + len(items)
+        return {"items": items, "pending": pending,
+                "input_message_id": target[0],
+                "next_offset": end if end < len(identities) else None}
 
     @staticmethod
     def _summary(identity: str, recall: Recall) -> dict[str, object]:

--- a/plugins/akasha/message_plugin.py
+++ b/plugins/akasha/message_plugin.py
@@ -147,12 +147,15 @@ async def apply(ctx: Context, config: Config) -> None:
               turn_id: str | None) -> dict[str, object]:
         inspector = get_inspector()
         if method == "recall.turn":
-            if (not session_id or set(payload) != {"message_id", "source"}
+            offset = payload.get("offset", 0)
+            if (not session_id or set(payload) - {"message_id", "source", "offset"}
+                or not {"message_id", "source"} <= set(payload)
+                or not isinstance(offset, int) or isinstance(offset, bool) or offset < 0
                 or not isinstance(payload["message_id"], str) or not payload["message_id"]
                 or not isinstance(payload["source"], str)):
                 raise MobileUiRpcInvalidRequest("检索卡片缺少消息或会话")
             return inspector.for_turn(session_id, payload["message_id"], payload["source"],
-                                      ctx.require(TURN_PROJECTION))
+                                      ctx.require(TURN_PROJECTION), offset=offset)
         if method == "inspector.recent":
             try:
                 page = InspectorPage.model_validate(payload)

--- a/plugins/akasha/runtime.py
+++ b/plugins/akasha/runtime.py
@@ -112,7 +112,7 @@ async def prepare_materials(
     members = set(projected[-1].message_ids)
     inputs = tuple(message for message in snapshot
                    if message.message_id in members and isinstance(message.body, Input)
-                   and message.author == "user")
+                   and message.author == "user")[-1:]
     material = Materials("")
     if any(learning.text(message).strip() for message in inputs):
         # 同一真实输入使用稳定身份；工具续步、Reminder 和重启只读原记录。

--- a/plugins/computer/control.py
+++ b/plugins/computer/control.py
@@ -9,6 +9,10 @@ from collections.abc import Mapping
 from pathlib import Path
 
 
+class ComputerDriverError(RuntimeError):
+    """驱动已返回失败，调用方可读取错误并纠正下一次操作。"""
+
+
 def endpoint_name(data_root: Path, generation_id: str) -> str:
     """按数据目录和实际 MCP generation 路由控制 socket。"""
     if not isinstance(generation_id, str) or not generation_id:
@@ -54,6 +58,8 @@ async def request(name: str, payload: Mapping[str, object]) -> dict[str, object]
         if not isinstance(value, dict):
             raise TypeError("Computer control returned an invalid response")
         if "error" in value:
+            if value.get("kind") == "driver_error":
+                raise ComputerDriverError(str(value["error"]))
             raise RuntimeError(str(value["error"]))
         return value
     finally:

--- a/plugins/computer/mcp_server.py
+++ b/plugins/computer/mcp_server.py
@@ -144,6 +144,10 @@ def driver_content(value: dict[str, Any]) -> dict[str, object]:
     return {"content": content, "call_id": value["call_id"]}
 
 
+class DriverResponseError(RuntimeError):
+    """HTTP 驱动已返回明确的失败响应。"""
+
+
 async def control_connection(
     reader: asyncio.StreamReader, writer: asyncio.StreamWriter
 ) -> None:
@@ -168,7 +172,7 @@ async def control_connection(
             async def send(path, body):
                 response = await client.post(path, json=body)
                 if response.status_code >= 400:
-                    raise RuntimeError(
+                    raise DriverResponseError(
                         f"Computer returned {response.status_code}: {response.text[:16000]}"
                     )
                 if len(response.content) > 8 * 1024 * 1024:
@@ -217,7 +221,10 @@ async def control_connection(
         httpx.HTTPError,
     ) as error:
         if not writer.is_closing():
-            writer.write(json.dumps({"error": str(error)}).encode() + b"\n")
+            writer.write(json.dumps({
+                "error": str(error),
+                "kind": "driver_error" if isinstance(error, DriverResponseError) else "control_error",
+            }).encode() + b"\n")
             try:
                 await writer.drain()
             except (ConnectionError, BrokenPipeError):

--- a/plugins/computer/plugin.py
+++ b/plugins/computer/plugin.py
@@ -29,7 +29,7 @@ from plugins.turn_projection.plugin import TURN_PROJECTION, TurnProjection
 from session.log import MessageCatalog, OwnerRecord, OwnerStore
 from session.message import ContentPart, Input, Message, Output, ToolCall
 
-from .control import endpoint_name, request
+from .control import ComputerDriverError, endpoint_name, request
 
 COMPUTER_CONTROL = ServiceKey["ComputerControl"]("computer.control.v1")
 
@@ -73,16 +73,19 @@ class ComputerControl:
         elif existing.value != value:
             raise ValueError("Computer 调用回执身份不一致")
         async with self.ctx.require(MCP_SERVERS).open(self.ctx, "computer") as server:
-            return await request(
-                endpoint_name(self.ctx.data_root, server.generation_id),
-                {
-                    "op": "run",
-                    "context": _driver_context(server.generation_id, identity, key),
-                    "code": arguments["code"],
-                    "timeoutMs": arguments.get("timeout_ms", 60000),
-                    "reset": arguments.get("reset", False),
-                },
-            )
+            try:
+                return await request(
+                    endpoint_name(self.ctx.data_root, server.generation_id),
+                    {
+                        "op": "run",
+                        "context": _driver_context(server.generation_id, identity, key),
+                        "code": arguments["code"],
+                        "timeoutMs": arguments.get("timeout_ms", 60000),
+                        "reset": arguments.get("reset", False),
+                    },
+                )
+            except ComputerDriverError as error:
+                return {"kind": "driver_error", "error": str(error)}
 
     async def end_turn(self, identity: ComputerCall, call_id: str) -> None:
         """通过同一归档 MCP 关闭已结算 Turn。"""
@@ -203,6 +206,8 @@ class _ComputerTool:
 
     async def invoke(self, key: str, arguments: Mapping[str, object]) -> Result:
         value = await self._control.run(key, self._control_binding, arguments)
+        if value.get("kind") == "driver_error":
+            return Result("error", (ContentPart("text", cast(str, value["error"])),))
         return Result("success", (ContentPart("text", json.dumps(value, ensure_ascii=False)),))
 
     async def query(self, key: str) -> Result | None:

--- a/plugins/computer/skills/computer/SKILL.md
+++ b/plugins/computer/skills/computer/SKILL.md
@@ -18,6 +18,26 @@ Omit `allowed_risk`: Computer is marked `external-side-effect` because it can op
 even when this call only reads a page. Its exact tool name is `computer`.
 
 Bindings persist within this Akashic Session; a timeout, error, reset, or workload restart invalidates them.
+After a tool error, read the error and API, then re-list tabs and acquire fresh bindings.
+Earlier actions may have taken effect: inspect the current page before retrying an action.
+Correct an invalid method and continue; do not treat a script error as task completion.
+
+Before the first browser action, read the installed API in a separate call:
+
+```js
+nodeRepl.write(await browser.documentation());
+```
+
+Use only methods shown by that API. Create a tab with `await browser.tabs.new()`;
+`browser.tabs.create()` does not exist. For example:
+
+```js
+var tab = await browser.tabs.new();
+await tab.goto("about:blank");
+await tab.ax.write();
+```
+
+To inspect an existing tab:
 
 ```js
 var tabs = await browser.tabs.list();
@@ -26,7 +46,7 @@ var tab = await browser.tabs.get(tabs[0].id);
 await tab.ax.write();
 ```
 
-Read the API when needed: `nodeRepl.write(await browser.documentation())`. Read additional documents
+Read additional documents
 with `agent.documentation.get(name)` using names listed in that guidance. The bundled API is the reference Browser API; optional capabilities must be
 listed before use. macOS application AX and optional desktop audio are unavailable here.
 

--- a/scripts/mobile-web-lab/verify-recall-once.mjs
+++ b/scripts/mobile-web-lab/verify-recall-once.mjs
@@ -68,10 +68,28 @@ try {
       assert.equal(await page.locator(".akasha-mobile-recall-group").count(), 1, `${width}px phase ${index}`);
       if (index >= 2) assert.equal(await page.locator(".tool-step-title").filter({ hasText: "read" }).count() > 0, true);
     }
+    // 同 Turn 的真实追加输入分开两段过程，旧输入卡片仍可展开。
+    const correction = { ...structuredClone(input), author: "user", id: "correction-input", seq: 5 };
+    correction.body.parts = [{ kind: "text", value: "用户追加的新输入" }];
+    const corrected = structuredClone(base);
+    corrected.messages = [input, call, result, correction,
+      { ...second, seq: 6 }, { ...secondResult, seq: 7 }, { ...final, seq: 8 }];
+    corrected.throughSeq = 8;
+    corrected.projectionGeneration += 20;
+    corrected.history = { hasOlder: false, isLatest: true, loading: false };
+    corrected.replyStatus.items = [];
+    corrected.sessions[0].isRunning = false;
+    corrected.composer.isStreaming = false;
+    await page.evaluate(snapshot => window.AkashicMobile.receiveSnapshot(snapshot), corrected);
+    for (const button of await page.getByRole("button", { name: /已思考/ }).all()) {
+      if (await button.getAttribute("aria-expanded") !== "true") await button.click();
+    }
+    await page.waitForFunction(() => document.querySelectorAll(".akasha-mobile-recall-group").length === 2);
+    assert.equal(await page.locator(".akasha-mobile-recall-group").count(), 2);
     assert.deepEqual(errors, []);
     await page.close();
   }
-  console.log("Recall stays single through waiting, thinking, two tool calls and final history at 320/412px");
+  console.log("Recall stays single through tool steps and splits at a new real input at 320/412px");
 } finally {
   await browser.close();
   await lab.close();

--- a/tests/test_akasha_message_queries.py
+++ b/tests/test_akasha_message_queries.py
@@ -71,7 +71,7 @@ async def memory_runtime(tmp_path, *, max_chars=12000):
 
 
 @pytest.mark.asyncio
-async def test_context_query_uses_fixed_multimessage_input_and_published_references(tmp_path):
+async def test_context_query_uses_latest_real_input_and_published_references(tmp_path):
     async with memory_runtime(tmp_path) as (runtime, consumer, log, records, calls, write):
         write("old-u1", "first detail")
         write("old-u2", "important correction")
@@ -87,7 +87,7 @@ async def test_context_query_uses_fixed_multimessage_input_and_published_referen
         write("later", "later input must stay out")
         material = await runtime.prepare(snapshot, "chat")
         assert material.system_prompt == ""
-        assert calls[-1] == ["remember the detail", "and the correction"]
+        assert calls[-1] == ["and the correction"]
         assert [ref.ref for ref in material.references] == ["old-u1", "old-u2", "old-a"]
         assert isinstance(material.reminders[0].text, str)
         assert "learned answer" in material.reminders[0].text
@@ -104,8 +104,8 @@ async def test_context_query_uses_fixed_multimessage_input_and_published_referen
         assert await runtime.consume() == 1
         assert records.read(identity) == record
         assert consumer.cycle.state_version == 2
-        # 消费复用查询阶段固定的两个向量，只补后来输入与答案。
-        assert calls[-1] == ["later input must stay out", "new answer"]
+        # 学习仍保留全部输入，只补未用于本次查询的输入与答案向量。
+        assert calls[-1] == ["remember the detail", "later input must stay out", "new answer"]
     with closing(MessageLog(tmp_path / "sessions.db")) as restored:
         assert RecallRecords(restored.owner("plugin:akasha")).read(identity) == record
 

--- a/tests/test_akasha_message_ui.mjs
+++ b/tests/test_akasha_message_ui.mjs
@@ -49,6 +49,7 @@ test("chat recall mounts the old two lanes, escapes memory text and stops after 
   const dom = new JSDOM("<div id='host'></div>");
   const host = dom.window.document.getElementById("host");
   const calls = [];
+  globalThis.document = dom.window.document;
   const close = mountRecall(host, { messageId: "draft", block: { source: "conversation" },
     query: async (...args) => { calls.push(args); return { items: [detail], pending: false }; } });
   await new Promise((done) => setImmediate(done));
@@ -59,6 +60,26 @@ test("chat recall mounts the old two lanes, escapes memory text and stops after 
   assert.doesNotMatch(host.textContent, /conversation/);
   assert.deepEqual(calls[0], ["recall.turn", { message_id: "draft", source: "conversation" },
     { cache: "none", transport: "https" }]);
+  close();
+  dom.window.close();
+});
+
+test("recall pagination stays pinned to its input and leaves cached pages unchanged", async () => {
+  const dom = new JSDOM("<div id='host'></div>");
+  globalThis.document = dom.window.document;
+  const host = dom.window.document.getElementById("host");
+  const first = { items: [detail], pending: false, input_message_id: "user-input", next_offset: 1 };
+  const second = { items: [{ ...detail, hits: [{ ...detail.hits[0], messages: [
+    { message_id: "new", preview: "another memory" },
+  ] }] }], pending: false, next_offset: null };
+  const calls = [];
+  const close = mountRecall(host, { messageId: "output", block: { source: "conversation" },
+    query: async (method, payload) => { calls.push(payload); return payload.offset ? second : first; } });
+  await new Promise(done => setImmediate(done));
+  assert.deepEqual(calls, [{ message_id: "output", source: "conversation" },
+    { message_id: "user-input", source: "conversation", offset: 1 }]);
+  assert.match(host.textContent, /another memory/);
+  assert.equal(first.items.length, 1);
   close();
   dom.window.close();
 });

--- a/tests/test_akasha_recall_records.py
+++ b/tests/test_akasha_recall_records.py
@@ -298,3 +298,69 @@ def test_recall_turn_cache_tracks_source_head_and_keeps_global_query_head(tmp_pa
         inputs.append("new", Input((ContentPart("text", "next"),)))
         assert inspector.for_turn("s", "draft-next", "chat", projection)["pending"] is True
         assert projection.calls == 3
+
+
+def test_recall_cards_split_same_turn_inputs_and_page_explicit_queries(tmp_path):
+    import json
+    from contextlib import closing
+    from datetime import timedelta
+    from plugins.akasha.inspector import RecallInspector
+    from plugins.akasha.recalls import ToolSource
+    from plugins.turn_projection.plugin import TurnProjection
+    from session.message import CallRef, ToolCall, ToolResult
+
+    with closing(MessageLog(tmp_path / "sessions.db")) as log:
+        inputs = log.writer("s", author="user", source="chat", body_types=(Input,),
+                            content={"text": lambda part: ContentReferences()})
+        outputs = log.writer("s", author="assistant", source="chat", body_types=(Output,),
+                             content={"text": lambda part: ContentReferences()}, check_call=lambda call: None)
+        records = RecallRecords(log.owner("akasha"))
+        inputs.append("u1", Input((ContentPart("text", "first" * 48),)))
+        outputs.append("step1", Output((), "continue"))
+        inputs.append("u2", Input((ContentPart("text", "new question" * 20),)))
+        log.writer("s", author="system", source="chat", body_types=(Input,),
+                   content={"text": lambda part: ContentReferences()}).append(
+            "reminder", Input((ContentPart("text", "system reminder"),)))
+        log.save_binding("recall", {"artifact": "test-recall"})
+        calls = []
+        for number in range(8):
+            call = outputs.append(f"call-{number}", Output((ToolCall("recall", {}),), "continue"))
+            ref = CallRef(call.message_id, 0)
+            calls.append(ref)
+            log.writer("s", author="tool", source="chat", body_types=(ToolResult,),
+                       content={}, call_ref=ref).append(f"result-{number}", ToolResult(ref, "success", ()))
+        outputs.append("a", Output((ContentPart("text", "answer" * 40),), "complete"))
+        records.save("first", record(0))
+        records.save("second", record(2))
+        records.save("old-duplicate", record(3).model_copy(update={
+            "timestamp": record(0).timestamp + timedelta(seconds=1)}))
+        # 多个主动查询累计超过一次 RPC，仍须逐页读全。
+        hit = record(0).hits[0]
+        for number in range(8):
+            records.save(f"explicit-{number}", record(4).model_copy(update={
+                "source": ToolSource(session_id="s", call_ref=calls[number]),
+                "timestamp": record(0).timestamp + timedelta(seconds=number + 2),
+                "graph_version": 45,
+                "hits": tuple(hit.model_copy(update={"node_id": index}) for index in range(45)),
+            }))
+        before = log.reader("s").snapshot()
+        saved = records.list()
+        inspector = RecallInspector(read=records.read, list_records=records.list, catalog=log.catalog())
+        projection = TurnProjection()
+        assert len(projection.project(before, "chat")) == 1
+        first = inspector.for_turn("s", "step1", "chat", projection)
+        assert first["pending"] is False
+        assert [item["query_id"] for item in first["items"]] == ["first"]
+        page = inspector.for_turn("s", "a", "chat", projection)
+        assert page["input_message_id"] == "u2"
+        assert page["next_offset"] is not None
+        ids = []
+        while True:
+            assert len(json.dumps(page, ensure_ascii=False, separators=(",", ":")).encode()) < 192 * 1024
+            ids.extend(item["query_id"] for item in page["items"])
+            if page["next_offset"] is None:
+                break
+            page = inspector.for_turn("s", page["input_message_id"], "chat", projection,
+                                      offset=page["next_offset"])
+        assert ids == ["second", *(f"explicit-{number}" for number in range(8))]
+        assert records.list() == saved and log.reader("s").snapshot() == before

--- a/tests/test_computer_driver_plugin.py
+++ b/tests/test_computer_driver_plugin.py
@@ -533,6 +533,12 @@ def _start_test_gateway(
                 self.end_headers()
                 self.wfile.write(b"temporary end failure")
                 return
+            if body.get("code") == "browser.tabs.create()":
+                self.send_response(500)
+                self.send_header("content-type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": "TypeError: browser.tabs.create is not a function; earlier effects may remain; JS bindings for this session were reset"}).encode())
+                return
             if body.get("code") == "hold":
                 state.hold_release.wait(10)
                 state.events.append(("released", body))
@@ -735,8 +741,9 @@ async def test_computer_failure_retries_started_owner_after_restart_and_source_c
     try:
         state.fail_runs = 1
         reply = harness.add_call("failure", code="fail")
-        with pytest.raises(RuntimeError, match="503"):
-            await harness.execute(reply)
+        result = await harness.execute(reply)
+        assert result.outcome == "error"
+        assert "503" in result.parts[0].value
         assert harness.owner(reply).value["phase"] == "started"
         state.fail_ends = 1
         harness.finish(reply, "complete")
@@ -858,3 +865,28 @@ async def test_computer_failure_retries_started_owner_after_restart_and_source_c
         if new_gateway is not None:
             new_gateway.shutdown()
             new_gateway.server_close()
+
+
+@pytest.mark.asyncio
+async def test_computer_script_error_is_durable_and_next_call_can_continue(tmp_path: Path) -> None:
+    harness = await _computer_harness(tmp_path)
+    try:
+        reply = harness.add_call("script-error", code="browser.tabs.create()")
+        result = await harness.execute(reply)
+        assert result.outcome == "error"
+        assert "browser.tabs.create is not a function" in result.parts[0].value
+        assert "earlier effects may remain" in result.parts[0].value
+        assert "JS bindings for this session were reset" in result.parts[0].value
+        calls = len(harness.gateway_state.calls)
+        assert await harness.execute(reply) == result
+        assert len(harness.gateway_state.calls) == calls
+        output = harness._writer(reply.reader.session_id, "assistant", (Output,)).append(
+            "corrected-call", Output((ToolCall(harness.binding, {"code": "browser.tabs.new()"}),), "continue"))
+        ref = CallRef(output.message_id, 0)
+        following = MessageReply("corrected-result", ref, reply.reader,
+            harness._writer(reply.reader.session_id, "tool", (ToolResult,), call_ref=ref), lambda: None)
+        assert (await harness.execute(following)).outcome == "success"
+        assert len(harness.gateway_state.calls) == calls + 1
+        harness.finish(following, "complete")
+    finally:
+        await harness.close()


### PR DESCRIPTION
## 问题与结果

同一 Turn 追加输入后，自动召回仍混合此前输入，聊天卡片也汇集整段 Turn 的历史查询，可能超过 192 KiB RPC 上限。现在只以最新真实用户输入构造 cue，卡片按输入分组，只读首次自动查询及该输入后的主动查询；主动查询逐页读取，历史记录保持完整。

Computer 的 HTTP 脚本失败原先抛出到执行循环，错误正文未交给模型。现在由 Computer 控制边界区分驱动失败和内部错误，明确的驱动失败保存为 error ToolResult，下一次调用可继续纠正；skill 要求先读已安装 API，使用 browser.tabs.new，并在错误后重新检查绑定与页面状态。

## Change intent

- change_type: fix；semantic_delta: compatible。
- capability_owner: plugin / WebUI；consumer_scope: Akasha、Computer、Web/Mobile 共享聊天。
- runtime_patch: none；Core 的异常、取消和持久日志语义不变。
- authoritative_state_owner: Session MessageLog、Akasha RecallRecords、Computer effect owner。
- client_only_alternative: 无；cue 和 Computer 错误结算必须由插件修复，卡片分组由共享 WebUI 负责。
- protected_state: 全部历史消息、召回、学习图、浏览器登录状态；没有迁移或删除。
- 允许副作用: 未来召回、工具结果及正常正式发布；禁止改写旧消息、召回和插件 cache。
- 关联不变量: MEM-010、CTX-001、插件 generation 和工具结算边界。

## 验证

- Akasha 定向 Python：17 passed。
- Computer 定向 Python：7 passed，1 个需指定真实网关的旧测试未运行；另以正式镜像 digest 9bd4f6e… 的一次性容器实际复现 tabs.create 500 → tabs.new 成功 → endTurn，未接触正式 profile。
- 共享 timeline 与 Akasha UI：23 passed。
- 真实 Chromium Mobile Lab：320px / 412px，等待、思考、两次工具续步、完成历史只出现一组卡片；同 Turn 追加真实输入分成两组。
- npm typecheck、相关 Python 模块类型检查、skill 校验、git diff --check 通过。
- mcp_server.py 存在基线已有的 screenshot_result 返回 object 类型错误（原文件第 138 行）；已用 f954e1fc 的原文件复核，本次未修改该路径。
- 用户明确要求不跑 CI 和 Gate，均跳过，包括独立概念 Gate。

## 正交性、文档和恢复

- 自动召回以真实输入为单位；学习样本仍按完整 Turn，主动 recall 仍按调用身份。
- 页面缓存仅保存来源引用和已完成查询，分页不修改缓存对象；旧 recall.turn 方法名保留供已有页面调用。
- Computer 将驱动错误转换为可持久化值后跨归档 binding 传递；传输失败、内部契约错误、取消和 endTurn 失败仍明确传播。
- 已核对 INDEX、WORKFLOW、projectneed、NOW 和持久化状态地图；MEM-010 已补充输入 cue 与卡片边界，NOW 无对应完成项。
- 代码恢复点：main@f954e1fc，源码完整备份 /tmp/input-recall-computer-errors-20260909-backup/source-f954e1fc.tar。
- 部署前恢复点：/srv/data/services/akashic/backups/pre-input-recall-20260909T1350；原生 SQLite 导出、Borg check、提取和 62 个文件 checksum 已通过。