### PR TITLE
避免主循环停顿误报 Workload 健康失败 [skip ci]

### DIFF
--- a/agent/plugins/workload_generation_host.py
+++ b/agent/plugins/workload_generation_host.py
@@ -554,21 +554,27 @@ def _check_stop_receipt(
 
 
 async def _http_health(url: str, timeout_seconds: float) -> tuple[bool, str]:
+    """在工作线程中探测，避免主循环停顿被误判为网络超时。"""
     deadline = asyncio.get_running_loop().time() + timeout_seconds
     last = "health deadline exceeded"
-    async with httpx.AsyncClient() as client:
-        while True:
-            try:
-                response = await client.get(url, timeout=min(2.0, timeout_seconds))
-                if 200 <= response.status_code < 300:
-                    return True, f"HTTP {response.status_code}"
-                last = f"HTTP {response.status_code}"
-            except httpx.HTTPError as error:
-                last = _error_text(error)
-            remaining = deadline - asyncio.get_running_loop().time()
-            if remaining <= 0:
-                return False, last
-            await asyncio.sleep(min(0.2, remaining))
+    while True:
+        try:
+            status = await asyncio.to_thread(_health_status, url, min(2.0, timeout_seconds))
+            if 200 <= status < 300:
+                return True, f"HTTP {status}"
+            last = f"HTTP {status}"
+        except httpx.HTTPError as error:
+            last = _error_text(error)
+        remaining = deadline - asyncio.get_running_loop().time()
+        if remaining <= 0:
+            return False, last
+        await asyncio.sleep(min(0.2, remaining))
+
+
+def _health_status(url: str, timeout_seconds: float) -> int:
+    # 客户端只由本次请求持有；取消等待后，线程仍能关闭自己的连接。
+    with httpx.Client() as client:
+        return client.get(url, timeout=timeout_seconds).status_code
 
 
 async def _await_task_after_cancellation(task: asyncio.Task[Any]) -> Any:

--- a/tests/test_workload_borrow.py
+++ b/tests/test_workload_borrow.py
@@ -1,5 +1,8 @@
 import asyncio
 from dataclasses import replace
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
+import time
 
 import pytest
 import pytest_asyncio
@@ -14,7 +17,7 @@ from agent.plugin_composition.workload_slots import (
     WorkloadPort,
     _WorkloadDeclarations,
 )
-from agent.plugins.workload_generation_host import WorkloadGenerationHost
+from agent.plugins.workload_generation_host import WorkloadGenerationHost, _http_health
 from agent.workloads.model import (
     WorkloadEndpoint,
     WorkloadLease,
@@ -54,6 +57,33 @@ class Controller:
     async def cleanup_candidates(self, workspace_id: str) -> tuple[WorkloadStopReceipt, ...]:
         _ = workspace_id
         return ()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [200, 503])
+async def test_health_probe_does_not_mistake_busy_loop_for_unhealthy_workload(status):
+    """主循环停顿时，按健康接口的真实结果判定。"""
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(status)
+            self.end_headers()
+
+        def log_message(self, *_args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    worker = Thread(target=server.serve_forever, daemon=True)
+    worker.start()
+    # 故意让主循环停顿超过探测预算，重现启动和同步插件代码造成的延迟。
+    pause = asyncio.get_running_loop().call_later(0.001, time.sleep, 0.2)
+    try:
+        result = await _http_health(f"http://localhost:{server.server_port}/health", 0.05)
+        assert result == (status == 200, f"HTTP {status}")
+    finally:
+        pause.cancel()
+        await asyncio.to_thread(server.shutdown)
+        server.server_close()
+        worker.join()
 
 
 @pytest_asyncio.fixture(loop_scope="session")


### PR DESCRIPTION
## 问题与结果

Computer 容器健康接口正常时，Core 主循环的同步任务仍可能让异步 HTTP 探测触发 ConnectTimeout。正式环境因此把 Computer 标为 degraded，后续工具调用报“没有唯一且就绪的相同 Workload”。

每次 HTTP 探测改为在线程中执行有超时限制的请求，让网络结果不受主循环停顿影响。HTTP 失败仍按原有预算重试和报告。

## Change intent

- change_type: fix；semantic_delta: compatible。
- capability_owner: core；consumer_scope: Workload 健康探测；runtime_patch: required，客户端无法修复资源 owner 的健康误判。
- authoritative_state_owner: WorkloadGenerationHost；保留原来的就绪、故障和恢复协议。
- protected_state: 历史 Message、工具回执、插件数据和浏览器 profile；无数据库或配置迁移。
- 允许副作用：相同健康 URL 的只读请求、按既有发布流程切换服务；禁止重新执行旧业务工具调用。
- concept_gate: not_applicable；这是局部 HTTP 探测修复，不增加领域概念或更改生命周期。

## 改动范围与恢复

仅修改 agent/plugins/workload_generation_host.py 和现有 tests/test_workload_borrow.py。每次请求自己持有并关闭 HTTP 客户端；取消等待不转移连接所有权。源代码恢复点 /tmp/workload-health-source-7ae094a5.tar；可回退到 7ae094a5b60b0594b608066cfee2424d8b2ac83f。

## 验证

- 新回归先在旧实现失败：健康 HTTP 200 被报告为 ConnectTimeout。
- tests/test_workload_borrow.py + tests/test_computer_driver_plugin.py：11 passed，1 skipped（需显式容器 oracle 的既有测试）。随后增加 HTTP 503 参数并验证两种状态：2 passed。
- 额外真实 HTTP 对照：四种主循环阻塞时序，旧实现四次 ConnectTimeout，新实现均 HTTP 200。
- pyright：0 errors，16 个既有警告；git diff --check 通过。
- 按本次任务已明确指示，不运行 CI 和 Gate；sourceDigest/planDigest 不适用。
- 正式容器、原 session 的 Computer 调用和聊天记录读取将在部署后继续验收，当前尚未声称完成。

## 工作手册与评审

已核对工作手册和完整两文件 diff；没有长期产品语义变化，没有 NOW 对应待办。无架构性变化、schema lineage 变化或跨客户端协议变化。正常链路为健康 URL → HTTP 状态 → 原健康 owner；失败链路保留具体网络/HTTP 错误。