### PR TITLE
修复插件候选复制阻塞 Core 与数据库锁无限等待

### DIFF
--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -12,6 +12,7 @@ import secrets
 import shutil
 import sqlite3
 import sys
+import time
 import tomllib
 from dataclasses import dataclass, replace
 from contextlib import ExitStack, asynccontextmanager, contextmanager
@@ -4973,7 +4974,7 @@ class PluginManager:
                     / generation.data_dir.name
                 )
                 validation_data_dir.parent.mkdir(parents=True, exist_ok=True)
-                generation.validation_data_inventory = _copy_validation_tree(
+                generation.validation_data_inventory = await _copy_in_thread(_copy_validation_tree,
                     generation.data_dir,
                     validation_data_dir,
                     _candidate_data_exclude_paths(generation.static_manifest),
@@ -5181,9 +5182,9 @@ class PluginManager:
         try:
             async with RuntimeScope(lease):
                 try:
-                    host = self._build_validation_host(lease)
+                    host = await self._build_validation_host(lease)
                     self._validation_hosts[host.identity] = host
-                    self._copy_validation_bindings(host)
+                    await self._copy_validation_bindings(host)
                     await self._copy_validation_artifacts(host)
                     self._reload_journal.annotate(cast(str, update.reload_tx_id), {
                         "event": "business_validation_opened", "validation_id": host.identity,
@@ -5248,7 +5249,7 @@ class PluginManager:
             self._notify_updates()
             raise
 
-    def _build_validation_host(
+    async def _build_validation_host(
         self, lease: RuntimeSnapshotLease,
     ) -> ValidationHost:
         """先固定声明数据，再保存完整消息库；验证只打开独立副本。"""
@@ -5258,9 +5259,13 @@ class PluginManager:
         workspace = self._workspace / "runtime" / "plugin-update-validation" / identity / "workspace"
         workspace.mkdir(parents=True)
         archive = PluginArchive(workspace / "runtime" / "plugin-archives")
-        self._copy_validation_components(lease.snapshot, workspace, archive)
-        # 图与 receipt 先复制；正常只追加的消息库随后覆盖它们已有的历史引用。
-        self._message_log.backup(workspace / "sessions.db")
+        try:
+            await self._copy_validation_components(lease.snapshot, workspace, archive)
+            # 图与 receipt 先复制；正常只追加的消息库随后覆盖它们已有的历史引用。
+            await _copy_in_thread(self._message_log.backup, workspace / "sessions.db")
+        except BaseException:
+            await _copy_in_thread(_remove_validation_data_dir, workspace.parent)
+            raise
         messages = MessageLog(workspace / "sessions.db")
         try:
             artifacts = ArtifactStore(workspace / "sessions.db")
@@ -5285,7 +5290,7 @@ class PluginManager:
         assert task is not None
         return ValidationHost(identity, workspace, child, messages, artifacts, bus, ExitStack(), task, lease.fork())
 
-    def _copy_validation_components(
+    async def _copy_validation_components(
         self, snapshot: RuntimeSnapshot, workspace: Path, archive: PluginArchive,
     ) -> None:
         """逐项保存声明数据；每个 SQLite 自身一致，不承诺跨文件的共同切点。"""
@@ -5302,12 +5307,12 @@ class PluginManager:
             validate_workspace_plugin_data_path(data_dir, workspace)
             # 日志副本形成后才能知道历史绑定；凭据文件先不进入验证目录。
             excluded = (*_candidate_data_exclude_paths(generation.static_manifest), "config.local.toml")
-            _ = _copy_validation_tree(generation.data_dir, data_dir, excluded)
+            _ = await _copy_in_thread(_copy_validation_tree, generation.data_dir, data_dir, excluded)
         plugins = tuple(cast(ComposablePlugin, item.instance) for item in snapshot.generations.values())
-        self._project_candidate_workspace_roots(plugins, workspace)
-        self._project_candidate_workspace_files(plugins, workspace)
+        await self._project_candidate_workspace_roots(plugins, workspace)
+        await self._project_candidate_workspace_files(plugins, workspace)
 
-    def _copy_validation_bindings(self, host: ValidationHost) -> None:
+    async def _copy_validation_bindings(self, host: ValidationHost) -> None:
         """按消息副本的实际绑定保存历史代码与数据，不从当前安装补齐旧实现。"""
         archive = host.manager._archive
         current = {item.archive_ref for item in host.parent_lease.snapshot.generations.values()}
@@ -5342,13 +5347,13 @@ class PluginManager:
             validate_workspace_plugin_data_path(target, host.workspace)
             excluded = tuple(sorted(exclusions[data]))
             if not target.exists():
-                _ = _copy_validation_tree(source, target, excluded)
+                _ = await _copy_in_thread(_copy_validation_tree, source, target, excluded)
             elif not _candidate_data_path_is_excluded(Path("config.local.toml"), excluded):
                 old_config, new_config = source / "config.local.toml", target / "config.local.toml"
                 if old_config.exists() and not new_config.exists():
                     if old_config.is_symlink() or not old_config.is_file():
                         raise RuntimeError(f"candidate 配置只能复制普通文件: {old_config}")
-                    _ = shutil.copy2(old_config, new_config)
+                    _ = await _copy_in_thread(shutil.copy2, old_config, new_config)
             if ref not in current:
                 # 只读取旧模块声明，不 apply，也不覆盖当前候选已固定的共享数据。
                 with self._archived_generations((ref,), secrets.token_hex(16)) as generations:
@@ -5356,16 +5361,16 @@ class PluginManager:
                     for name in plugin.workspace_roots:
                         old_root = resolve_declared_workspace_root(self._workspace, name)
                         if old_root.exists():
-                            _ = _copy_validation_tree(old_root, host.workspace / name, (), keep_existing=True)
+                            _ = await _copy_in_thread(_copy_validation_tree, old_root, host.workspace / name, (), keep_existing=True)
                     for name in plugin.workspace_files:
                         old_file = resolve_declared_workspace_file(self._workspace, name)
                         new_file = host.workspace / name
                         if old_file.exists() and not new_file.exists():
                             new_file.parent.mkdir(parents=True, exist_ok=True)
                             if _is_sqlite_database(old_file):
-                                _copy_sqlite_snapshot(old_file, new_file)
+                                await _copy_in_thread(_copy_sqlite_snapshot, old_file, new_file)
                             else:
-                                _ = shutil.copy2(old_file, new_file)
+                                _ = await _copy_in_thread(shutil.copy2, old_file, new_file)
 
     async def _copy_validation_artifacts(self, host: ValidationHost) -> None:
         """复制消息副本已引用的不可变文件，读取仍经过正式 Artifact owner 校验。"""
@@ -5377,8 +5382,10 @@ class PluginManager:
                 payload = await lease.read_bytes(max_bytes=record.ref.size_bytes)
                 path = host.workspace / record.storage_key
                 path.parent.mkdir(parents=True, exist_ok=True)
-                with path.open("xb") as output:
-                    _ = output.write(payload)
+                def write_payload() -> None:
+                    with path.open("xb") as output:
+                        _ = output.write(payload)
+                await _copy_in_thread(write_payload)
             finally:
                 await lease.aclose()
 
@@ -6099,11 +6106,11 @@ class PluginManager:
         attempt_workspace = attempt_root / "workspace"
         root._defer_internal_cleanup(  # pyright: ignore[reportPrivateUsage]
             "candidate_attempt_data",
-            lambda: _remove_validation_data_dir(attempt_root),
+            lambda: _copy_in_thread(_remove_validation_data_dir, attempt_root),
         )
         clones: list[tuple[PluginGeneration, ComposablePlugin, Path, object]] = []
         for generation in selected:
-            clone, module_path, data_dir, config = self._clone_candidate_composable(
+            clone, module_path, data_dir, config = await self._clone_candidate_composable(
                 generation,
                 candidate_owner=candidate_owner,
                 attempt_workspace=attempt_workspace,
@@ -6124,11 +6131,11 @@ class PluginManager:
                     f"{generation.plugin_id}"
                 )
             clones.append((generation, clone, data_dir, config))
-        self._project_candidate_workspace_roots(
+        await self._project_candidate_workspace_roots(
             tuple(item[1] for item in clones),
             attempt_workspace,
         )
-        self._project_candidate_workspace_files(
+        await self._project_candidate_workspace_files(
             tuple(item[1] for item in clones),
             attempt_workspace,
         )
@@ -6151,7 +6158,7 @@ class PluginManager:
                 ),
             )
 
-    def _project_candidate_workspace_roots(
+    async def _project_candidate_workspace_roots(
         self,
         plugins: tuple[ComposablePlugin, ...],
         attempt_workspace: Path,
@@ -6168,9 +6175,9 @@ class PluginManager:
             source = resolve_declared_workspace_root(self._workspace, name)
             if not source.exists():
                 continue
-            _ = _copy_validation_tree(source, attempt_workspace / name, ())
+            _ = await _copy_in_thread(_copy_validation_tree, source, attempt_workspace / name, ())
 
-    def _project_candidate_workspace_files(
+    async def _project_candidate_workspace_files(
         self,
         plugins: tuple[ComposablePlugin, ...],
         attempt_workspace: Path,
@@ -6185,11 +6192,11 @@ class PluginManager:
             target = attempt_workspace / name
             target.parent.mkdir(parents=True, exist_ok=True)
             if _is_sqlite_database(source):
-                _copy_sqlite_snapshot(source, target)
+                await _copy_in_thread(_copy_sqlite_snapshot, source, target)
             else:
-                _ = shutil.copy2(source, target)
+                _ = await _copy_in_thread(shutil.copy2, source, target)
 
-    def _clone_candidate_composable(
+    async def _clone_candidate_composable(
         self,
         generation: PluginGeneration,
         *,
@@ -6204,7 +6211,7 @@ class PluginManager:
         plugin_dir = self._archive.open(cast(str, record["code"]))
         data_dir = attempt_workspace / "plugin-data" / generation.data_dir.name
         _ = data_dir.parent.mkdir(parents=True, exist_ok=True)
-        inventory = _copy_validation_tree(
+        inventory = await _copy_in_thread(_copy_validation_tree,
             generation.data_dir,
             data_dir,
             _candidate_data_exclude_paths(generation.static_manifest),
@@ -7628,6 +7635,14 @@ def _validate_candidate_formal_snapshot_identity(
         )
 
 
+async def _copy_in_thread(copy_files: Callable[..., U], *args: Any, **kwargs: Any) -> U:
+    """复制完成后才传播取消，避免清理目录时后台线程仍在写入。"""
+    result, cancelled = await _complete_critical(asyncio.to_thread(copy_files, *args, **kwargs))
+    if cancelled:
+        raise asyncio.CancelledError
+    return result
+
+
 def _copy_validation_tree(
     source: Path,
     target: Path,
@@ -7708,13 +7723,23 @@ def _is_sqlite_database(path: Path) -> bool:
         return stream.read(16) == b"SQLite format 3\x00"
 
 
+_SQLITE_BACKUP_LOCK_TIMEOUT_SECONDS = 5.0
+
+
 def _copy_sqlite_snapshot(source: Path, target: Path) -> None:
     """Copy one transactionally consistent SQLite snapshot."""
 
-    reader = sqlite3.connect(f"file:{source}?mode=ro", uri=True)
-    writer = sqlite3.connect(target)
+    deadline = time.monotonic() + _SQLITE_BACKUP_LOCK_TIMEOUT_SECONDS
+
+    def check_progress(status: int, remaining: int, total: int) -> None:
+        # Chromium 等外部进程可持有独占锁；失败由候选 owner 撤销临时副本。
+        if status in (sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED) and time.monotonic() >= deadline:
+            raise TimeoutError(f"候选 SQLite 备份等待锁超时: {source}")
+
+    reader = sqlite3.connect(source.resolve().as_uri() + "?mode=ro", uri=True, timeout=0.0)
+    writer = sqlite3.connect(target, timeout=0.0)
     try:
-        reader.backup(writer)
+        reader.backup(writer, pages=256, progress=check_progress, sleep=0.05)
     finally:
         writer.close()
         reader.close()

--- a/docs/design/plugin-mcp-hot-reload-cache-drain.md
+++ b/docs/design/plugin-mcp-hot-reload-cache-drain.md
@@ -71,6 +71,14 @@ TLS 只是最稳定的触发器。任何由旧进程延迟读取的解释器文�
 - `PluginManager._on_snapshot_drained()` 只在 snapshot 没有 lease 后处理旧 generation；`PluginScope.aclose()` 逆序执行 cleanup。
 - `McpGenerationHost.prepare()` 把每个 `McpClient.disconnect()` 登记到 generation scope；scope 排空会关闭旧 MCP catalog 和进程。
 
+### 候选数据复制与外部数据库锁
+
+候选准备和显式验证会复制声明的 plugin-data、workspace 文件与目录。文件和 SQLite 复制在线程中完成；Context、RuntimeSnapshotLease、归档模块导入及挂载仍留在所属异步任务。收到取消后先等待复制线程退出，再按原 scope 清理临时副本，不能让线程继续写已被释放的目录。
+
+SQLite 使用只读源连接和 backup API 保存已提交状态；外部进程持续持锁时，在五秒锁等待期限后报告源路径并拒绝候选。失败不会改写原库或提升 stable，也不会通过跳过数据库制造完整副本。业务验证宿主尚未建成时的失败同样清理本次临时目录。
+
+真实独占锁回归及受控线程回归见 `tests/test_plugin_candidate_data.py`：覆盖锁超时、正式数据不变、事件循环继续运行、安装与显式验证取消后才清理副本。
+
 ### 3.3 事故专项证据
 
 `tests/test_plugin_runtime_control.py::test_installed_mcp_update_keeps_old_artifact_until_lease_drains` 已把原来分散的机制接成一个边界回归：

--- a/tests/test_plugin_candidate_data.py
+++ b/tests/test_plugin_candidate_data.py
@@ -70,3 +70,103 @@ async def apply(ctx, config):
             assert writer.execute("SELECT value FROM records").fetchone()[0] == "latest committed"
         finally:
             await host.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_locked_candidate_database_fails_without_changing_stable(tmp_path, monkeypatch):
+    """真实独占锁必须拒绝候选并清理副本，不能挂住 Core 或改写原库。"""
+    import agent.plugins.manager as manager
+
+    source, workspace, home = (tmp_path / name for name in ("source", "workspace", "home"))
+    from tests.test_plugin_business_validation import MODULE
+    _write_v3_plugin(source, name="probe", module_source=MODULE)
+    _commit(source)
+    install_git_plugin(workspace=workspace, source=str(source), marketplace="lab", plugins_home=home)
+    host = PluginManager([], event_bus=EventBus(), workspace=workspace, installed_cache_root=home / "cache")
+    try:
+        await host.load_all()
+        stable = host.current_snapshot
+        path = workspace / "plugin-data/probe-lab/locked.sqlite3"
+        with closing(sqlite3.connect(path)) as writer:
+            writer.execute("CREATE TABLE records(value TEXT)")
+            writer.execute("INSERT INTO records VALUES ('original')")
+            writer.commit()
+            writer.execute("BEGIN EXCLUSIVE")
+            (source / "plugin.py").write_text((source / "plugin.py").read_text() + "\nmarker = 'new'\n")
+            _commit(source)
+            monkeypatch.setattr(manager, "_SQLITE_BACKUP_LOCK_TIMEOUT_SECONDS", 0.0)
+            with pytest.raises(RuntimeError, match="SQLite.*等待锁超时"):
+                await host.install_candidate(source=str(source), marketplace="lab", ref_name="", sparse_paths=[], update_id="locked-copy")
+            assert host.current_snapshot is stable
+            assert host.read_update("locked-copy").phase == "rolled_back"
+            assert not list((workspace / "runtime/plugin-validation").rglob("locked.sqlite3"))
+            assert writer.execute("SELECT value FROM records").fetchall() == [("original",)]
+            writer.rollback()
+    finally:
+        await host.terminate_all()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("phase", ["install", "validation"])
+async def test_candidate_copy_keeps_loop_live_and_finishes_before_cancel_cleanup(tmp_path, monkeypatch, phase):
+    """复制线程未退出时不释放 scope 或删除目录，且事件循环仍可处理其他工作。"""
+    import asyncio
+    import threading
+    import agent.plugins.manager as manager
+    from tests.test_plugin_business_validation import prepare, MODULE
+
+    source, workspace, _, log, host = prepare(tmp_path)
+    entered, release = asyncio.Event(), threading.Event()
+    loop = asyncio.get_running_loop()
+    copied = []
+    real_copy = manager._copy_validation_tree
+
+    def blocked_copy(*args, **kwargs):
+        loop.call_soon_threadsafe(entered.set)
+        if not release.wait(10):
+            raise TimeoutError("test copy was not released by the event loop")
+        value = real_copy(*args, **kwargs)
+        copied.append(args[1])
+        return value
+
+    try:
+        await host.load_all()
+        stable = host.current_snapshot
+        (source / "plugin.py").write_text(MODULE + "\nmarker = 'new'\n")
+        _commit(source)
+        if phase == "validation":
+            result, _ = await host.install_candidate(source=str(source), marketplace="lab", ref_name="", sparse_paths=[])
+
+            async def run():
+                async with host.open_validation(result.update_id):
+                    pytest.fail("cancelled validation entered its body")
+        else:
+            async def run():
+                await host.install_candidate(source=str(source), marketplace="lab", ref_name="", sparse_paths=[])
+        monkeypatch.setattr(manager, "_copy_validation_tree", blocked_copy)
+        task = asyncio.create_task(run())
+        try:
+            await asyncio.wait_for(entered.wait(), 3)
+            # 必须在 worker 仍受阻时执行主循环回调，再取消外层调用。
+            responsive = loop.create_future()
+            loop.call_soon(responsive.set_result, True)
+            assert await responsive
+            task.cancel()
+            cancelled = loop.create_future()
+            loop.call_soon(cancelled.set_result, True)
+            await cancelled
+            assert not task.done()
+            assert not copied
+        finally:
+            release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert copied
+        assert all(not path.exists() for path in copied)
+        assert host.current_snapshot is stable
+        assert host._validation_hosts == {}
+        assert host.latest_snapshot.lease_count == 0
+    finally:
+        release.set()
+        await host.terminate_all()
+        log.close()

--- a/tests/test_plugin_candidate_data.py
+++ b/tests/test_plugin_candidate_data.py
@@ -134,14 +134,15 @@ async def test_candidate_copy_keeps_loop_live_and_finishes_before_cancel_cleanup
         stable = host.current_snapshot
         (source / "plugin.py").write_text(MODULE + "\nmarker = 'new'\n")
         _commit(source)
+        result = None
         if phase == "validation":
             result, _ = await host.install_candidate(source=str(source), marketplace="lab", ref_name="", sparse_paths=[])
 
-            async def run():
+        async def run():
+            if result is not None:
                 async with host.open_validation(result.update_id):
                     pytest.fail("cancelled validation entered its body")
-        else:
-            async def run():
+            else:
                 await host.install_candidate(source=str(source), marketplace="lab", ref_name="", sparse_paths=[])
         monkeypatch.setattr(manager, "_copy_validation_tree", blocked_copy)
         task = asyncio.create_task(run())


### PR DESCRIPTION
## 问题与结果

正式 Calendar 更新在复制 Computer 浏览器资料时等待 Chromium 的 SQLite 独占锁，同步 `backup()` 阻塞 Core 主线程，HTTP 健康检查和控制请求均超时。

将候选准备与显式验证的文件、SQLite 和附件目标写入放到线程中；Context、lease、模块导入与挂载仍在所属异步任务。取消必须等复制线程退出后才清理副本。SQLite 持续锁等待五秒后明确拒绝候选，保留 stable 和正式数据；验证宿主尚未建立时的取消也清理临时目录。关联 #551，后续于 #586 的正式部署验收发现。

## Change intent

- change_type: fix；semantic_delta: compatible
- capability_owner: core；consumer_scope: plugin candidate preparation and explicit validation
- runtime_patch: required；原因：文件复制与 candidate scope 生命周期归 PluginManager，客户端无法解除主线程阻塞。
- authoritative_state_owner: 原插件与 MessageLog；候选只复制其声明状态。
- client_only_alternative: 无；concept_gate: required（异步取消与清理边界）
- protected_state: 正式消息、记忆、plugin-data、凭据和 stable 指针。
- 允许副作用：新建验证副本；失败/取消后删除本次临时副本，恢复候选安装指针。
- 禁止副作用：修改或减少原库、跳过锁定数据库并伪造完整快照。

## 范围与恢复

- manager、现有 candidate data 测试及热更新设计说明；无 schema、配置、公共 API 或插件版本变更。
- base: 44d50d24c90ddaa09fd0af7fe72e3f745b664f29；head: a343801e。
- 恢复：回退本提交；生产原始数据保持原 owner，部署前已有独立恢复包与实际解包校验。

## 验证

- 16 项 candidate data/business validation 测试通过（13.17s）。
- Pyright：0 errors；manager 原有 15 warnings。
- 新回归：真实 BEGIN EXCLUSIVE 锁及时拒绝候选；原数据库未改写且副本已清理；受控线程下事件循环保持可用；install/open_validation 取消等待真实复制退出，scope 与数据随后清理。
- change-impact Gate：最终源码 26 场景通过；报告 `20260910-025707-aeb9d9b4`，plan digest `6fbbb12ab20b2080d4710b428d016b301f7570c84c1a24f60a2459b4660ec8e0`。
- 独立 gpt-5.6-terra / xhigh 概念 Gate：生产实现 de04549a 通过，零未处置 must-fix；后续 a343801e 仅修复测试的函数重复声明，test-project Pyright 0 errors。
- 远端 CI：check-and-test、change-impact-gate 均通过（run 34390659177）。
- 真实服务：44d50d24 上抓取到主线程 reader.backup 堆栈及 HTTP 超时；本补丁已正式部署，实际工具调用与稳定性验收见下方最终回执。

## 工作手册

长期持久语义与 owner 不变；已补充候选数据复制、锁超时和取消清理合同。当前无对应 NOW 条目需要移除。

## 正式部署验收（2026-09-10）

hua-home 已通过正式发布链激活 `4f9173c188a16289f0ac08d786f667e75df185d4`（#590）；运行镜像 revision、进程提交及 Wake/Context 源码哈希与通过 CI 的 tree 一致。

- 连续观察 500.68 秒：Core/Workloads 持续 healthy、零重启、无 OOM，Core 新增 1 次 GitHub 连接重试耗尽 warning，无 error；既有冷却后于 23:26:03 UTC 日志确认 GitHub transport recovered。
- plugin doctor：51 个插件全部 healthy，14 个外部插件；退役安装已卸载，Skill 检查通过。
- 正式 programmatic session `programmatic:pr571-551-final-4f9173c1` 为 learning=excluded。真实 ToolSearch binding 逐项匹配 53 个公开工具；Steam 在线人数、Calendar 日历列表、GitHub Watch runtime info、Scheduler 列表全部成功，整轮 complete。
- Observe 持久游标已追上本轮 E2E；Markdown 的正式 MEMORY +100 / SELF +4 回执、原条目、before-image 和 155 个 Message 引用复核通过。
- 原 17,539 条 Message、325 条 binding、642 条消息绑定与 9 条附件关联逐行哈希保持一致；完整备份已完成恢复核验。
- 公网 WebSocket 实际收到 server.challenge；Host Bridge 与正式服务单元 active。
- Wake 原 100 候选的真实只读模型复验返回 8 个完整有效 ID（总输出 9,628 token）；部署后有效初筛 0 次。最新自然初筛因非法 JSON 参数明确 failure/defer；同批候选只读复验再次选中 8 个有效 ID（总输出 9,148 token）。模型复验未提交决定或发送消息，不作为手机送达证据。窗口后 Telegram 仍有瞬断并自动重试。

Core #571、#586、#587、#588、#589、#590，Calendar #10 和 Fleet #2 均已合并；关联 #551 已关闭。53 项为目录覆盖核验，未执行所有有写入副作用的工具。
