### PR TITLE
修复 Wake 空响应后的自恢复

### DIFF
--- a/agent/plugin_composition/models.py
+++ b/agent/plugin_composition/models.py
@@ -668,6 +668,12 @@ class TransportError(ModelError):
     retryable = True
 
 
+class EmptyResponseError(ModelError):
+    """模型调用成功，但没有可提交的正文或工具调用。"""
+
+    retryable = True
+
+
 class DriverUnavailableError(ModelError): ...
 
 

--- a/migrations/yoyo/20260909_01_close_empty_wake_responses.py
+++ b/migrations/yoyo/20260909_01_close_empty_wake_responses.py
@@ -1,0 +1,216 @@
+"""把旧 React 空响应留下的 Wake 阶段追加为可重试失败。"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import closing
+from pathlib import Path
+from typing import NamedTuple
+from uuid import uuid4
+
+from yoyo import step
+
+from agent.migrations.context import current_migration_context
+from agent.migrations.session_db_backup import backup_sqlite_database
+from plugins.wake.messages import finished
+from plugins.wake.request import Stage, WakeFailure, read_phase, read_request
+from session.log import MessageLog
+from session.message import Control
+
+__depends__ = {"20260908_01_legacy_summaries"}
+__transactional__ = False
+
+_MIGRATION = "close-empty-wake-responses"
+_ERROR = "模型没有产生内容或工具调用；空响应不是 quiet"
+_DETAIL = f"ValueError: {_ERROR}"
+_WAKE_DB = Path("plugin-data/wake-builtin/wake.sqlite3")
+_MESSAGE_OBJECTS = {
+    "attachments",
+    "bindings",
+    "idx_message_attachments_artifact",
+    "ix_message_embeddings_hash",
+    "message_attachments",
+    "message_bindings",
+    "message_call_result",
+    "message_embeddings",
+    "messages",
+    "owner_records",
+    "sessions",
+}
+
+
+class _Candidate(NamedTuple):
+    flow_id: str
+    session_id: str
+    stage: Stage
+
+
+def _failed_flows(path: Path) -> tuple[tuple[str, str], ...]:
+    """读取 Wake 已确认的旧空响应 attempt，不推断其他失败。"""
+
+    if not path.is_file():
+        return ()
+    with closing(sqlite3.connect(path)) as connection:
+        table = connection.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='wake_attempts'"
+        ).fetchone()
+        if table is None:
+            raise RuntimeError("Wake 空响应迁移发现 wake_attempts 表缺失")
+        if connection.execute("PRAGMA integrity_check").fetchall() != [("ok",)]:
+            raise RuntimeError("Wake 空响应迁移发现 wake.sqlite3 损坏")
+        columns = tuple(
+            str(row[1]) for row in connection.execute("PRAGMA table_info(wake_attempts)")
+        )
+        if columns != (
+            "attempt_id", "timer_id", "scheduled_for", "fired_at", "mail_watermark",
+            "outcome", "owner", "detail", "completed_at",
+        ):
+            raise RuntimeError("Wake 空响应迁移发现 wake_attempts schema 不匹配")
+        rows = connection.execute(
+            "SELECT attempt_id, owner FROM wake_attempts "
+            "WHERE outcome='delivery_unknown' AND detail=? ORDER BY attempt_id",
+            (_DETAIL,),
+        ).fetchall()
+    return tuple((str(row[0]), str(row[1])) for row in rows)
+
+
+def _check_sessions(path: Path) -> None:
+    """只读确认 MessageLog 打开时不会补建缺失对象。"""
+
+    uri = f"{path.resolve().as_uri()}?mode=ro"
+    with closing(sqlite3.connect(uri, uri=True)) as connection:
+        connection.execute("PRAGMA query_only=ON")
+        objects = {
+            str(row[0])
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type IN ('table','index')"
+            )
+        }
+        missing = sorted(_MESSAGE_OBJECTS - objects)
+        if missing:
+            raise RuntimeError(
+                "Wake 空响应迁移发现 sessions.db schema 不完整: " + ", ".join(missing)
+            )
+        if (
+            connection.execute("PRAGMA integrity_check").fetchall() != [("ok",)]
+            or connection.execute("PRAGMA foreign_key_check").fetchall()
+        ):
+            raise RuntimeError("Wake 空响应迁移发现 sessions.db 完整性检查失败")
+
+
+def _candidates(workspace: Path) -> tuple[_Candidate, ...]:
+    """只选择仍 pending、已有阶段 Input 且没有终态的精确旧 flow。"""
+
+    sessions = workspace / "sessions.db"
+    flow_ids = _failed_flows(workspace / _WAKE_DB)
+    if not flow_ids:
+        return ()
+    if not sessions.is_file():
+        raise RuntimeError("Wake 空响应迁移发现 sessions.db 缺失")
+    _check_sessions(sessions)
+    log = MessageLog(sessions)
+    try:
+        owner = log.owner("plugin:wake")
+        selected: list[_Candidate] = []
+        for flow_id, attempt_owner in flow_ids:
+            row = owner.read("flow:" + flow_id)
+            if row is None:
+                raise RuntimeError(f"Wake flow {flow_id} 缺少恢复指针")
+            pointer = dict(row.value)
+            if set(pointer) != {"session_id", "input_id", "settled"}:
+                raise RuntimeError(f"Wake flow {flow_id} pointer 结构不匹配")
+            if pointer["settled"] is True:
+                continue
+            if pointer["settled"] is not False:
+                raise RuntimeError(f"Wake flow {flow_id} settled 不是布尔值")
+            reader = log.reader(str(pointer["session_id"]))
+            request = read_request(reader.snapshot())
+            if (
+                request.flow_id,
+                request.session_id,
+                request.input_id,
+                request.owner,
+            ) != (
+                flow_id,
+                pointer["session_id"],
+                pointer["input_id"],
+                attempt_owner,
+            ):
+                raise RuntimeError(f"Wake flow {flow_id} pointer 与请求不一致")
+            _, phase = read_phase(reader.snapshot(), request)
+            if finished(reader, request, phase.stage) is None:
+                selected.append(_Candidate(flow_id, request.session_id, phase.stage))
+        return tuple(selected)
+    finally:
+        log.close()
+
+
+def migrate(workspace: Path) -> int:
+    """备份后只追加失败 Control；Source 在启动时继续领域结算。"""
+
+    candidates = _candidates(workspace)
+    if not candidates:
+        return 0
+    sessions = workspace / "sessions.db"
+    backup_sqlite_database(
+        sessions,
+        workspace / "backups" / _MIGRATION / uuid4().hex,
+        migration=_MIGRATION,
+    )
+
+    log = MessageLog(sessions)
+    try:
+        owner = log.owner("plugin:wake")
+        reason = WakeFailure(message=_ERROR, retryable=True).model_dump_json()
+        appended = 0
+        for candidate in candidates:
+            row = owner.read("flow:" + candidate.flow_id)
+            if row is None or dict(row.value).get("settled") is not False:
+                raise RuntimeError(f"Wake flow {candidate.flow_id} 在迁移提交前发生变化")
+            reader = log.reader(candidate.session_id)
+            request = read_request(reader.snapshot())
+            _, phase = read_phase(reader.snapshot(), request)
+            if (
+                request.flow_id != candidate.flow_id
+                or request.session_id != candidate.session_id
+                or phase.stage != candidate.stage
+            ):
+                raise RuntimeError(f"Wake flow {candidate.flow_id} 在迁移提交前发生变化")
+            if finished(reader, request, phase.stage) is not None:
+                continue
+            source_head = reader.head(source="wake")
+            writer = log.writer(
+                candidate.session_id,
+                author="wake",
+                source="wake",
+                body_types=(Control,),
+                content={},
+            )
+            try:
+                terminal = writer.append(
+                    request.phase_id(phase.stage) + ":failure",
+                    Control("failure", source_head, reason),
+                    expected_source_head=source_head,
+                )
+            finally:
+                writer.expire()
+            if finished(reader, request, phase.stage) != terminal:
+                raise RuntimeError(f"Wake flow {candidate.flow_id} 失败终态未提交")
+            appended += 1
+    finally:
+        log.close()
+    with closing(sqlite3.connect(sessions)) as connection:
+        if (
+            connection.execute("PRAGMA integrity_check").fetchall() != [("ok",)]
+            or connection.execute("PRAGMA foreign_key_check").fetchall()
+        ):
+            raise RuntimeError("Wake 空响应迁移后 sessions.db 完整性检查失败")
+    return appended
+
+
+def apply(_ledger: object) -> int:
+    return migrate(current_migration_context().workspace)
+
+
+steps = [step(apply)]

--- a/plugins/react/plugin.py
+++ b/plugins/react/plugin.py
@@ -9,7 +9,13 @@ from uuid import uuid4
 
 from agent.plugin_composition import Context, RuntimeScope, ServiceKey
 from agent.plugins.snapshot import get_current_runtime_lease
-from agent.plugin_composition.models import BoundChatModel, ContextLengthError, LLMResponse, StreamCallback
+from agent.plugin_composition.models import (
+    BoundChatModel,
+    ContextLengthError,
+    EmptyResponseError,
+    LLMResponse,
+    StreamCallback,
+)
 from plugins.context.api import ContextOverflow, Materials, SummaryReducer
 from session.log import MessageReader, MessageWriter
 from session.message import CallRef, Control, Message, Output, Part, ContentPart, ToolCall, ToolResult
@@ -244,7 +250,7 @@ async def react(
                 indices.append(len(parts))
                 parts.append(ToolCall(tools.bind(call.name), call.arguments))
             if not parts:
-                raise ValueError("模型没有产生内容或工具调用；空响应不是 quiet")
+                raise EmptyResponseError("模型没有产生内容或工具调用；空响应不是 quiet")
             parts.append(projection.facts(response, indices))
             if prepared.summary is not None:
                 parts.append(ContentPart("context.summary", {"reference": prepared.summary.reference}))

--- a/tests/test_close_empty_wake_responses_migration.py
+++ b/tests/test_close_empty_wake_responses_migration.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import json
+import importlib.util
+import sqlite3
+import sys
+from contextlib import closing
+from datetime import datetime, timezone
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+import yoyo
+
+from plugins.eventmail.plugin import EVENTMAIL_CONTENT_SOURCE
+from plugins.wake.api import EVENTMAIL_WAKE
+from plugins.wake.request import Phase, check_phase, retryable
+from plugins.wake.state import WakeState
+from session.message import ContentPart, Control, Input
+from tests.test_wake_messages import application, request
+
+
+def _migration(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    path = Path(__file__).parents[1] / "migrations/yoyo/20260909_01_close_empty_wake_responses.py"
+    spec = importlib.util.spec_from_file_location("close_empty_wake_responses_test", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setattr(yoyo, "step", lambda callback: callback)
+    monkeypatch.setitem(sys.modules, spec.name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _raw_messages(path: Path) -> list[tuple[object, ...]]:
+    with closing(sqlite3.connect(path)) as connection:
+        return connection.execute("SELECT * FROM messages ORDER BY session_key, seq").fetchall()
+
+
+def test_migration_rejects_incomplete_sessions_without_writing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    state = WakeState(workspace / "plugin-data/wake-builtin/wake.sqlite3")
+    state.initialize()
+    now = datetime.now(timezone.utc)
+    state.begin_attempt(
+        attempt_id="b" * 32,
+        timer_id="timer:legacy-empty",
+        scheduled_for=now,
+        fired_at=now,
+    )
+    state.finish_attempt(
+        attempt_id="b" * 32,
+        outcome="delivery_unknown",
+        owner="content",
+        detail="ValueError: 模型没有产生内容或工具调用；空响应不是 quiet",
+        completed_at=now,
+    )
+    sessions = workspace / "sessions.db"
+    sessions.touch()
+
+    with pytest.raises(RuntimeError, match="sessions.db schema 不完整"):
+        _migration(monkeypatch).migrate(workspace)
+
+    assert sessions.read_bytes() == b""
+    assert not (workspace / "backups/close-empty-wake-responses").exists()
+
+
+@pytest.mark.asyncio
+async def test_migration_closes_only_exact_legacy_empty_response_and_source_recovers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """旧空响应只追加失败终态，随后由现有 Source 结算原职责。"""
+
+    workspace = tmp_path / "workspace"
+    async with application(tmp_path) as (_, log, ctx, source, control):
+        now = datetime.now(timezone.utc)
+        producer = ctx.require(EVENTMAIL_CONTENT_SOURCE).bind("feed")
+        producer.submit(
+            "batch",
+            [{
+                "item_id": "one",
+                "revision": "1",
+                "not_before": now,
+                "requires_ack": True,
+                "payload": {"title": "keep this content"},
+            }],
+        )
+        snapshot = ctx.require(EVENTMAIL_WAKE).snapshot(now)
+        original = request(ctx, "content", now).model_copy(
+            update={
+                "snapshot_seq": snapshot["snapshot_seq"],
+                "items": tuple(dict(item) for item in snapshot["items"]),
+            }
+        )
+        source.accept(original)
+        writer = log.writer(
+            original.session_id,
+            author="wake",
+            source="wake",
+            body_types=(Input,),
+            content={"wake.phase": check_phase},
+        )
+        try:
+            writer.append(
+                original.phase_id("screen"),
+                Input((ContentPart(
+                    "wake.phase",
+                    Phase(input_id=original.input_id, stage="screen").model_dump(mode="json"),
+                ),)),
+            )
+        finally:
+            writer.expire()
+
+        source.state.begin_attempt(
+            attempt_id=original.flow_id,
+            timer_id="timer:legacy-empty",
+            scheduled_for=now,
+            fired_at=now,
+        )
+        detail = "ValueError: 模型没有产生内容或工具调用；空响应不是 quiet"
+        source.state.finish_attempt(
+            attempt_id=original.flow_id,
+            outcome="delivery_unknown",
+            owner="content",
+            detail=detail,
+            completed_at=now,
+        )
+        migrate = _migration(monkeypatch).migrate
+        pointer = log.owner("plugin:wake").read("flow:" + original.flow_id)
+        assert pointer is not None
+        with closing(sqlite3.connect(workspace / "sessions.db")) as connection, connection:
+            connection.execute(
+                "DELETE FROM owner_records WHERE owner=? AND key=?",
+                ("plugin:wake", "flow:" + original.flow_id),
+            )
+        with pytest.raises(RuntimeError, match="缺少恢复指针"):
+            migrate(workspace)
+        assert not (workspace / "backups/close-empty-wake-responses").exists()
+        log.owner("plugin:wake").transact(
+            lambda tx: tx.save(
+                "flow:" + original.flow_id,
+                pointer.value,
+                expected_version=None,
+            )
+        )
+        before = _raw_messages(workspace / "sessions.db")
+
+        assert migrate(workspace) == 1
+
+        rows = log.reader(original.session_id).snapshot()
+        assert _raw_messages(workspace / "sessions.db")[:-1] == before
+        assert isinstance(rows[-1].body, Control)
+        assert rows[-1].body.action == "failure"
+        assert retryable(rows[-1]) is True
+        assert source.state.get_attempt(original.flow_id)["detail"] == detail
+
+        backups = list((workspace / "backups/close-empty-wake-responses").glob("*"))
+        assert len(backups) == 1
+        manifest = json.loads((backups[0] / "manifest.json").read_text())
+        assert manifest["migration"] == "close-empty-wake-responses"
+        with closing(sqlite3.connect(backups[0] / "sessions.db")) as saved:
+            assert saved.execute(
+                "SELECT * FROM messages ORDER BY session_key, seq"
+            ).fetchall() == before
+
+        assert migrate(workspace) == 0
+        assert list((workspace / "backups/close-empty-wake-responses").glob("*")) == backups
+        task = await source.start(original.flow_id)
+        assert task is not None
+        assert await task.join() == "deferred"
+        assert control["calls"] == []
+        assert source.pending() == ()

--- a/tests/test_migration_runner.py
+++ b/tests/test_migration_runner.py
@@ -68,6 +68,7 @@ _LEGACY_AGENT_CONFIG_ID = "20260907_02_retire_legacy_agent_config"
 _MESSAGE_METADATA_ID = "20260907_03_message_metadata"
 _SKILL_PROMPT_GRANT_ID = "20260907_03_skill_prompt_grant"
 _LEGACY_SUMMARIES_ID = "20260908_01_legacy_summaries"
+_CLOSE_EMPTY_WAKE_RESPONSES_ID = "20260909_01_close_empty_wake_responses"
 _CURRENT_IDS = (
     _ORIGIN_ID,
     _AKASHA_V9_ID,
@@ -115,6 +116,7 @@ _CURRENT_IDS = (
     _MESSAGE_METADATA_ID,
     _SKILL_PROMPT_GRANT_ID,
     _LEGACY_SUMMARIES_ID,
+    _CLOSE_EMPTY_WAKE_RESPONSES_ID,
 )
 _CURRENT_LEDGER_IDS = tuple(sorted(_CURRENT_IDS))
 
@@ -475,6 +477,7 @@ def test_toolset_wiring_migration_retires_only_the_exact_legacy_default(
         _MESSAGE_METADATA_ID,
         _SKILL_PROMPT_GRANT_ID,
         _LEGACY_SUMMARIES_ID,
+        _CLOSE_EMPTY_WAKE_RESPONSES_ID,
     )
     migrated = tomllib.loads(config.read_text(encoding="utf-8"))
     assert "agent" not in migrated
@@ -543,7 +546,13 @@ def test_toolset_wiring_migration_preserves_config_symlink_identity(
 
     outcome = _runner(root).run()
 
-    assert outcome.migrations == (_LEGACY_AGENT_CONFIG_ID, _MESSAGE_METADATA_ID, _SKILL_PROMPT_GRANT_ID, _LEGACY_SUMMARIES_ID)
+    assert outcome.migrations == (
+        _LEGACY_AGENT_CONFIG_ID,
+        _MESSAGE_METADATA_ID,
+        _SKILL_PROMPT_GRANT_ID,
+        _LEGACY_SUMMARIES_ID,
+        _CLOSE_EMPTY_WAKE_RESPONSES_ID,
+    )
 
     assert config.is_symlink()
     assert os.readlink(config) == source.name
@@ -637,6 +646,7 @@ def test_embedding_backfill_runs_after_selection_is_already_recorded(
         _MESSAGE_METADATA_ID,
         _SKILL_PROMPT_GRANT_ID,
         _LEGACY_SUMMARIES_ID,
+        _CLOSE_EMPTY_WAKE_RESPONSES_ID,
     )
 
 
@@ -1000,6 +1010,7 @@ api_key = "secret"
         _MESSAGE_METADATA_ID,
         _SKILL_PROMPT_GRANT_ID,
         _LEGACY_SUMMARIES_ID,
+        _CLOSE_EMPTY_WAKE_RESPONSES_ID,
     )
     assert (
         CredentialStore.for_workspace(root / "workspace").api_key("model_deepseek_main")

--- a/tests/test_wake_messages.py
+++ b/tests/test_wake_messages.py
@@ -45,7 +45,7 @@ async def apply(ctx, config):
     if wake_delivery:
         text = text.replace("await _original_apply(ctx, config)",
             'await _original_apply(ctx, Config.model_validate({"delivery": {"channel": "test", "recipient": "room", "session_id": "test:room"}}))')
-    text += "\nfrom tests.test_wake_messages import CONTROLS\n_original_runtime = Runtime\ndef Runtime(ctx, config):\n    runtime = _original_runtime(ctx, config)\n    control = CONTROLS[" + repr(str(tmp_path)) + "]\n    control['runtime'] = runtime\n    deadline = runtime.duties.deadline\n    def observe(now):\n        value = deadline(now)\n        control.setdefault('deadlines', []).append(value)\n        control['due_read'].set()\n        return value\n    runtime.duties.deadline = observe\n    return runtime\n"
+    text += "\nfrom tests.test_wake_messages import CONTROLS\n_original_runtime = Runtime\ndef Runtime(ctx, config):\n    runtime = _original_runtime(ctx, config)\n    control = CONTROLS[" + repr(str(tmp_path)) + "]\n    control['runtime'] = runtime\n    deadline = runtime.duties.deadline\n    def observe(now):\n        value = deadline(now)\n        control.setdefault('deadlines', []).append(value)\n        control['due_read'].set()\n        return value\n    runtime.duties.deadline = observe\n    finish_attempt = runtime.state.finish_attempt\n    def observe_attempt(**kwargs):\n        finish_attempt(**kwargs)\n        control['attempts'].put_nowait(kwargs)\n    runtime.state.finish_attempt = observe_attempt\n    return runtime\n"
     module.write_text(text)
     provider = sources / "models_fixture"
     provider.mkdir()
@@ -94,6 +94,9 @@ async def apply(ctx, config):
             await control["release"].wait()
             if control["failure"] is not None:
                 raise control["failure"]
+            if control["thinking_only"]:
+                control["thinking_only"] -= 1
+                return LLMResponse(None, thinking="private reasoning")
             if control.get("content") and len(control["calls"]) == 1:
                 return LLMResponse(None, [ToolCall("screen", "screen_content", {"items": [{
                     "candidate_id": control["candidate"], "initial_interest": "relevant", "question": "verify this"}]})])
@@ -127,7 +130,8 @@ async def apply(ctx, config):
     await ctx.require(DELIVERY_SENDERS).register(ctx, name="test", idempotent=True, open=sender)
 '''.replace("CONTROL_PATH", repr(str(tmp_path))))
     control = {"calls": [], "sent": [], "entered": asyncio.Queue(), "release": asyncio.Event(),
-               "tool": "share_content", "failure": None, "due_read": asyncio.Event()}
+               "tool": "share_content", "failure": None, "thinking_only": 0,
+               "due_read": asyncio.Event(), "attempts": asyncio.Queue()}
     control["release"].set()
     CONTROLS[str(tmp_path)] = control
     try:
@@ -391,6 +395,39 @@ async def test_model_failure_keeps_real_control_and_original_retry_classificatio
         assert bool(ctx.require(DRIFT_WAKE).snapshot(now)["proposals"]) is can_retry
         assert not control["sent"] and len(control["calls"]) == 1
         assert await source.start(original.flow_id) is None
+
+
+@pytest.mark.asyncio
+async def test_reasoning_only_response_defers_one_flow_and_runtime_handles_the_next(tmp_path):
+    from plugins.wake.request import retryable
+    from session.message import Control
+
+    async with application(tmp_path, wake_delivery=True) as (host, log, ctx, source, control):
+        control["thinking_only"] = 1
+        now = datetime.now(timezone.utc)
+        ctx.require(DRIFT_PROPOSALS).propose(
+            "empty", "1", {"summary": "first duty"}, now,
+            next_due=now + timedelta(hours=1),
+        )
+        await host.start_runtime()
+        runtime = control["runtime"]
+
+        while True:
+            first = await asyncio.wait_for(control["attempts"].get(), 10)
+            if first["owner"] == "drift":
+                break
+        assert first["outcome"] == "deferred"
+        assert runtime.source.pending() == ()
+        rows = log.reader("wake:" + first["attempt_id"]).snapshot()
+        assert isinstance(rows[-1].body, Control) and retryable(rows[-1]) is True
+
+        ctx.require(DRIFT_PROPOSALS).propose("later", "1", {"summary": "next duty"}, now)
+        while True:
+            second = await asyncio.wait_for(control["attempts"].get(), 10)
+            if second["outcome"] == "shared":
+                break
+        assert len(control["calls"]) == 2 and len(control["sent"]) == 1
+        assert runtime.source.pending() == ()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 问题与结果

- 解决的问题：模型只返回 reasoning、没有正文或工具调用时，React 抛出普通 `ValueError`；Wake 无法把它保存为可恢复终态，旧 pending flow 会在每次启动时再次中止 watcher。
- 用户可见结果：新空响应按可重试模型失败延期；一次性迁移为精确命中的旧 pending Wake flow 追加同一失败终态，启动后沿现有领域路径完成结算，后续 Wake 继续运行。
- 本 PR 不处理：不增加运行时兼容分支，不改旧 Message、Wake attempt、EventMail 或 delivery 记录。

## Change intent

- `change_type`：`fix` + `migration`
- `semantic_delta`：`compatible`
- `capability_owner`：`mixed`（Core 模型错误分类 + Wake 恢复）
- `consumer_scope`：所有 React 调用获得明确空响应错误；Wake 将其按 retryable 模型失败处理。
- `runtime_patch`：`required`
- `runtime_patch_reason`：空响应事实由共享 React 解码边界确认，Wake 只拥有本来源的失败落盘与领域结算。
- `authoritative_state_owner`：MessageLog 拥有追加消息；Wake state 拥有 attempt；`plugin:wake` owner record 拥有 flow pointer。
- `client_only_alternative`：`not_applicable`
- `concept_gate`：`required`
- `concept_gate_reason`：涉及模型错误分类、归档 program binding 与持久化恢复链。
- 关联不变量：Message 只追加；每项状态保持原 owner；终态存在时 `Source._phase` 不打开归档程序。
- `protected_state`：既有 Message、Wake attempt、EventMail、delivery 和 settled pointer 原样保留。
- 允许的副作用：精确旧失败命中时先备份 `sessions.db`，再追加一个 retryable `Control.failure`；启动后现有 Source 更新自己的领域状态和 pointer。
- 禁止的副作用：UPDATE/DELETE 旧消息、改写 Wake attempt、字符串兼容分支、重复通知。

## 改动范围

- 主要文件：`agent/plugin_composition/models.py`、`plugins/react/plugin.py`、Wake Yoyo 迁移及对应测试。
- 配置或迁移影响：新增 `20260909_01_close_empty_wake_responses`；只处理 outcome/detail/owner/pointer/request/phase 全部一致且尚无终态的 flow。
- 已知 schema lineage 与最终 schema identity：迁移要求依赖点完整 MessageLog object 集和 Wake v8 attempt 列；不变更 schema。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：base `017dbc5ac1f4053cf487574aa997fc1877144ff4`，candidate `2cbad06d`。
- 回滚方式：部署前代码可回退该提交；迁移运行后从 `backups/close-empty-wake-responses/<id>/sessions.db` 恢复，或保留追加终态并回退代码。

## 验证

- [x] 相关 targeted tests 已通过：76 passed。
- [x] Python 编译与 `git diff --check` 已通过；共享 venv 未安装 Ruff。
- [ ] `python docker/debug/gate.py run --base origin/main` 已运行。
- `sourceDigest`：未生成。
- `planDigest`：未生成。
- 真实设备证据：不适用。
- 未运行项与原因：按维护者明确要求未运行 CI 和 change-impact Gate；部署后另验真实 hua-home 状态。

## 正交性与概念完整性

- 是否属于架构性 PR 或大改动：`yes`
- 独立 reviewer / model / reasoning：`wake_fix_review` / `gpt-5.6-terra` / `xhigh`
- 审查 head：`2cbad06d` 对应完整 dirty diff（提交前同内容）
- 新增概念及其唯一 owner；没有时写 `none`：`EmptyResponseError` 由共享模型组合层拥有空响应错误分类。
- 无关设计轴的变化传播；没有时写 `none`：`none`
- 最短正常/失败/热更新链路：React 空响应 → retryable ModelError → Wake program 追加 failure；旧 flow → Yoyo 追加 failure → Source 读终态 → defer/settle。
- legacy/source-specific 残留扫描：没有运行时 legacy/string branch；Yoyo 只识别既有精确错误证据。
- must-fix 及处置证据：缺 pointer、缺/不完整 sessions schema 均在写入前 fail-loud；测试证明空库不被初始化且不生成备份。
- 最终结论：`pass`

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 本次没有长期语义变化。
- [x] 不涉及跨仓库或客户端改动。
- [x] 当前没有对应 `NOW.md` 事项。
