### PR TITLE
修复旧工具结果导致的 Akasha 出处校验失败

### DIFF
--- a/plugins/compaction/message_summary.py
+++ b/plugins/compaction/message_summary.py
@@ -13,7 +13,7 @@ from agent.plugin_composition.models import (
 from session.message import CallRef, ContentPart, Control, Message, Output, ToolCall, ToolResult
 from plugins.context.api import settled_prefixes
 from plugins.turn_projection.plugin import TurnProjection
-from session.message_codec import encode_body
+from session.message_codec import body_to_dict
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +52,7 @@ def source_text(messages: Sequence[Message]) -> str:
                 }
             ))
         rows.append({"message_id": message.message_id, "source": message.source, "author": message.author,
-                     "seq": message.seq, "body": json.loads(encode_body(body))})
+                     "seq": message.seq, "body": body_to_dict(body)})
     return json.dumps(rows, ensure_ascii=False, separators=(",", ":"))
 
 

--- a/plugins/wake/runtime.py
+++ b/plugins/wake/runtime.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
-import json
 from collections.abc import Callable, Mapping
 from datetime import UTC, datetime, timedelta
 from typing import cast
@@ -22,7 +21,7 @@ from plugins.standard_web.plugin import STANDARD_WEB_TOOLS
 from plugins.tools.plugin import TOOLS, ToolView
 from session.log import MessageReader, OwnerRecord
 from session.message import Message
-from session.message_codec import encode_body
+from session.message_codec import body_to_dict
 
 from .admission import Admission, Duties
 from .api import Config, DRIFT_WAKE, EVENTMAIL_WAKE
@@ -110,7 +109,7 @@ class DashboardView:
 
     @staticmethod
     def _message(message: Message) -> Mapping[str, object]:
-        body = json.loads(encode_body(message.body))
+        body = body_to_dict(message.body)
         parts = body.get("parts", ()) if isinstance(body, dict) else ()
         text = "\n".join(
             str(part.get("value"))

--- a/plugins/workbench_ui/dashboard.py
+++ b/plugins/workbench_ui/dashboard.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from typing import Literal
 from dataclasses import asdict
-import json
 
 from fastapi import FastAPI, HTTPException, Query
 
@@ -12,7 +11,7 @@ from agent.plugin_composition.messages import MESSAGE_CATALOG
 from agent.plugins.snapshot import get_current_runtime_snapshot
 from infra.channels.message_view import session_row
 from session.log import InvalidPage, MessageCatalog
-from session.message_codec import encode_body
+from session.message_codec import body_to_dict
 
 
 def _catalog() -> MessageCatalog:
@@ -55,7 +54,7 @@ def register(app: FastAPI, context: DashboardContext) -> None:
         return {"version": 2, "session_id": session_id, "items": [{"id": message.message_id, "session_id": message.session_id,
                     "seq": message.seq, "timestamp": message.recorded_at.isoformat(),
                     "author": message.author, "source": message.source,
-                    "body": json.loads(encode_body(message.body))} for message in page.messages],
+                    "body": body_to_dict(message.body)} for message in page.messages],
                 "before_seq": before_seq, "through_seq": page.through_seq,
                 "next_before_seq": page.messages[0].seq if page.messages else None,
                 "has_more": page.has_more}

--- a/session/log.py
+++ b/session/log.py
@@ -894,7 +894,6 @@ class MessageWriter:
     ) -> Message:
         # 1. 固定 writer 的能力范围；内容 schema 由其注册 owner 验证。
         self._check_grant(body)
-        payload = encode_body(body)
         message_metadata = freeze_metadata({} if metadata is None else metadata)
         if self._check_metadata is None and not message_metadata.keys() <= self._message_metadata_keys:
             raise PermissionError("writer 未获授这些 Message metadata 命名空间")
@@ -904,6 +903,7 @@ class MessageWriter:
         old = connection.execute(
             "SELECT * FROM messages WHERE id=?", (message_id,)
         ).fetchone()
+        payload = encode_body(body, allow_legacy=old is not None)
         if old is not None:
             if (old["session_key"], old["author"], old["source"], old["body"]) != (
                 self._session_id,

--- a/session/message.py
+++ b/session/message.py
@@ -145,6 +145,8 @@ class Output:
 
 @dataclass(frozen=True, slots=True)
 class ToolResult:
+    # 仅持久化解码器记录旧表示；运行时 outcome 仍遵守当前值域。
+    _legacy_unknown: bool = field(default=False, init=False, repr=False, compare=False)
     call_ref: CallRef
     outcome: Literal["success", "denied", "error", "interrupted"]
     parts: tuple[ContentPart, ...]

--- a/session/message_codec.py
+++ b/session/message_codec.py
@@ -29,8 +29,8 @@ def json_value(value: object) -> object:
     return value
 
 
-def encode_body(body: Body) -> str:
-    """只编码一份消息事实，不创建 provider 或 UI 的平行持久模型。"""
+def body_to_dict(body: Body) -> dict[str, object]:
+    """返回当前运行时消息字段，供展示和上下文使用。"""
     data: dict[str, object]
     if isinstance(body, Control):
         data = {
@@ -70,6 +70,16 @@ def encode_body(body: Body) -> str:
                     "part_index": body.call_ref.part_index,
                 },
             }
