### PR TITLE
固定已修复 QUIC 的 Computer 镜像 [skip ci]

### DIFF
--- a/plugins/computer/akashic.plugin.toml
+++ b/plugins/computer/akashic.plugin.toml
@@ -16,7 +16,7 @@ exclude_data_paths = [
 
 [[workload]]
 name = "computer"
-image = "ghcr.io/kachofugetsu09/akashic-computer@sha256:9bd4f6e215b4848e91f0dbfea75a7b227faeba96268c422d62e81a9b64d5ac92"
+image = "ghcr.io/kachofugetsu09/akashic-computer@sha256:4a4381b211024ac1fbf3730bd835a8cfa6cd7dd36996bf018437c13796ef0894"
 command = ["/opt/computer/start.sh"]
 user_namespaces = true
 

--- a/plugins/computer/plugin.py
+++ b/plugins/computer/plugin.py
@@ -160,7 +160,7 @@ web_contract_digests = {
 
 _IMAGE = (
     "ghcr.io/kachofugetsu09/akashic-computer@"
-    "sha256:9bd4f6e215b4848e91f0dbfea75a7b227faeba96268c422d62e81a9b64d5ac92"
+    "sha256:4a4381b211024ac1fbf3730bd835a8cfa6cd7dd36996bf018437c13796ef0894"
 )
 
 

--- a/tests/test_computer_driver_plugin.py
+++ b/tests/test_computer_driver_plugin.py
@@ -762,7 +762,7 @@ async def test_computer_failure_retries_started_owner_after_restart_and_source_c
 
         computer_source = harness.root / "computer" / "plugin.py"
         manifest_source = harness.root / "computer" / "akashic.plugin.toml"
-        old_digest = "9bd4f6e215b4848e91f0dbfea75a7b227faeba96268c422d62e81a9b64d5ac92"
+        old_digest = "4a4381b211024ac1fbf3730bd835a8cfa6cd7dd36996bf018437c13796ef0894"
         old_image = "ghcr.io/kachofugetsu09/akashic-computer@sha256:" + old_digest
         new_image = old_image[:-1] + "a"
         new_digest = new_image.rsplit(":", 1)[1]


### PR DESCRIPTION
## 问题与结果

固定 PR #583 已发布的 Computer 镜像，让正式 Chromium 使用 --disable-quic，修复分享页 ERR_CONNECTION_CLOSED。插件源码与静态声明使用同一个不可变 digest；现有跨版本测试同步基准镜像。

- 镜像：ghcr.io/kachofugetsu09/akashic-computer@sha256:4a4381b211024ac1fbf3730bd835a8cfa6cd7dd36996bf018437c13796ef0894。
- 镜像源码：73703889ef23febaa2c30e2fd64d2e8f703e0b11；[专用构建发布成功](https://github.com/kachofugetsu09/akashic-agent/actions/runs/34323300006)。
- hua-home 已按 digest 拉取，镜像 label 与源码一致，内部 start.sh 已核对 --disable-quic。

## 范围与验证

change_type=fix，semantic_delta=compatible；capability_owner=plugin；consumer_scope=Computer 浏览器。Workload、profile、权限和持久化合同不变；runtime_patch=required，客户端无法更换服务端浏览器镜像。无架构或 schema 变化，concept_gate=not_applicable。

- tests/test_computer_driver_plugin.py：7 passed，1 skipped（可选真实容器 oracle）；pyright 0 errors、19 个既有警告；git diff --check 通过。
- 既有镜像的独立 Chromium 对照已证明关闭 QUIC 后能渲染目标分享页；正式原 session 的最终正文读取仍待部署验收。
- 按本次任务要求不运行 CI 测试/Gate，仅专用镜像发布 workflow 已完成。
- 源码恢复点 /tmp/computer-quic-image-source-73703889.tar；正式切换前离线备份数据库和完整 Computer 数据目录，恢复可用旧 release/image。
- 已核对工作手册；没有长期语义变化和对应 NOW 待办。