### PR TITLE
修复 Computer Chromium 的 QUIC 连接失败 [skip ci]

### DIFF
--- a/.github/workflows/computer-image.yml
+++ b/.github/workflows/computer-image.yml
@@ -1,6 +1,7 @@
 name: Computer image
 
 on:
+  workflow_dispatch:
   push:
     paths:
       - docker/computer/**

--- a/docker/computer/start.sh
+++ b/docker/computer/start.sh
@@ -87,6 +87,7 @@ chromium \
   --test-type \
   --disable-dev-shm-usage \
   --disable-gpu \
+  --disable-quic \
   --hide-crash-restore-bubble \
   --no-first-run \
   --no-default-browser-check \


### PR DESCRIPTION
## 问题与结果

正式 Computer Chromium 打开 ChatGPT 分享页时出现 ERR_CONNECTION_CLOSED，Page.navigate 和后续页面读取超时。同容器的 HTTP 请求正常；独立临时 Chromium 对照中，默认连接 30 秒超时，添加 --disable-quic 后成功渲染分享页（标题「字节SP薪资估算」，约 3.17 MB DOM）。

为 Chromium 固定 --disable-quic，使用 TCP 上的 HTTPS。专用 Computer image workflow 增加手动触发入口，用于单独构建发布镜像；镜像 digest 随后通过插件声明固定。

## Change intent 与保护范围

- change_type: fix；semantic_delta: compatible；capability_owner: plugin；consumer_scope: Computer Chromium 网络访问。
- runtime_patch: required，浏览器启动参数由 Computer 镜像拥有，客户端不能替代。
- authoritative_state_owner: 原 Workload 和浏览器 profile；没有数据库、凭据、权限、插件生命周期或数据路径变化。
- 允许副作用：镜像发布和按既有流程切换 Computer；不改动历史 Message、登录状态或用户标签页。
- concept_gate: not_applicable，两个局部声明变更，没有新抽象。

## 验证与恢复

- sh -n docker/computer/start.sh、git diff --check 通过。
- 从干净源码 de81fedac7253e98fd20bc9e02138d80c6bfa5c9 构建的本地镜像成功。
- 正式环境同网络下，默认 Chromium 与关闭 QUIC 的临时 Chromium 已完成独立 profile 对照。
- 仅运行专用镜像构建发布，按当前任务要求不运行 CI 测试/Gate。正式 agent 读取聊天正文仍待发布后验收。
- 源码恢复点 /tmp/computer-quic-source-0ddf0e73.tar；当前正式镜像 digest 保持原值，后续 pin 单独提交。
- 无需工作手册或 schema 更新，没有对应 NOW 待办。