+    return data
+
+
+def encode_body(body: Body, *, allow_legacy: bool = True) -> str:
+    """保留已读消息的历史编码；新写入可显式拒绝旧表示。"""
+    data = body_to_dict(body)
+    if isinstance(body, ToolResult) and body._legacy_unknown:
+        if not allow_legacy:
+            raise ValueError("旧 unknown 工具结果只能重放已有消息，不能作为新消息写入")
+        data["outcome"] = "unknown"
     return json.dumps(
         data, ensure_ascii=False, sort_keys=True, separators=(",", ":"), allow_nan=False
     )
@@ -137,9 +147,13 @@ def decode_body(payload: str) -> Body:
             cast(Literal["continue", "complete", "quiet"], row["finish"]),
         )
     call = _object(row["call_ref"], {"message_id", "part_index"})
-    return ToolResult(
+    result = ToolResult(
         CallRef(cast(str, call["message_id"]), cast(int, call["part_index"])),
         cast(Literal["success", "denied", "error", "interrupted"],
              "error" if row["outcome"] == "unknown" else row["outcome"]),
         cast(tuple[ContentPart, ...], parts),
     )
+
+    if row["outcome"] == "unknown":
+        object.__setattr__(result, "_legacy_unknown", True)
+    return result

--- a/tests/test_message_log.py
+++ b/tests/test_message_log.py
@@ -18,7 +18,7 @@ from session.message import (
     ToolCall,
     ToolResult,
 )
-from session.message_codec import decode_body, encode_body
+from session.message_codec import body_to_dict, decode_body, encode_body
 
 
 def text_schema(part):
@@ -526,3 +526,48 @@ def test_live_message_reuse_checks_entire_row_and_does_not_keep_history(log):
     del first, second
     gc.collect()
     assert held() is None
+
+
+def test_legacy_result_keeps_stored_identity_and_rejects_new_append(log):
+    """旧消息重放保持原始正文，新身份不得复制已退役的结果表示。"""
+    log.save_binding("legacy-binding", {"artifact": "v1"})
+    writer(log, author="agent", bodies=(Output,), check_call=lambda call: None).append(
+        "legacy-call", Output((ToolCall("legacy-binding", {}),), "continue"),
+    )
+    results = writer(log, author="tool", bodies=(ToolResult,), call_ref=CallRef("legacy-call", 0))
+    current = ToolResult(CallRef("legacy-call", 0), "error", (ContentPart("text", "回执丢失"),))
+    results.append("legacy-result", current)
+    raw = json.loads(encode_body(current))
+    raw["outcome"] = "unknown"
+    original = json.dumps(raw, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    # 模拟升级前已存在的数据库事实，不通过当前 writer 创建旧值域。
+    log._connection.execute("UPDATE messages SET body=? WHERE id='legacy-result'", (original,))
+    log._connection.commit()
+    legacy = decode_body(original)
+    assert isinstance(legacy, ToolResult) and legacy.outcome == "error"
+    assert body_to_dict(legacy)["outcome"] == "error"
+    assert encode_body(legacy) == original
+    assert results.append("legacy-result", legacy).body == current
+    with pytest.raises(MessageConflict):
+        results.append("legacy-result", current)
+    with pytest.raises(ValueError, match="不能作为新消息"):
+        results.append("new-result", legacy)
+    assert log._connection.execute("SELECT body FROM messages WHERE id='legacy-result'").fetchone()[0] == original
+    assert len(log.reader("s").snapshot()) == 2
+
+
+def test_akasha_source_digest_keeps_legacy_result_bytes():
+    """升级后的学习出处摘要仍匹配升级前保存的摘要。"""
+    import hashlib
+    from datetime import UTC, datetime
+    from plugins.akasha.projection import Sample, source_digest
+    from session.message import Message
+
+    original = '{"call_ref":{"message_id":"call","part_index":0},"kind":"tool_result","outcome":"unknown","parts":[{"kind":"text","value":"回执丢失"}]}'
+    stamp = datetime(2026, 9, 1, tzinfo=UTC)
+    observation = Message("result", "s", 1, stamp, "tool", "conversation", decode_body(original))
+    ending = Message("ending", "s", 2, stamp, "agent", "conversation", Output((), "complete"))
+    rows = [["s", 2, "ending", "agent", "conversation", stamp.isoformat(), encode_body(ending.body)],
+            ["s", 1, "result", "tool", "conversation", stamp.isoformat(), original]]
+    expected = hashlib.sha256(json.dumps(rows, ensure_ascii=False, separators=(",", ":")).encode()).hexdigest()
+    assert source_digest(Sample(ending, (ending,), (observation,))) == expected


### PR DESCRIPTION
## 问题与结果

升级前的 `unknown` 工具结果在读边界转为 `error` 后，Akasha 重新计算出的学习出处摘要与旧摘要不一致，导致正式 workspace 启动失败。此次保留旧消息的持久化编码身份，使历史摘要和同 ID 重放保持一致；当前界面和上下文仍使用 `error`，新消息拒绝旧表示。

## Change intent

- change_type: fix；semantic_delta: compatible。
- capability_owner: core；consumer_scope: Message writer、Akasha、Workbench、compaction、Wake。
- runtime_patch: required；原因：历史解码和追加幂等身份由 Message 持久化边界拥有，客户端无法修复。
- authoritative_state_owner: sessions.db/messages 及 Akasha 已存出处摘要。
- protected_state: 原消息正文、消息身份、绑定、附件与学习记录。
- 允许副作用：读取旧编码时记录私有出处标记；新写入显式拒绝旧表示。
- 禁止副作用：改写数据库历史事实、迁移学习摘要、恢复 unknown 为新公共 outcome。

## 改动范围与恢复

仅调整 Message codec/writer 与三个当前展示消费者，添加两个真实回归测试。无 schema、配置或数据迁移。源码恢复点为 70e34b59；部署前完整 Borg 快照已完成实际恢复及哈希核验。正式部署的状态恢复必须由该快照负责，不能把代码回退当数据回滚。

## 验证

- Message log/react 55 tests passed。
- Akasha projection/consumption、compaction summary、Wake 54 tests passed。
- 生产及 tests pyright：0 errors；git diff --check 通过。
- change-impact Gate：26 个公开场景全部通过，报告 `20260910-013059-391ade88`。
- sourceDigest: `ca946ea8029d22561fcda7b3dbe8cb27ab8e2e78600165e4e7fa802395e29037`；planDigest: `1479f085ac865444cd1edc4767ceec702be0b0bae9d708daa1efa1667109244c`。
- 生产只读证据：29 条 Applied 的原始消息摘要全部匹配；直接归一化后仅 28 条匹配。补丁实际 codec 对正式库 29 条 Applied 的全部成员与观察逐条只读重编码复核通过。正式服务激活与在线验收已完成，见下方最终回执。

## 正交性与概念完整性

独立 reviewer production_fixes_review / gpt-5.6-terra / xhigh，结论 PASS，0 must-fix。审查提交 da53ef1d。私有 provenance 只归持久化 codec，不扩展公共结果类型；运行时展示共享 body_to_dict。已核对全部 encode_body 消费者、精确 writer 授权、历史重放和新身份拒绝路径。

## 工作手册

已核对 Message append-only、历史出处和 Decision 0063；本次修复恢复既有合同，无新长期产品语义、schema 或 NOW 事项。

## 正式部署验收（2026-09-10）

hua-home 已通过正式发布链激活 `4f9173c188a16289f0ac08d786f667e75df185d4`（#590）；运行镜像 revision、进程提交及 Wake/Context 源码哈希与通过 CI 的 tree 一致。

- 连续观察 500.68 秒：Core/Workloads 持续 healthy、零重启、无 OOM，Core 新增 1 次 GitHub 连接重试耗尽 warning，无 error；既有冷却后于 23:26:03 UTC 日志确认 GitHub transport recovered。
- plugin doctor：51 个插件全部 healthy，14 个外部插件；退役安装已卸载，Skill 检查通过。
- 正式 programmatic session `programmatic:pr571-551-final-4f9173c1` 为 learning=excluded。真实 ToolSearch binding 逐项匹配 53 个公开工具；Steam 在线人数、Calendar 日历列表、GitHub Watch runtime info、Scheduler 列表全部成功，整轮 complete。
- Observe 持久游标已追上本轮 E2E；Markdown 的正式 MEMORY +100 / SELF +4 回执、原条目、before-image 和 155 个 Message 引用复核通过。
- 原 17,539 条 Message、325 条 binding、642 条消息绑定与 9 条附件关联逐行哈希保持一致；完整备份已完成恢复核验。
- 公网 WebSocket 实际收到 server.challenge；Host Bridge 与正式服务单元 active。
- Wake 原 100 候选的真实只读模型复验返回 8 个完整有效 ID（总输出 9,628 token）；部署后有效初筛 0 次。最新自然初筛因非法 JSON 参数明确 failure/defer；同批候选只读复验再次选中 8 个有效 ID（总输出 9,148 token）。模型复验未提交决定或发送消息，不作为手机送达证据。窗口后 Telegram 仍有瞬断并自动重试。

Core #571、#586、#587、#588、#589、#590，Calendar #10 和 Fleet #2 均已合并；关联 #551 已关闭。53 项为目录覆盖核验，未执行所有有写入副作用的工具。
