### PR TITLE
修复 Markdown 历史学习与后台模型流式恢复

### DIFF
--- a/docs/design/persistence-state-map.md
+++ b/docs/design/persistence-state-map.md
@@ -621,7 +621,7 @@ Markdown `memory_writes` 保持无自动 retention。回执与 trace 一起包�
 ### 13.1 已存在的局部机制
 
 - Markdown plugin 在 `markdown-profile-writes.db` 中按文档保存 before-image、draft 和 applied receipt，并在启动时前向恢复。
-  学习请求按完整 Turn 的切点分批；历史迁入消息只展示原文正文与已校验的出处角色，不重复投送原始 provider extra 和工具回放。原 Message、摘要来源与学习资格保持不变。每批以当前内存草稿继续，全部批次及来源证据通过后才交给原 writer；失败或取消不写中间档案、不推进 receipt。单个完整 Turn 可以超过 32k token 的批次目标，但不能超过模型窗口预算；无法容纳时明确失败，不裁切原文。
+  学习请求按完整 Turn 的切点分批；历史迁入消息只展示原文正文与已校验的出处角色，不重复投送原始 provider extra 和工具回放。原 Message、摘要来源与学习资格保持不变。模型只返回新增条目的文档、章节、单行正文和实际消息 ID；Markdown owner 保留既有档案，从同一条目生成完整 v2 草稿与证据表，不让模型重复抄写整份档案或改写旧事实。每批以当前内存草稿继续，全部批次及来源证据通过后才交给原 writer；失败或取消不写中间档案、不推进 receipt。单个完整 Turn 可以超过 32k token 的批次目标，但不能超过模型窗口预算；无法容纳时明确失败，不裁切原文。新增条目和模型推理共用输出预算，沿模型声明的生成上限；能力未知时交给 provider 默认值。模型草稿不满足格式或证据合同时，同一批原文与 before-image 只修正一次；连续不合格交回 follower 延时重试。持久草稿损坏和原文解析错误仍明确失败，不转换成模型重试。
 - PENDING 与 PENDING.snapshot 只由一次 legacy migration 读取；原始 bytes/digest 先进入 immutable receipt，并归档到 PENDING.retired 后才清空旧文件。
 - MCP 声明修改前创建历史备份，发布失败自动回滚。
 - 凭据覆盖前保留一个固定名称备份。

--- a/docs/design/persistence-state-map.md
+++ b/docs/design/persistence-state-map.md
@@ -621,6 +621,7 @@ Markdown `memory_writes` 保持无自动 retention。回执与 trace 一起包�
 ### 13.1 已存在的局部机制
 
 - Markdown plugin 在 `markdown-profile-writes.db` 中按文档保存 before-image、draft 和 applied receipt，并在启动时前向恢复。
+  学习请求按完整 Turn 的切点分批；历史迁入消息只展示原文正文与已校验的出处角色，不重复投送原始 provider extra 和工具回放。原 Message、摘要来源与学习资格保持不变。每批以当前内存草稿继续，全部批次及来源证据通过后才交给原 writer；失败或取消不写中间档案、不推进 receipt。单个完整 Turn 可以超过 32k token 的批次目标，但不能超过模型窗口预算；无法容纳时明确失败，不裁切原文。
 - PENDING 与 PENDING.snapshot 只由一次 legacy migration 读取；原始 bytes/digest 先进入 immutable receipt，并归档到 PENDING.retired 后才清空旧文件。
 - MCP 声明修改前创建历史备份，发布失败自动回滚。
 - 凭据覆盖前保留一个固定名称备份。

--- a/docs/design/persistence-state-map.md
+++ b/docs/design/persistence-state-map.md
@@ -308,6 +308,7 @@ workspace 之外还有两组明确的全局状态：
 │   ├── consolidation_writes.db
 │   ├── markdown-profile-writes.db
 │   ├── markdown-profile.lock
+│   ├── markdown-profile-update.lock
 │   ├── memory2.db                     退役经典记忆归档
 │   ├── akasha.db                      akasha engine
 │   ├── MEMORY.bak.md / SELF.bak.md
@@ -621,6 +622,16 @@ Markdown `memory_writes` 保持无自动 retention。回执与 trace 一起包�
 ### 13.1 已存在的局部机制
 
 - Markdown plugin 在 `markdown-profile-writes.db` 中按文档保存 before-image、draft 和 applied receipt，并在启动时前向恢复。
+  `markdown-profile-update.lock` 只串行一次完整更新（选源、模型、提交或启动初始化/恢复）；既有 `markdown-profile.lock` 只保护两份文件的快照读取与安装。writer 总按 update → profile 的顺序取锁，模型等待只持 update，普通回复因此可以读取完整旧档案。两把锁只协调并发，不保存档案事实，不算初始态的持久业务数据。旧文件及 v2 回执不迁移、不减少。
+
+  ```text
+  ┌ 更新锁：同一时刻只有一次档案更新 ────────────────────┐
+  │ 文件锁：读旧档案 → 释放 → 模型分批生成 → 文件锁：提交 │
+  └─────────────────────────────────────────────────────┘
+                          ↑
+              普通回复在生成期间读取旧档案
+  ```
+
   学习请求按完整 Turn 的切点分批；历史迁入消息只展示原文正文与已校验的出处角色，不重复投送原始 provider extra 和工具回放。原 Message、摘要来源与学习资格保持不变。模型只返回新增条目的文档、章节、单行正文和实际消息 ID；Markdown owner 保留既有档案，从同一条目生成完整 v2 草稿与证据表，不让模型重复抄写整份档案或改写旧事实。每批以当前内存草稿继续，全部批次及来源证据通过后才交给原 writer；失败或取消不写中间档案、不推进 receipt。单个完整 Turn 可以超过 32k token 的批次目标，但不能超过模型窗口预算；无法容纳时明确失败，不裁切原文。新增条目和模型推理共用输出预算，沿模型声明的生成上限；能力未知时交给 provider 默认值。模型草稿不满足格式或证据合同时，同一批原文与 before-image 只修正一次；连续不合格交回 follower 延时重试。持久草稿损坏和原文解析错误仍明确失败，不转换成模型重试。
 - PENDING 与 PENDING.snapshot 只由一次 legacy migration 读取；原始 bytes/digest 先进入 immutable receipt，并归档到 PENDING.retired 后才清空旧文件。
 - MCP 声明修改前创建历史备份，发布失败自动回滚。

--- a/plugins/markdown_memory/message_plugin.py
+++ b/plugins/markdown_memory/message_plugin.py
@@ -45,10 +45,12 @@ name = "markdown_memory"
 version = "4.0.0"
 desc = "把已使用摘要的确切原文投影到 MEMORY.md 和 SELF.md"
 inject = (CHAT_MODELS, MATERIALS, BINDINGS, MESSAGE_CATALOG, TURN_PROJECTION)
+_UPDATE_LOCK_NAME = "markdown-profile-update.lock"
 workspace_files = (
     "memory/MEMORY.md", "memory/SELF.md", "memory/markdown-profile-writes.db",
     "memory/markdown-profile.lock", "memory/PENDING.md", "memory/PENDING.snapshot.md",
     "memory/PENDING.retired.md",
+    f"memory/{_UPDATE_LOCK_NAME}",
 )
 
 
@@ -133,11 +135,11 @@ def _profile_batch_size(rows: tuple[tuple[str, ...], ...], memory: str, self_pro
 
 async def prepare_profile_draft(
     groups: tuple[tuple[Message, ...], ...],
-    store: MarkdownProfileStore,
+    before_memory: str,
+    before_self: str,
     chat_models: ChatModels,
 ) -> dict[str, object]:
     """分批核对精确正文；全部成功后才把完整草稿交给原持久 writer。"""
-    before_memory, before_self = store.read_memory(), store.read_self()
     memory, self_profile = before_memory, before_self
     messages = tuple(message for group in groups for message in group)
     rows = tuple(_profile_source_rows(group) for group in groups)
@@ -256,16 +258,17 @@ async def start_store(
 ) -> None:
     """Recover document commits, then retire the old pending queue."""
 
-    async with profile_lock(lock_path):
-        for source_ref in store.pending_source_refs():
-            store.apply_pending(source_ref)
-    await _migrate_pending(
-        store,
-        lock_path,
-        pending_path,
-        snapshot_path,
-        retired_path,
-    )
+    async with profile_lock(lock_path.with_name(_UPDATE_LOCK_NAME)):
+        async with profile_lock(lock_path):
+            for source_ref in store.pending_source_refs():
+                store.apply_pending(source_ref)
+        await _migrate_pending(
+            store,
+            lock_path,
+            pending_path,
+            snapshot_path,
+            retired_path,
+        )
 
 
 async def _migrate_pending(
@@ -581,7 +584,7 @@ def _validate_self(content: str) -> None:
 
 @asynccontextmanager
 async def profile_lock(path: Path, *, create: bool = True) -> AsyncGenerator[None]:
-    """跨 Session 和 generation 串行写档案；取消等待不会遗留持锁线程。"""
+    """按文件名提供跨 Session 和 generation 的排他锁；取消等待不会遗留持锁线程。"""
     if create:
         path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a+b" if create else "rb") as handle:
@@ -652,10 +655,12 @@ async def project(message: Message, *, reader: MessageReader, bindings: Bindings
     if len(refs) != 1:
         raise ValueError("一个 Output 只能声明实际使用的一份摘要")
     reference = check_summary(refs[0]).binding_ids[0]
-    async with profile_lock(lock_path):
-        # 1. 先完成已固定的文件写入；重复 Output 不重新调用模型。
-        for pending in store.pending_source_refs():
-            store.apply_pending(pending)
+    # 1. 更新串行；两文件锁只保护已提交档案的读取和安装，不覆盖模型等待。
+    async with profile_lock(lock_path.with_name(_UPDATE_LOCK_NAME)):
+        async with profile_lock(lock_path):
+            for pending in store.pending_source_refs():
+                store.apply_pending(pending)
+            before_memory, before_self = store.read_memory(), store.read_self()
         async with bindings.open(reference, COMPACTION_SUMMARIES) as (lookup, metadata):
             record = lookup.resolve(metadata, session_id=message.session_id)
             if store.is_applied(record.reference):
@@ -667,16 +672,17 @@ async def project(message: Message, *, reader: MessageReader, bindings: Bindings
             selected = tuple(message for group in groups for message in group)
         # 模型属于当前 Markdown 作用域；先关闭旧摘要的只读归档 scope。
         if draft is None:
-            draft = await prepare_profile_draft(groups, store, models)
+            draft = await prepare_profile_draft(groups, before_memory, before_self, models)
         if draft.get("version") == 2:
             check_evidence(draft, selected)
         elif draft.get("version") != 1:
             raise ValueError("不支持的 Markdown 草稿版本")
-        # model draft 后退出也可能缺 order；用实际摘要身份补齐整份准备再写文件。
-        _ = store.write_draft(record.reference, draft, session_key=record.session_id, generation=record.generation)
-        # 2. 取消前若已留下 draft，下一次沿同一恢复点继续，不重算 before-image。
-        check_draft(draft)
-        store.apply_draft(record.reference, draft)
+        # 2. 读者只会看到完整的旧档案或新档案；两次文件安装与回执在同一短锁内。
+        async with profile_lock(lock_path):
+            _ = store.write_draft(record.reference, draft, session_key=record.session_id, generation=record.generation)
+            # 取消前若已留下 draft，下一次沿同一恢复点继续，不重算 before-image。
+            check_draft(draft)
+            store.apply_draft(record.reference, draft)
 
 
 async def apply(ctx: Context, config: Config) -> None:
@@ -695,7 +701,7 @@ async def apply(ctx: Context, config: Config) -> None:
     async def prepare(snapshot: tuple[Message, ...], source: str) -> Materials:
         # 完整初始态只投影 Store 的同一默认值；不创建文件或消费旧队列。
         state_files = tuple(ctx.workspace_file(name) for name in workspace_files
-                            if name != "memory/markdown-profile.lock")
+                            if not name.endswith(".lock"))
         if not any(path.exists() for path in state_files):
             self_profile, memory = DEFAULT_SELF_MD.strip(), ""
         else:
@@ -753,8 +759,10 @@ async def apply(ctx: Context, config: Config) -> None:
 
     async def start(_event: object) -> None:
         nonlocal store, watcher
-        store = MarkdownProfileStore(ctx.workspace_file("memory/MEMORY.md"), ctx.workspace_file("memory/SELF.md"),
-                                     ctx.workspace_file("memory/markdown-profile-writes.db"))
+        # 首次创建默认档案和 schema 也不能向读者暴露部分初始化。
+        async with profile_lock(lock_path.with_name(_UPDATE_LOCK_NAME)), profile_lock(lock_path):
+            store = MarkdownProfileStore(ctx.workspace_file("memory/MEMORY.md"), ctx.workspace_file("memory/SELF.md"),
+                                         ctx.workspace_file("memory/markdown-profile-writes.db"))
         await start_store(store, lock_path, ctx.workspace_file("memory/PENDING.md"),
                            ctx.workspace_file("memory/PENDING.snapshot.md"), ctx.workspace_file("memory/PENDING.retired.md"))
         watcher = await ctx.spawn(follow(ctx.require(MESSAGE_CATALOG)), name="markdown-memory")

--- a/plugins/markdown_memory/message_plugin.py
+++ b/plugins/markdown_memory/message_plugin.py
@@ -8,7 +8,8 @@ import json
 import logging
 from contextlib import aclosing, asynccontextmanager
 from pathlib import Path
-from typing import AsyncGenerator
+from dataclasses import replace
+from typing import AsyncGenerator, cast
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -22,18 +23,18 @@ from agent.plugin_composition import (
 )
 from agent.plugin_composition.bindings import BINDINGS, Bindings
 from agent.plugin_composition.messages import MESSAGE_CATALOG
-from agent.plugin_composition.models import ChatModels, ModelError
+from agent.plugin_composition.models import BoundChatModel, ChatModels, ContextLengthError, ModelError
 from agent.llm_json import load_json_object_loose
 from agent.turn_effects import PostCommitEffect
 from infra.persistence.json_store import atomic_write_text
 from plugins.compaction.records import COMPACTION_SUMMARIES, SummaryLookup, StoredSummary
-from plugins.compaction.message_summary import source_text, summary_groups
+from plugins.compaction.message_summary import source_text, summary_groups, window_starts
 from plugins.content.api import is_user_input, legacy_post_commit_effect
 from plugins.context.api import Materials, check_summary, summary_range
 from plugins.context.materials import MATERIALS
 from plugins.turn_projection.plugin import TURN_PROJECTION, TurnProjection
 from session.log import MessageCatalog, MessageReader
-from session.message import ContentPart, Input, Message, Output
+from session.message import ContentPart, Input, Message, Output, ToolResult
 
 from .store import DEFAULT_SELF_MD, MEMORY_WRITES, MarkdownProfileStore, content_digest
 
@@ -71,25 +72,103 @@ class Config(BaseModel):
     sources: tuple[str, ...] = Field(default=("conversation", "programmatic", "legacy-unattributed"), min_length=1)
 
 
+def _profile_source_rows(messages: tuple[Message, ...]) -> tuple[str, ...]:
+    """正文逐字保留；历史回放与原始 extra 不重复投送，证据仍核对完整 Message。"""
+    rows: list[str] = []
+    for message in messages:
+        # 1. 只缩小本次模型展示，不改变日志、摘要来源或证据资格。
+        if isinstance(message.body, (Input, Output, ToolResult)):
+            body = replace(message.body, parts=tuple(
+                part for part in message.body.parts
+                if not isinstance(part, ContentPart) or part.kind not in {
+                    "history.transcript", "history.record", "history.turn_input",
+                }
+            ))
+            message_view = replace(message, body=body)
+        else:
+            message_view = message
+        row = json.loads(source_text((message_view,)))[0]
+        for part in row["body"].get("parts", []):
+            if part["kind"] == "history.provenance":
+                provenance = part["value"]
+                part["value"] = {key: provenance[key] for key in ("schema", "role")}
+        rows.append(json.dumps(row, ensure_ascii=False, separators=(",", ":")))
+    return tuple(rows)
+
+
+def _profile_batch_size(rows: tuple[tuple[str, ...], ...], memory: str, self_profile: str,
+                        provider: BoundChatModel) -> int:
+    """按完整 Turn 前缀估算分批；原文不截断，仍须满足模型窗口。"""
+    window = provider.descriptor.capabilities.context_window
+    if window is None:
+        raise ValueError("Markdown 模型缺少已确认的 context_window")
+    hard_limit = int(window * 0.74)
+    # 2. 每批限制待核对证据量，避免超长历史再次形成巨大请求体。
+    limit = min(32_768, hard_limit)
+
+    def tokens(size: int) -> int:
+        prompt = _profile_prompt(memory, self_profile, "[" + ",".join(row for group in rows[:size] for row in group) + "]")
+        return provider.estimate_context_tokens([{"role": "user", "content": prompt}])
+
+    if tokens(1) > hard_limit:
+        raise ContextLengthError("Markdown 完整 Turn 和现有档案超出模型窗口，未减少原文")
+    low, high = 1, len(rows)
+    while low < high:
+        middle = (low + high + 1) // 2
+        if tokens(middle) <= limit:
+            low = middle
+        else:
+            high = middle - 1
+    return low
+
+
 async def prepare_profile_draft(
-    messages: tuple[Message, ...],
+    groups: tuple[tuple[Message, ...], ...],
     store: MarkdownProfileStore,
     chat_models: ChatModels,
 ) -> dict[str, object]:
-    """按真实消息准备完整档案及逐条证据，验证后才交给持久 writer。"""
-    current_memory = store.read_memory()
-    current_self = store.read_self()
-    prompt = _profile_prompt(current_memory, current_self, source_text(messages))
+    """分批核对精确正文；全部成功后才把完整草稿交给原持久 writer。"""
+    before_memory, before_self = store.read_memory(), store.read_self()
+    memory, self_profile = before_memory, before_self
+    messages = tuple(message for group in groups for message in group)
+    rows = tuple(_profile_source_rows(group) for group in groups)
+    evidence: dict[str, dict[str, list[str]]] = {"memory": {}, "self": {}}
+    offset = 0
     async with chat_models.independent_execution() as execution:
         provider = execution.chat(ModelRole.DEFAULT)
-        output_cap = provider.descriptor.capabilities.max_output_tokens or 4_096
-        response = await provider.complete(
-            ModelRequest(
-                messages=[{"role": "user", "content": prompt}],
-                max_output_tokens=min(4_096, output_cap),
-                disable_reasoning=True,
-            )
-        )
+        while offset < len(groups):
+            size = _profile_batch_size(rows[offset:], memory, self_profile, provider)
+            source = "[" + ",".join(row for group in rows[offset:offset + size] for row in group) + "]"
+            selected = tuple(message for group in groups[offset:offset + size] for message in group)
+            batch = await _prepare_profile_batch(selected, source, memory, self_profile, provider)
+            memory, self_profile = cast(str, batch["memory"]), cast(str, batch["self"])
+            batch_evidence = cast(dict[str, dict[str, list[str]]], batch["evidence"])
+            for document in evidence:
+                if evidence[document].keys() & batch_evidence[document].keys():
+                    raise ValueError("Markdown 跨批新增条目重复，不能覆盖已有证据")
+                evidence[document].update(batch_evidence[document])
+            offset += size
+    # 3. 中间结果只在内存；失败重试仍从同一 before-image 开始。
+    draft: dict[str, object] = {
+        "version": 2, "evidence": evidence, "memory": memory, "self": self_profile,
+        "memory_before": before_memory, "self_before": before_self,
+        "memory_before_digest": content_digest(before_memory), "self_before_digest": content_digest(before_self),
+        "memory_after_digest": content_digest(memory), "self_after_digest": content_digest(self_profile),
+    }
+    check_evidence(draft, messages)
+    return draft
+
+
+async def _prepare_profile_batch(messages: tuple[Message, ...], source: str,
+                                 current_memory: str, current_self: str,
+                                 provider: BoundChatModel) -> dict[str, object]:
+    """校验一批新增事实与当前内存档案，不写文件或推进 receipt。"""
+    prompt = _profile_prompt(current_memory, current_self, source)
+    output_cap = provider.descriptor.capabilities.max_output_tokens or 4_096
+    response = await provider.complete(ModelRequest(
+        messages=[{"role": "user", "content": prompt}],
+        max_output_tokens=min(4_096, output_cap), disable_reasoning=True,
+    ))
     raw = load_json_object_loose(response.content or "")
     if not isinstance(raw, dict):
         raise ValueError("Markdown memory 模型必须返回 JSON object")
@@ -313,7 +392,8 @@ def _profile_prompt(memory: str, self_profile: str, source: str) -> str:
 
 只返回 JSON：{{"memory":"完整 MEMORY.md", "self":"完整 SELF.md", "evidence":{{"memory":{{"新增完整条目":["message_id"]}},"self":{{"新增完整条目":["message_id"]}}}}}}。
 
-新增内容必须是单行 Markdown 条目，每项引用本次来源中的真实 message_id。
+新增内容必须是单行 Markdown 条目，每项引用本次来源中的真实 message_id。现有条目及章节位置逐字保留。
+来源中的 history.provenance 只展示已校验的 schema 和 role；原始 extra 和历史工具回放不作为本次学习正文。
 用户事实、偏好、明确要求和 SELF 中对用户或关系的判断，只能以真实用户 Input 原文为依据：当前消息的 author=user；迁入旧消息须有 history.provenance 中 schema=sessions.messages.v0、role=user 的原始出处。
 助手转述、工具输出、后台报告、召回和摘要都不能代替用户的原话；即使助手把它重复成结论也不行。
 助手操作上下文和自身人格变化可以引用其他实际消息，但不得借这些章节存放用户资料。
@@ -468,10 +548,10 @@ async def profile_lock(path: Path, *, create: bool = True) -> AsyncGenerator[Non
             fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
-async def _unapplied_messages(record: StoredSummary, lookup: SummaryLookup, reader: MessageReader,
+async def _unapplied_groups(record: StoredSummary, lookup: SummaryLookup, reader: MessageReader,
                         store: MarkdownProfileStore, sources: tuple[str, ...],
-                        projection: TurnProjection) -> tuple[Message, ...] | None:
-    """从最近已写入的祖先之后取原文，跳过未使用的摘要不会漏掉它覆盖的事实。"""
+                        projection: TurnProjection) -> tuple[tuple[Message, ...], ...] | None:
+    """从最近已写入的祖先之后取完整组的原文，跳过未使用的摘要不会漏掉它覆盖的事实。"""
     start = 0
     latest = store.latest_applied(record.session_id)
     if latest is not None:
@@ -500,10 +580,14 @@ async def _unapplied_messages(record: StoredSummary, lookup: SummaryLookup, read
             effects = tuple(legacy_post_commit_effect(by_id[identity]) for identity in ids)
             if PostCommitEffect.SUPPRESS in effects:
                 excluded.update(ids)
-    selected = tuple(message for message in snapshot[covered.start + start:covered.stop]
-                     if message.source in sources and message.message_id not in excluded)
-    # 摘要使用了哪些原始 ID 不等于每条原文都可沉淀；迟到结果沿同一放弃边界排除。
-    return tuple(message for group in summary_groups((selected,), snapshot[:covered.stop]) for message in group)
+    after = covered.start + start
+    cuts = (after, *(index for index in window_starts(snapshot[:covered.stop], projection) if index > after), covered.stop)
+    groups = tuple(snapshot[left:right] for left, right in zip(cuts, cuts[1:]))
+    selected = tuple(tuple(message for message in group
+                           if message.source in sources and message.message_id not in excluded)
+                     for group in groups)
+    # 批次切点来自完整前缀；学习资格与迟到结果沿原 source/放弃边界过滤。
+    return summary_groups(selected, snapshot[:covered.stop])
 
 
 async def project(message: Message, *, reader: MessageReader, bindings: Bindings,
@@ -527,12 +611,13 @@ async def project(message: Message, *, reader: MessageReader, bindings: Bindings
             if store.is_applied(record.reference):
                 return
             draft = store.read_draft(record.reference)
-            selected = await _unapplied_messages(record, lookup, reader, store, sources, projection)
-            if not selected:
+            groups = await _unapplied_groups(record, lookup, reader, store, sources, projection)
+            if not groups:
                 return
+            selected = tuple(message for group in groups for message in group)
         # 模型属于当前 Markdown 作用域；先关闭旧摘要的只读归档 scope。
         if draft is None:
-            draft = await prepare_profile_draft(selected, store, models)
+            draft = await prepare_profile_draft(groups, store, models)
         if draft.get("version") == 2:
             check_evidence(draft, selected)
         elif draft.get("version") != 1:

--- a/plugins/markdown_memory/message_plugin.py
+++ b/plugins/markdown_memory/message_plugin.py
@@ -23,7 +23,7 @@ from agent.plugin_composition import (
 )
 from agent.plugin_composition.bindings import BINDINGS, Bindings
 from agent.plugin_composition.messages import MESSAGE_CATALOG
-from agent.plugin_composition.models import BoundChatModel, ChatModels, ContextLengthError, ModelError
+from agent.plugin_composition.models import BoundChatModel, ChatModels, ContextLengthError, LLMResponse, ModelError
 from agent.llm_json import load_json_object_loose
 from agent.turn_effects import PostCommitEffect
 from infra.persistence.json_store import atomic_write_text
@@ -70,6 +70,15 @@ _SELF_HEADINGS = (
 class Config(BaseModel):
     model_config = ConfigDict(extra="forbid")
     sources: tuple[str, ...] = Field(default=("conversation", "programmatic", "legacy-unattributed"), min_length=1)
+
+
+class _InvalidDraft(ValueError):
+    """档案自身的合同拒绝；原文或持久状态错误不属于模型重试。"""
+
+
+class ProfileDraftError(ModelError):
+    """外部模型连续提交了不合格草稿；保留回执边界供 follower 重试。"""
+    retryable = True
 
 
 def _profile_source_rows(messages: tuple[Message, ...]) -> tuple[str, ...]:
@@ -164,29 +173,65 @@ async def _prepare_profile_batch(messages: tuple[Message, ...], source: str,
                                  provider: BoundChatModel) -> dict[str, object]:
     """校验一批新增事实与当前内存档案，不写文件或推进 receipt。"""
     prompt = _profile_prompt(current_memory, current_self, source)
-    output_cap = provider.descriptor.capabilities.max_output_tokens or 4_096
-    response = await provider.complete(ModelRequest(
-        messages=[{"role": "user", "content": prompt}],
-        max_output_tokens=min(4_096, output_cap), disable_reasoning=True,
-    ))
+    # 新增条目与模型推理共享输出预算，采用 provider 已声明的生成上限。
+    output_cap = provider.descriptor.capabilities.max_output_tokens or 0
+    repaired = False
+    while True:
+        response = await provider.complete(ModelRequest(
+            messages=[{"role": "user", "content": prompt}],
+            max_output_tokens=output_cap, disable_reasoning=True,
+        ))
+        try:
+            return _check_profile_response(response, messages, current_memory, current_self)
+        except _InvalidDraft as error:
+            if repaired:
+                raise ProfileDraftError(str(error)) from error
+            # 原草稿没有提交；只反馈合同错误，不补写模型猜错的证据或消息 ID。
+            logger.warning("Markdown 模型草稿不合格，本批修正一次: %s", error)
+            prompt = "上次草稿没有提交，校验失败：" + str(error)
+            prompt += "\n重新生成新增条目；message_id 从本次来源逐字符完整复制，不缩写、不猜测。\n\n"
+            prompt += _profile_prompt(current_memory, current_self, source)
+            repaired = True
+
+
+def _check_profile_response(response: LLMResponse, messages: tuple[Message, ...],
+                            current_memory: str, current_self: str) -> dict[str, object]:
+    """只验证模型草稿；原始 Message 的解析错误保持原异常。"""
+    if response.finish_reason == "length":
+        raise _InvalidDraft("模型输出达到生成上限，草稿尚未完整")
     raw = load_json_object_loose(response.content or "")
     if not isinstance(raw, dict):
-        raise ValueError("Markdown memory 模型必须返回 JSON object")
-    memory = raw.get("memory")
-    self_profile = raw.get("self")
-    if not isinstance(memory, str) or not isinstance(self_profile, str):
-        raise ValueError("Markdown memory 模型缺少 memory/self 字符串")
-    memory = memory.strip()
-    self_profile = self_profile.strip() + "\n"
-    if memory:
-        memory += "\n"
-    _validate_memory(memory)
-    _validate_self(self_profile)
-    _validate_preserved_bullets(current_memory, memory, document="MEMORY.md")
-    _validate_preserved_bullets(current_self, self_profile, document="SELF.md")
+        raise _InvalidDraft("Markdown memory 模型必须返回 JSON object")
+    additions = raw.get("additions")
+    if set(raw) != {"additions"} or not isinstance(additions, list):
+        raise _InvalidDraft("Markdown 模型必须只返回 additions 数组")
+    documents = {"memory": current_memory, "self": current_self}
+    evidence: dict[str, dict[str, list[str]]] = {"memory": {}, "self": {}}
+    # 1. 外部响应只表达一次条目与出处，完整档案和 evidence 由同一 owner 生成。
+    for addition in additions:
+        if not isinstance(addition, dict) or set(addition) != {"document", "section", "line", "message_ids"}:
+            raise _InvalidDraft("新增条目必须包含 document、section、line、message_ids")
+        document, section, line, ids = (addition[key] for key in ("document", "section", "line", "message_ids"))
+        if not isinstance(document, str) or document not in documents:
+            raise _InvalidDraft("新增条目 document 必须是 memory 或 self")
+        headings = (*_MEMORY_HEADINGS[1:], _MEMORY_OPTIONAL_HEADING) if document == "memory" else _SELF_HEADINGS[1:]
+        if not isinstance(section, str) or section not in headings:
+            raise _InvalidDraft("新增条目 section 必须是目标档案允许的完整二级标题")
+        if not isinstance(line, str) or not line.startswith("- ") or line.strip() != line or len(line.splitlines()) != 1:
+            raise _InvalidDraft("新增条目 line 必须是以 '- ' 开头的完整单行条目")
+        if not isinstance(ids, list) or not ids or any(not isinstance(identity, str) for identity in ids):
+            raise _InvalidDraft("新增条目 message_ids 必须是非空消息 ID 数组")
+        content = documents[document]
+        if line in content.splitlines():
+            raise _InvalidDraft("additions 不得重复已有条目或本批新增条目")
+        if document == "memory" and not content:
+            content = "\n\n".join(_MEMORY_HEADINGS) + "\n"
+        documents[document] = _append_section_lines(content, section, [line])
+        evidence[document][line] = ids
+    memory, self_profile = documents["memory"], documents["self"]
     draft: dict[str, object] = {
         "version": 2,
-        "evidence": raw.get("evidence"),
+        "evidence": evidence,
         "memory": memory,
         "self": self_profile,
         "memory_before": current_memory,
@@ -196,6 +241,8 @@ async def _prepare_profile_batch(messages: tuple[Message, ...], source: str,
         "memory_after_digest": content_digest(memory),
         "self_after_digest": content_digest(self_profile),
     }
+    # 2. 持久草稿沿原结构、保留和来源资格检查；不接受模型自报的用户身份。
+    check_draft(draft)
     check_evidence(draft, messages)
     return draft
 
@@ -388,11 +435,14 @@ def _append_section_lines(content: str, heading: str, lines: list[str]) -> str:
 
 
 def _profile_prompt(memory: str, self_profile: str, source: str) -> str:
-    return f"""你维护两个长期 Markdown 档案。根据本次已提交的精确对话事实，返回完整的新档案。
+    return f"""你维护两个长期 Markdown 档案。根据本次已提交的精确对话事实，只返回需要新增的条目。
 
-只返回 JSON：{{"memory":"完整 MEMORY.md", "self":"完整 SELF.md", "evidence":{{"memory":{{"新增完整条目":["message_id"]}},"self":{{"新增完整条目":["message_id"]}}}}}}。
+只返回 JSON：{{"additions":[{{"document":"memory", "section":"## 用户事实", "line":"- 新增事实", "message_ids":["完整 message_id"]}}]}}。
+没有合格的新事实时返回 {{"additions":[]}}。当前档案是只读的；不要重写、修订、移动或重复已有条目。每个新增条目只返回一次。
+document 只能是 memory 或 self。memory 的 section 只能是 ## 用户事实、## 用户偏好、## 用户明确要求长期记住的关键内容、## 助手操作上下文；self 的 section 只能是 ## 人格与形象、## 我对当前用户的理解、## 我们关系的定义。
 
-新增内容必须是单行 Markdown 条目，每项引用本次来源中的真实 message_id。现有条目及章节位置逐字保留。
+新增内容必须是单行 Markdown 条目，每项引用本次来源中的真实 message_id。message_id 须逐字符完整复制，包括前缀和全部尾部，不缩写、不猜测。
+line 必须包含开头的 '- '，条目正文与出处只在这一项中出现，不另写 evidence 或完整档案。
 来源中的 history.provenance 只展示已校验的 schema 和 role；原始 extra 和历史工具回放不作为本次学习正文。
 用户事实、偏好、明确要求和 SELF 中对用户或关系的判断，只能以真实用户 Input 原文为依据：当前消息的 author=user；迁入旧消息须有 history.provenance 中 schema=sessions.messages.v0、role=user 的原始出处。
 助手转述、工具输出、后台报告、召回和摘要都不能代替用户的原话；即使助手把它重复成结论也不行。
@@ -423,7 +473,7 @@ def check_draft(payload: dict[str, object]) -> None:
         isinstance(value, str)
         for value in (memory, self_profile, memory_before, self_before)
     ):
-        raise ValueError("Markdown profile draft schema 无效")
+        raise _InvalidDraft("Markdown profile draft schema 无效")
     assert isinstance(memory, str)
     assert isinstance(self_profile, str)
     assert isinstance(memory_before, str)
@@ -440,7 +490,7 @@ def check_evidence(draft: dict[str, object], messages: tuple[Message, ...]) -> N
     by_id = {item.message_id: item for item in messages}
     evidence = draft.get("evidence")
     if not isinstance(evidence, dict) or set(evidence) != {"memory", "self"}:
-        raise ValueError("Markdown 新条目缺少 evidence")
+        raise _InvalidDraft("Markdown 新条目缺少 evidence")
     for document in ("memory", "self"):
         before, after = draft[document + "_before"], draft[document]
         assert isinstance(before, str) and isinstance(after, str)
@@ -454,7 +504,7 @@ def check_evidence(draft: dict[str, object], messages: tuple[Message, ...]) -> N
                 old_lines.add((old_heading, line))
         cited = evidence[document]
         if not isinstance(cited, dict):
-            raise ValueError("Markdown evidence 必须按完整条目列出消息 ID")
+            raise _InvalidDraft("Markdown evidence 必须按完整条目列出消息 ID")
         added: set[str] = set()
         heading = ""
         for line in after.splitlines():
@@ -466,19 +516,19 @@ def check_evidence(draft: dict[str, object], messages: tuple[Message, ...]) -> N
                 continue
             # 2. 不允许用段落或换行绕开按条目的证据检查。
             if not line.startswith("- "):
-                raise ValueError("Markdown 新内容必须是单行条目")
+                raise _InvalidDraft("Markdown 新内容必须是单行条目")
             added.add(line)
             ids = cited.get(line)
             if not isinstance(ids, list) or not ids or any(not isinstance(key, str) or key not in by_id for key in ids):
-                raise ValueError("Markdown 条目必须引用本次实际消息")
+                raise _InvalidDraft("Markdown 条目必须引用本次实际消息")
             user_fact = (document == "memory" and heading != _MEMORY_OPTIONAL_HEADING
                          or document == "self" and heading in _SELF_HEADINGS[2:])
             if user_fact and not any(
                 is_user_input(by_id[key]) for key in ids
             ):
-                raise ValueError("用户事实必须引用真实用户 Input，不能仅引用助手或后台结果")
+                raise _InvalidDraft("用户事实必须引用真实用户 Input，不能仅引用助手或后台结果")
         if set(cited) != added:
-            raise ValueError("Markdown evidence 必须与新增条目一一对应")
+            raise _InvalidDraft("Markdown evidence 必须与新增条目一一对应")
 
 
 def _validate_preserved_bullets(before: str, after: str, *, document: str) -> None:
@@ -492,7 +542,7 @@ def _validate_preserved_bullets(before: str, after: str, *, document: str) -> No
     }
     removed = sorted(old_facts - new_facts)
     if removed:
-        raise ValueError(f"{document} 不得隐式删除既有事实: {removed}")
+        raise _InvalidDraft(f"{document} 不得隐式删除既有事实: {removed}")
 
 
 def _headings(content: str) -> tuple[str, ...]:
@@ -511,22 +561,22 @@ def _validate_memory(content: str) -> None:
         _MEMORY_HEADINGS,
         _MEMORY_HEADINGS + (_MEMORY_OPTIONAL_HEADING,),
     } or "```" in content:
-        raise ValueError("MEMORY.md 模型输出格式无效")
+        raise _InvalidDraft("MEMORY.md 模型输出格式无效")
     if not any(line.lstrip().startswith("- ") for line in content.splitlines()):
-        raise ValueError("MEMORY.md 模型输出不包含记忆条目")
+        raise _InvalidDraft("MEMORY.md 模型输出不包含记忆条目")
 
 
 def _validate_self(content: str) -> None:
     lines = content.splitlines()
     if _headings(content) != _SELF_HEADINGS or "```" in content:
-        raise ValueError("SELF.md 模型输出格式无效")
+        raise _InvalidDraft("SELF.md 模型输出格式无效")
     positions = [lines.index(heading) for heading in _SELF_HEADINGS] + [len(lines)]
     for index in range(1, len(_SELF_HEADINGS)):
         if not any(
             line.lstrip().startswith("- ")
             for line in lines[positions[index] + 1 : positions[index + 1]]
         ):
-            raise ValueError(f"SELF.md section 为空: {_SELF_HEADINGS[index]}")
+            raise _InvalidDraft(f"SELF.md section 为空: {_SELF_HEADINGS[index]}")
 
 
 @asynccontextmanager

--- a/plugins/openai_compatible/driver.py
+++ b/plugins/openai_compatible/driver.py
@@ -114,7 +114,7 @@ class _BoundChat:
                 "OpenAI-compatible Chat Completions does not support continuation state"
             )
         body = _chat_body(self._descriptor, self._connection, self._config, request)
-        if request.on_delta is None:
+        if request.on_delta is None and not _is_deepseek_v4(self._descriptor.model):
             payload = await _request_json(
                 self._connection,
                 self._credential,
@@ -124,6 +124,7 @@ class _BoundChat:
                 http=self._http,
             )
             return _parse_chat_response(payload)
+        # V4 长生成可能超过网关非流式等待窗口；无观察者时也完整聚合 SSE。
         body["stream"] = True
         body["stream_options"] = {"include_usage": True}
         return await _stream_chat(
@@ -401,6 +402,10 @@ def _model_config(config: Mapping[str, Any]) -> _ModelConfig:
     )
 
 
+def _is_deepseek_v4(model: str) -> bool:
+    return model.rsplit("/", 1)[-1].lower().startswith("deepseek-v4-")
+
+
 def _chat_body(
     descriptor: BoundModelDescriptor,
     connection: _ConnectionConfig,
@@ -425,6 +430,8 @@ def _chat_body(
     if request.disable_reasoning:
         for key in ("enable_thinking", "thinking", "reasoning_effort"):
             body.pop(key, None)
+        if _is_deepseek_v4(descriptor.model):
+            body["thinking"] = {"type": "disabled"}
     return body
 
 
@@ -563,7 +570,7 @@ async def _stream_chat(
     connection: _ConnectionConfig,
     credential: CredentialHandle,
     body: Mapping[str, Any],
-    on_delta: Callable[[dict[str, str]], Awaitable[None]],
+    on_delta: Callable[[dict[str, str]], Awaitable[None]] | None,
     http: HttpClient,
 ) -> LLMResponse:
     last_error: Exception | None = None
@@ -590,7 +597,10 @@ async def _stream_chat(
             mapped = _map_error(error)
             if mapped is error and not isinstance(error, ModelError):
                 raise
-            response_delta_seen = bool(getattr(error, "response_delta_seen", False))
+            # 无观察者时尚未交付任何结果，断流仍可从原请求重试。
+            response_delta_seen = on_delta is not None and bool(getattr(error, "response_delta_seen", False))
+            if on_delta is None and isinstance(error, _StreamReadError) and isinstance(mapped, TransportError):
+                setattr(mapped, "retry_safe", True)
             if response_delta_seen:
                 setattr(mapped, "retryable", False)
             if (
@@ -619,7 +629,7 @@ class _CallbackError(RuntimeError):
 
 async def _consume_stream(
     response: httpx.Response,
-    on_delta: Callable[[dict[str, str]], Awaitable[None]],
+    on_delta: Callable[[dict[str, str]], Awaitable[None]] | None,
 ) -> LLMResponse:
     content: list[str] = []
     thinking: list[str] = []
@@ -740,9 +750,11 @@ async def _consume_stream(
 
 
 async def _emit_delta(
-    on_delta: Callable[[dict[str, str]], Awaitable[None]],
+    on_delta: Callable[[dict[str, str]], Awaitable[None]] | None,
     delta: dict[str, str],
 ) -> None:
+    if on_delta is None:
+        return
     try:
         await on_delta(delta)
     except asyncio.CancelledError:

--- a/tests/test_builtin_system.py
+++ b/tests/test_builtin_system.py
@@ -52,19 +52,14 @@ class ScriptedModel:
             return self.text_response(body, "\n".join(headings) + "\nPREFERENCE:用户喜欢青绿色。")
         if "本次精确来源：" in serialized:
             self.profile_requests.append(body)
-            memory = self.root / "workspace/memory/MEMORY.md"
-            existing = memory.read_text() if memory.exists() else ""
-            if not existing.strip():
-                existing = "# 用户长期记忆\n## 用户事实\n## 用户偏好\n## 用户明确要求长期记住的关键内容\n"
-            text = existing if "用户喜欢青绿色" in existing else existing + "\n- 用户喜欢青绿色。\n"
+            existing = messages[0]["content"].split("当前 MEMORY.md：\n", 1)[1].split("\n\n当前 SELF.md：", 1)[0]
             source = json.loads(messages[0]["content"].split("本次精确来源：\n", 1)[1])
-            evidence = {} if text == existing else {"- 用户喜欢青绿色。": [
+            additions = [] if "用户喜欢青绿色" in existing else [{
+                "document": "memory", "section": "## 用户偏好", "line": "- 用户喜欢青绿色。", "message_ids": [
                 row["message_id"] for row in source if row["author"] == "user"
                 and row["body"]["kind"] == "input" and "用户喜欢青绿色" in json.dumps(row, ensure_ascii=False)
-            ]}
-            return self.text_response(body, json.dumps({"memory": text,
-                "self": (self.root / "workspace/memory/SELF.md").read_text(),
-                "evidence": {"memory": evidence, "self": {}}}, ensure_ascii=False))
+            ]}]
+            return self.text_response(body, json.dumps({"additions": additions}, ensure_ascii=False))
         for message in reversed(messages):
             if message["role"] != "user":
                 continue

--- a/tests/test_message_markdown_memory.py
+++ b/tests/test_message_markdown_memory.py
@@ -22,7 +22,7 @@ from session.message import ContentPart, Input, Output
 
 
 @asynccontextmanager
-async def application(tmp_path, *, start=False, transient_failure=False):
+async def application(tmp_path, *, start=False, transient_failure=False, draft_failures=0):
     sources = tmp_path / "plugins"
     if not sources.exists():
         for name in ("context", "compaction", "markdown_memory", "turn_projection"):
@@ -79,8 +79,9 @@ async def apply(ctx, config):
             evidence = {line: [row["message_id"] for row in source if user_input(row) and line[2:] in json.dumps(row)]
                         for line in memory.splitlines() if line.startswith("- ") and line not in previous.splitlines()}
             completed.set()
-            return LLMResponse(json.dumps({"memory": memory, "self": (root / "workspace/memory/SELF.md").read_text(),
-                                           "evidence": {"memory": evidence, "self": {}}}))
+            return LLMResponse(json.dumps({"additions": [
+                {"document": "memory", "section": "## 用户明确要求长期记住的关键内容", "line": line, "message_ids": ids}
+                for line, ids in evidence.items()]}))
     descriptor = BoundModelDescriptor(
         binding_id="fixture", plugin_snapshot_id="fixture", model_revision=0,
         model_id="fixture", connection_id="fixture", driver_id="fixture", driver_contract_version="1",
@@ -97,7 +98,15 @@ async def apply(ctx, config):
     await ctx.provide(CHAT_MODELS, Models())
     await ctx.provide(ServiceKey("fixture.profile_response"), completed)
 '''.replace("TEST_ROOT", repr(str(tmp_path))))
-    if transient_failure:
+    if draft_failures:
+        fixture = sources / "fixture_models/plugin.py"
+        fixture.write_text(fixture.read_text().replace("    completed = asyncio.Event()",
+            "    completed = asyncio.Event()\n    attempts = 0").replace(
+            "        async def complete(self, request):",
+            "        async def complete(self, request):\n            nonlocal attempts\n            attempts += 1").replace(
+            "            completed.set()",
+            f"            if attempts <= {draft_failures}:\n                evidence = {{line: [identity[:12] for identity in ids] for line, ids in evidence.items()}}\n            completed.set()"))
+    if transient_failure or draft_failures > 1:
         # 仅测试副本用事件控制重试等待，不修改全局 asyncio 时序。
         module = sources / "markdown_memory/message_plugin.py"
         module.write_text(module.read_text().replace("await asyncio.sleep(30)",
@@ -110,6 +119,19 @@ async def apply(ctx, config):
             '            if not failed.is_set():\n                failed.set()\n                from agent.plugin_composition.models import TransportError\n                raise TransportError("temporary fixture failure")\n            memory = (root / "workspace/memory/MEMORY.md").read_text()').replace(
             '    await ctx.provide(CHAT_MODELS, Models())',
             '    await ctx.provide(ServiceKey("fixture.retry_failed"), failed)\n    await ctx.provide(ServiceKey("fixture.retry_release"), release)\n    await ctx.provide(CHAT_MODELS, Models())'))
+    if draft_failures > 1:
+        fixture = sources / "fixture_models/plugin.py"
+        text = fixture.read_text()
+        start = text.index("            if not failed.is_set():")
+        end = text.index('            memory = (root / "workspace/memory/MEMORY.md").read_text()', start)
+        text = text[:start] + text[end:]
+        text = text.replace("            completed.set()",
+            f"            if attempts == {draft_failures}:\n                failed.set()\n            completed.set()")
+        fixture.write_text(text)
+    if draft_failures:
+        fixture = sources / "fixture_models/plugin.py"
+        fixture.write_text(fixture.read_text().replace("            completed.set()",
+            f"            if attempts > {draft_failures}:\n                completed.set()"))
     log = MessageLog(tmp_path / "sessions.db")
     host = PluginManager([sources], event_bus=EventBus(), workspace=tmp_path / "workspace",
                          installed_cache_root=tmp_path / "home", message_log=log)
@@ -648,8 +670,8 @@ async def test_profile_input_omits_large_legacy_replay_but_preserves_user_eviden
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("fail_second", [False, True])
-@pytest.mark.parametrize("window,text_size", [(32_000, 55_000), (200_000, 140_000)])
-async def test_profile_batches_keep_whole_turns_and_write_only_after_all_succeed(tmp_path, fail_second, window, text_size):
+@pytest.mark.parametrize("window,text_size,large_profile", [(32_000, 55_000, False), (200_000, 140_000, False), (200_000, 140_000, True)])
+async def test_profile_batches_keep_whole_turns_and_write_only_after_all_succeed(tmp_path, fail_second, window, text_size, large_profile):
     """两批真实完整 Turn 的档案和证据合并；后批失败不写文件或收据。"""
     import json
     from types import SimpleNamespace
@@ -668,6 +690,10 @@ async def test_profile_batches_keep_whole_turns_and_write_only_after_all_succeed
         original = log.reader("s").snapshot()
         groups = closed_groups(original, TurnProjection())
         store = profile_store(tmp_path)
+        if large_profile:
+            (tmp_path / "workspace/memory/MEMORY.md").write_text(
+                "# 用户长期记忆\n## 用户事实\n- " + "existing-fact " * 4_000
+                + "\n## 用户偏好\n## 用户明确要求长期记住的关键内容\n")
         before = (store.read_memory(), store.read_self(), store.read_writes(None, 20))
         requests = []
 
@@ -679,16 +705,13 @@ async def test_profile_batches_keep_whole_turns_and_write_only_after_all_succeed
             assert len(rows) == 3, "a complete Turn must stay in one request"
             if fail_second and len(requests) == 2:
                 raise TransportError("injected second batch failure")
-            memory = prompt.split("当前 MEMORY.md：\n", 1)[1].split("\n\n当前 SELF.md：", 1)[0]
-            if memory == "（空）":
-                memory = "# 用户长期记忆\n## 用户事实\n## 用户偏好\n## 用户明确要求长期记住的关键内容\n"
             fact = rows[0]["body"]["parts"][0]["value"].split()[0]
             line = "- " + fact
-            memory = memory.rstrip() + "\n" + line + "\n"
-            return LLMResponse(json.dumps({"memory": memory, "self": before[1],
-                "evidence": {"memory": {line: [rows[0]["message_id"]]}, "self": {}}}))
+            response = json.dumps({"additions": [{"document": "memory", "section": "## 用户事实",
+                "line": line, "message_ids": [rows[0]["message_id"]]}]})
+            return LLMResponse(response)
 
-        model = SimpleNamespace(descriptor=SimpleNamespace(capabilities=SimpleNamespace(context_window=window, max_output_tokens=4096)),
+        model = SimpleNamespace(descriptor=SimpleNamespace(capabilities=SimpleNamespace(context_window=window, max_output_tokens=32_768)),
                                 estimate_context_tokens=lambda messages: len(str(messages)) // 4, complete=complete)
 
         @asynccontextmanager
@@ -704,6 +727,8 @@ async def test_profile_batches_keep_whole_turns_and_write_only_after_all_succeed
             assert draft["memory_before"] == before[0]
             assert isinstance(draft["memory"], str)
             assert "- fact-0" in draft["memory"] and "- fact-1" in draft["memory"]
+            if large_profile:
+                assert "- " + "existing-fact " * 4_000 + "\n" in draft["memory"]
             assert draft["evidence"] == {"memory": {"- fact-0": ["input-0"], "- fact-1": ["input-1"]}, "self": {}}
         assert len(requests) == 2
         assert (store.read_memory(), store.read_self(), store.read_writes(None, 20)) == before
@@ -742,3 +767,112 @@ async def test_profile_keeps_allowed_turn_inside_mixed_source_group(tmp_path):
         assert "fact-one" not in prompt and "fact-two" not in prompt
         assert "fact-three" in store.read_memory() and store.is_applied(summary.reference)
         assert log.reader("s").snapshot()[:4] == original
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("draft_failures", [1, 2])
+async def test_invalid_model_draft_repairs_or_retries_without_partial_writes(tmp_path, draft_failures):
+    """缩短的证据 ID 不得提交；一轮修正失败后 follower 仍能从原回执重试。"""
+    async with application(tmp_path, draft_failures=draft_failures) as (log, host):
+        writer = log.writer("s", author="user", source="conversation", body_types=(Input,),
+                            content={"text": check_text})
+        writer.append("legacy-message:" + "a" * 64, Input((ContentPart("text", "fact-one"),)))
+        summary = publish(log, "draft-repair")
+        await record_use(log, host, summary, "used-summary")
+        original = log.reader("s").snapshot()
+        store = profile_store(tmp_path)
+        before = (store.read_memory(), store.read_self(), store.read_writes(None, 20))
+        await host.start_runtime()
+        if draft_failures == 2:
+            async with lease_runtime_snapshot(host.snapshot_store) as snapshot:
+                ctx = snapshot.composition_root.context
+                await asyncio.wait_for(ctx.require(ServiceKey("fixture.retry_failed")).wait(), 5)
+                assert (store.read_memory(), store.read_self(), store.read_writes(None, 20)) == before
+                assert not store.is_applied(summary.reference)
+                ctx.require(ServiceKey("fixture.retry_release")).set()
+        await wait_applied(tmp_path, host, summary.reference)
+        assert len((tmp_path / "requests.jsonl").read_text().splitlines()) == draft_failures + 1
+        assert store.read_memory().count("fact-one") == 1
+        assert log.reader("s").snapshot() == original
+
+
+@pytest.mark.parametrize("case", ["no_change", "new_fact", "empty_memory", "self", "multiline", "move_existing", "assistant_claim", "truncated"])
+def test_profile_additions_preserve_owner_files_and_enforce_evidence(tmp_path, case):
+    """模型无法用增量绕过旧事实保留、单行出处与真实用户证据边界。"""
+    import json
+    from agent.plugin_composition.models import LLMResponse
+    from plugins.markdown_memory.message_plugin import _check_profile_response
+
+    log = MessageLog(tmp_path / "messages.db")
+    try:
+        user = log.writer("s", author="user", source="conversation", body_types=(Input,), content={"text": check_text})
+        assistant = log.writer("s", author="assistant", source="conversation", body_types=(Output,), content={"text": check_text})
+        user.append("user-fact", Input((ContentPart("text", "请记住我喜欢红色"),)))
+        assistant.append("assistant-claim", Output((ContentPart("text", "用户喜欢红色"),), "complete"))
+        store = profile_store(tmp_path)
+        memory = "# 用户长期记忆\n## 用户事实\n## 用户偏好\n## 用户明确要求长期记住的关键内容\n## 助手操作上下文\n- 已有操作记录\n"
+        if case == "empty_memory":
+            memory = ""
+        before_self = store.read_self()
+        line = "- 用户喜欢红色"
+        if case == "multiline":
+            line += "\n- 没有证据的事实"
+        elif case == "move_existing":
+            line = "- 已有操作记录"
+        additions = [] if case == "no_change" else [{"document": "memory", "section": "## 用户偏好", "line": line,
+            "message_ids": ["assistant-claim" if case == "assistant_claim" else "user-fact"]}]
+        if case == "self":
+            additions[0].update(document="self", section="## 我对当前用户的理解")
+        response = LLMResponse(json.dumps({"additions": additions}), finish_reason="length" if case == "truncated" else "stop")
+        if case not in {"no_change", "new_fact", "empty_memory", "self"}:
+            with pytest.raises(ValueError):
+                _check_profile_response(response, log.reader("s").snapshot(), memory, before_self)
+        else:
+            draft = _check_profile_response(response, log.reader("s").snapshot(), memory, before_self)
+            assert draft["self_before"] == before_self
+            assert draft["memory_before"] == memory
+            if case == "no_change":
+                assert draft["memory"] == memory
+                assert draft["self"] == before_self
+                assert draft["evidence"] == {"memory": {}, "self": {}}
+            elif case == "self":
+                assert draft["memory"] == memory
+                assert isinstance(draft["self"], str)
+                assert before_self.split("## 我们关系的定义")[0] in draft["self"]
+                assert "- 用户喜欢红色\n## 我们关系的定义" in draft["self"]
+                assert draft["evidence"] == {"memory": {}, "self": {"- 用户喜欢红色": ["user-fact"]}}
+            else:
+                expected = memory or "# 用户长期记忆\n\n## 用户事实\n\n## 用户偏好\n\n## 用户明确要求长期记住的关键内容\n"
+                expected = expected.replace("## 用户明确要求长期记住的关键内容", "- 用户喜欢红色\n## 用户明确要求长期记住的关键内容")
+                assert draft["memory"] == expected
+                assert draft["self"] == before_self
+                assert draft["evidence"] == {"memory": {"- 用户喜欢红色": ["user-fact"]}, "self": {}}
+    finally:
+        log.close()
+
+
+@pytest.mark.parametrize("case", ["envelope", "entry", "section", "ids", "duplicate"])
+def test_profile_rejects_invalid_model_additions_before_building_a_durable_draft(tmp_path, case):
+    """畸形外部增量只形成可重试错误，不能产生部分持久草稿。"""
+    import json
+    from agent.plugin_composition.models import LLMResponse
+    from plugins.markdown_memory.message_plugin import _check_profile_response, _InvalidDraft
+
+    store = profile_store(tmp_path)
+    before = (store.read_memory(), store.read_self(), store.read_writes(None, 10))
+    entry: dict[str, object] = {"document": "memory", "section": "## 用户事实", "line": "- 新事实", "message_ids": ["missing"]}
+    additions = [entry]
+    payload: dict[str, object] = {"additions": additions}
+    if case == "envelope":
+        payload = {"memory": "overwrite", "additions": []}
+    elif case == "entry":
+        entry["replace"] = "old fact"
+    elif case == "section":
+        entry["section"] = "# 用户长期记忆"
+    elif case == "ids":
+        entry["message_ids"] = [None]
+    else:
+        additions.append(entry)
+    with pytest.raises(_InvalidDraft):
+        _check_profile_response(LLMResponse(json.dumps(payload)), (), before[0], before[1])
+    assert (store.read_memory(), store.read_self(), store.read_writes(None, 10)) == before

--- a/tests/test_message_markdown_memory.py
+++ b/tests/test_message_markdown_memory.py
@@ -596,3 +596,149 @@ async def test_markdown_retries_transient_failure_without_new_messages(tmp_path)
         assert log.reader("s").snapshot() == original
         assert len((tmp_path / "requests.jsonl").read_text().splitlines()) == 2
         assert profile_store(tmp_path).read_memory().count("fact-one") == 1
+
+
+@pytest.mark.asyncio
+async def test_profile_input_omits_large_legacy_replay_but_preserves_user_evidence(tmp_path):
+    """历史回放大小不再放大档案请求；学习资格和完整原文仍由原 Message 证明。"""
+    import json
+    from session.message import CallRef, ContentReferences, ToolCall, ToolResult
+    from plugins.markdown_memory.message_plugin import project
+
+    async with application(tmp_path) as (log, host):
+        writer = log.writer("s", author="legacy-attribution-unknown", source="legacy-unattributed",
+            body_types=(Input, Output), content={"text": check_text,
+                "history.provenance": lambda part: ContentReferences(),
+                "history.transcript": lambda part: ContentReferences(),
+                "history.record": lambda part: ContentReferences()})
+        writer.append("old-user", Input((ContentPart("text", "fact-one"),
+            legacy_part(json.dumps({"provider_replay": "opaque-extra" * 100_000})),
+            ContentPart("history.record", {"row": "opaque-record" * 100_000})) ))
+        writer.append("old-answer", Output((ContentPart("text", "acknowledged"),
+            ContentPart("history.transcript", {"raw": "opaque-tools" * 100_000})), "complete"))
+        log.save_binding("fixture:replay", {"fixture": "read-only-history"})
+        caller = log.writer("s", author="assistant", source="legacy-unattributed", body_types=(Output,),
+                            content={"text": check_text}, check_call=lambda call: None)
+        caller.append("replay-call", Output((ToolCall("fixture:replay", {}),), "continue"))
+        call_ref = CallRef("replay-call", 0)
+        log.writer("s", author="fixture", source="legacy-unattributed", body_types=(ToolResult,),
+            call_ref=call_ref, content={"text": check_text, "history.transcript": lambda part: ContentReferences()}).append(
+                "replay-result", ToolResult(call_ref, "success", (ContentPart("text", "result text"),
+                    ContentPart("history.transcript", {"raw": "opaque-result" * 100_000}))))
+        caller.append("replay-done", Output((ContentPart("text", "done"),), "complete"))
+        original = log.reader("s").snapshot()
+        summary = publish(log, "large-legacy")
+        used = await record_use(log, host, summary, "use", source="legacy-unattributed")
+        async with lease_runtime_snapshot(host.snapshot_store) as snapshot:
+            ctx = snapshot.composition_root.context
+            store = profile_store(tmp_path)
+            await project(used, reader=log.reader("s"), bindings=ctx.require(BINDINGS), store=store,
+                models=ctx.require(CHAT_MODELS), lock_path=tmp_path / "workspace/memory/markdown-profile.lock",
+                sources=("legacy-unattributed",), projection=ctx.require(TURN_PROJECTION))
+        prompts = (tmp_path / "requests.jsonl").read_text()
+        request = json.loads(prompts.splitlines()[0])
+        rows = json.loads(request.split("本次精确来源：\n", 1)[1])
+        assert rows[0]["body"]["parts"][1]["value"] == {"schema": "sessions.messages.v0", "role": "user"}
+        assert len(prompts) < 20_000
+        assert all(value not in prompts for value in ("opaque-extra", "opaque-tools", "opaque-result", "opaque-record"))
+        assert "result text" in prompts
+        assert "fact-one" in store.read_memory() and store.is_applied(summary.reference)
+        assert log.reader("s").snapshot()[:len(original)] == original
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fail_second", [False, True])
+@pytest.mark.parametrize("window,text_size", [(32_000, 55_000), (200_000, 140_000)])
+async def test_profile_batches_keep_whole_turns_and_write_only_after_all_succeed(tmp_path, fail_second, window, text_size):
+    """两批真实完整 Turn 的档案和证据合并；后批失败不写文件或收据。"""
+    import json
+    from types import SimpleNamespace
+    from plugins.markdown_memory.message_plugin import prepare_profile_draft
+    from plugins.compaction.message_summary import closed_groups
+    from plugins.turn_projection.plugin import TurnProjection
+    from agent.plugin_composition.models import ChatModels, LLMResponse, TransportError
+
+    log = MessageLog(tmp_path / "messages.db")
+    try:
+        writer = log.writer("s", author="user", source="conversation", body_types=(Input, Output), content={"text": check_text})
+        for index in range(2):
+            writer.append(f"input-{index}", Input((ContentPart("text", f"fact-{index} " + "x" * text_size),)))
+            writer.append(f"step-{index}", Output((ContentPart("text", "continue"),), "continue"))
+            writer.append(f"answer-{index}", Output((ContentPart("text", "done"),), "complete"))
+        original = log.reader("s").snapshot()
+        groups = closed_groups(original, TurnProjection())
+        store = profile_store(tmp_path)
+        before = (store.read_memory(), store.read_self(), store.read_writes(None, 20))
+        requests = []
+
+        async def complete(request):
+            prompt = request.messages[0]["content"]
+            rows = json.loads(prompt.split("本次精确来源：\n", 1)[1])
+            requests.append(rows)
+            assert (store.read_memory(), store.read_self(), store.read_writes(None, 20)) == before
+            assert len(rows) == 3, "a complete Turn must stay in one request"
+            if fail_second and len(requests) == 2:
+                raise TransportError("injected second batch failure")
+            memory = prompt.split("当前 MEMORY.md：\n", 1)[1].split("\n\n当前 SELF.md：", 1)[0]
+            if memory == "（空）":
+                memory = "# 用户长期记忆\n## 用户事实\n## 用户偏好\n## 用户明确要求长期记住的关键内容\n"
+            fact = rows[0]["body"]["parts"][0]["value"].split()[0]
+            line = "- " + fact
+            memory = memory.rstrip() + "\n" + line + "\n"
+            return LLMResponse(json.dumps({"memory": memory, "self": before[1],
+                "evidence": {"memory": {line: [rows[0]["message_id"]]}, "self": {}}}))
+
+        model = SimpleNamespace(descriptor=SimpleNamespace(capabilities=SimpleNamespace(context_window=window, max_output_tokens=4096)),
+                                estimate_context_tokens=lambda messages: len(str(messages)) // 4, complete=complete)
+
+        @asynccontextmanager
+        async def execution():
+            yield SimpleNamespace(chat=lambda role: model)
+
+        models = cast(ChatModels, SimpleNamespace(independent_execution=execution))
+        if fail_second:
+            with pytest.raises(TransportError, match="second batch"):
+                await prepare_profile_draft(groups, store, models)
+        else:
+            draft = await prepare_profile_draft(groups, store, models)
+            assert draft["memory_before"] == before[0]
+            assert isinstance(draft["memory"], str)
+            assert "- fact-0" in draft["memory"] and "- fact-1" in draft["memory"]
+            assert draft["evidence"] == {"memory": {"- fact-0": ["input-0"], "- fact-1": ["input-1"]}, "self": {}}
+        assert len(requests) == 2
+        assert (store.read_memory(), store.read_self(), store.read_writes(None, 20)) == before
+        assert log.reader("s").snapshot() == original
+    finally:
+        log.close()
+
+
+@pytest.mark.asyncio
+async def test_profile_keeps_allowed_turn_inside_mixed_source_group(tmp_path):
+    """交错来源共用批次切点，不把被抑制来源的资格传播给用户 Turn。"""
+    from plugins.markdown_memory.message_plugin import Config, project
+    from session.message import ContentReferences
+
+    async with application(tmp_path) as (log, host):
+        legacy = log.writer("s", author="legacy-attribution-unknown", source="legacy-unattributed",
+            body_types=(Input, Output), content={"text": check_text,
+                "history.provenance": lambda part: ContentReferences()})
+        user = log.writer("s", author="user", source="conversation", body_types=(Input, Output),
+            content={"text": check_text})
+        legacy.append("excluded-input", Input((ContentPart("text", "fact-one"),
+            legacy_part('{"effects":{"post_commit":"suppress"}}'))))
+        user.append("allowed-input", Input((ContentPart("text", "fact-three"),)))
+        legacy.append("excluded-answer", Output((ContentPart("text", "fact-two"),), "complete"))
+        user.append("allowed-answer", Output((ContentPart("text", "done"),), "complete"))
+        original = log.reader("s").snapshot()
+        summary = publish(log, "mixed-source")
+        used = await record_use(log, host, summary, "used")
+        async with lease_runtime_snapshot(host.snapshot_store) as snapshot:
+            ctx = snapshot.composition_root.context
+            store = profile_store(tmp_path)
+            await project(used, reader=log.reader("s"), bindings=ctx.require(BINDINGS), store=store,
+                models=ctx.require(CHAT_MODELS), lock_path=tmp_path / "workspace/memory/markdown-profile.lock",
+                sources=Config().sources, projection=ctx.require(TURN_PROJECTION))
+        prompt = (tmp_path / "requests.jsonl").read_text()
+        assert "fact-one" not in prompt and "fact-two" not in prompt
+        assert "fact-three" in store.read_memory() and store.is_applied(summary.reference)
+        assert log.reader("s").snapshot()[:4] == original

--- a/tests/test_message_markdown_memory.py
+++ b/tests/test_message_markdown_memory.py
@@ -335,6 +335,7 @@ async def test_markdown_replays_output_after_restart_and_does_not_skip_unused_pa
 
 @pytest.mark.asyncio
 async def test_restart_finishes_saved_draft_after_only_memory_file_was_applied(tmp_path, monkeypatch):
+    import fcntl
     from plugins.markdown_memory.message_plugin import project
 
     async with application(tmp_path) as (log, host):
@@ -347,6 +348,10 @@ async def test_restart_finishes_saved_draft_after_only_memory_file_was_applied(t
         apply_document = store._apply_document
         def fail_self(source_ref, document, path):
             if document == "self":
+                # 第一份文件已安装时，其他读者仍不能取得整对档案的锁。
+                with (tmp_path / "workspace/memory/markdown-profile.lock").open("rb") as lock:
+                    with pytest.raises(BlockingIOError):
+                        fcntl.flock(lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
                 raise OSError("injected second document failure")
             apply_document(source_ref, document, path)
         monkeypatch.setattr(store, "_apply_document", fail_self)
@@ -485,6 +490,79 @@ async def test_profile_lock_cancellation_closes_its_handle_and_allows_next_write
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("cancel_first", [False, True])
+async def test_profile_model_work_keeps_materials_readable_and_updates_serial(tmp_path, monkeypatch, cancel_first):
+    """模型停在确定性屏障时仍可读旧档案；另一次更新必须等待且可接替取消者。"""
+    from plugins.markdown_memory import message_plugin as plugin
+
+    async with application(tmp_path) as (log, host):
+        log.writer("s", author="user", source="conversation", body_types=(Input,), content={"text": check_text}).append(
+            "u", Input((ContentPart("text", "fact-one"),)))
+        record = publish(log, "read-during-model")
+        used = await record_use(log, host, record, "used")
+        store = profile_store(tmp_path)
+        before = (store.read_memory(), store.read_self(), store.read_writes(None, 100))
+        entered, release, second_waiting = asyncio.Event(), asyncio.Event(), asyncio.Event()
+        prepare_calls = []
+        original_prepare, original_flock = plugin.prepare_profile_draft, plugin.fcntl.flock
+
+        async def paused_prepare(*args, **kwargs):
+            prepare_calls.append(asyncio.current_task())
+            entered.set()
+            await release.wait()
+            return await original_prepare(*args, **kwargs)
+
+        async def update():
+            async with lease_runtime_snapshot(host.snapshot_store) as snapshot:
+                ctx = snapshot.composition_root.context
+                await plugin.project(used, reader=log.reader("s"), bindings=ctx.require(BINDINGS), store=store,
+                    models=ctx.require(CHAT_MODELS), lock_path=tmp_path / "workspace/memory/markdown-profile.lock",
+                    sources=("conversation",), projection=ctx.require(TURN_PROJECTION))
+
+        monkeypatch.setattr(plugin, "prepare_profile_draft", paused_prepare)
+        first = asyncio.create_task(update())
+        second = None
+        try:
+            await asyncio.wait_for(entered.wait(), 5)
+            second = asyncio.create_task(update())
+
+            def tracked_flock(fd, operation):
+                try:
+                    return original_flock(fd, operation)
+                except BlockingIOError:
+                    if asyncio.current_task() is second:
+                        second_waiting.set()
+                    raise
+
+            monkeypatch.setattr(plugin.fcntl, "flock", tracked_flock)
+            await asyncio.wait_for(second_waiting.wait(), 5)
+            assert prepare_calls == [first]
+            async with lease_runtime_snapshot(host.snapshot_store) as snapshot:
+                async with snapshot.composition_root.context.require(MATERIALS).bind() as materials:
+                    prepared = await asyncio.wait_for(materials.prepare((), "conversation"), 1)
+            assert before[1].strip() in prepared.system_prompt
+            assert "fact-one" not in prepared.system_prompt
+            assert (store.read_memory(), store.read_self(), store.read_writes(None, 100)) == before
+            if cancel_first:
+                first.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await first
+                assert (store.read_memory(), store.read_self(), store.read_writes(None, 100)) == before
+                assert store.read_draft(record.reference) is None
+            release.set()
+            await asyncio.gather(*([second] if cancel_first else [first, second]))
+            assert len(prepare_calls) == (2 if cancel_first else 1)
+            assert store.is_applied(record.reference)
+            assert store.read_memory().count("fact-one") == 1
+            assert len((tmp_path / "requests.jsonl").read_text().splitlines()) == 1
+        finally:
+            tasks = [first, *([second] if second is not None else [])]
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("existing", ["MEMORY.md", "markdown-profile-writes.db", "PENDING.md"])
 async def test_unstarted_markdown_does_not_treat_partial_state_as_initial(tmp_path, existing):
     async with application(tmp_path) as (log, host):
@@ -498,6 +576,19 @@ async def test_unstarted_markdown_does_not_treat_partial_state_as_initial(tmp_pa
                     await asyncio.wait_for(view.prepare((), "conversation"), 5)
         assert tuple(memory.iterdir()) == (path,)
         assert path.read_bytes() == b"preserved state"
+
+
+@pytest.mark.asyncio
+async def test_an_update_lock_alone_does_not_create_a_partial_profile_state(tmp_path):
+    async with application(tmp_path) as (_log, host):
+        path = tmp_path / "workspace/memory/markdown-profile-update.lock"
+        path.parent.mkdir()
+        path.touch()
+        async with lease_runtime_snapshot(host.snapshot_store) as snapshot:
+            async with snapshot.composition_root.context.require(MATERIALS).bind() as materials:
+                prepared = await materials.prepare((), "conversation")
+        assert "# Akashic 的自我认知" in prepared.system_prompt
+        assert tuple(path.parent.iterdir()) == (path,)
 
 
 @pytest.mark.asyncio
@@ -721,9 +812,9 @@ async def test_profile_batches_keep_whole_turns_and_write_only_after_all_succeed
         models = cast(ChatModels, SimpleNamespace(independent_execution=execution))
         if fail_second:
             with pytest.raises(TransportError, match="second batch"):
-                await prepare_profile_draft(groups, store, models)
+                await prepare_profile_draft(groups, before[0], before[1], models)
         else:
-            draft = await prepare_profile_draft(groups, store, models)
+            draft = await prepare_profile_draft(groups, before[0], before[1], models)
             assert draft["memory_before"] == before[0]
             assert isinstance(draft["memory"], str)
             assert "- fact-0" in draft["memory"] and "- fact-1" in draft["memory"]

--- a/tests/test_model_execution.py
+++ b/tests/test_model_execution.py
@@ -175,8 +175,13 @@ async def _noop_delta() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("streaming", [False, True])
-@pytest.mark.parametrize("driver_name", ["openai_compatible", "opencode_go", "codex"])
-async def test_driver_reuses_socket_and_reads_rotated_credentials(streaming, driver_name, caplog):
+@pytest.mark.parametrize("driver_name,model_name", [
+    ("openai_compatible", "fixture"),
+    ("openai_compatible", "deepseek-v4-flash"),
+    ("openai_compatible", "deepseek/deepseek-v4-flash-vision-exp"),
+    ("opencode_go", "fixture"), ("codex", "fixture"),
+])
+async def test_driver_reuses_socket_and_reads_rotated_credentials(streaming, driver_name, model_name, caplog):
     """同一连接的两次请求复用 socket，并使用各自读取到的凭据。"""
     from dataclasses import replace
     from agent.plugin_composition import DriverConnectionDescriptor
@@ -186,9 +191,11 @@ async def test_driver_reuses_socket_and_reads_rotated_credentials(streaming, dri
     from tests.model_plugin_fakes import BoundChatModelFake
 
     seen = []
+    truncated = 0
     caplog.set_level("DEBUG", logger="core.net.http")
 
     async def complete(request):
+        nonlocal truncated
         seen.append((request.transport, request.headers["Authorization"]))
         assert "Cookie" not in request.headers
         if driver_name == "codex":
@@ -196,11 +203,21 @@ async def test_driver_reuses_socket_and_reads_rotated_credentials(streaming, dri
                 text='data: {"type":"response.output_text.delta","delta":"ok"}\n\ndata: {"type":"response.completed","response":{}}\n\n',
                 content_type="text/event-stream",
             )
-        if streaming:
-            return web.Response(
-                text='data: {"choices":[{"delta":{"content":"ok"}}]}\n\ndata: [DONE]\n\n',
-                content_type="text/event-stream",
-            )
+        body = await request.json()
+        deepseek = driver_name == "openai_compatible" and "deepseek-v4-" in model_name
+        assert bool(body.get("stream")) == (streaming or deepseek)
+        if deepseek and not streaming:
+            assert body["thinking"] == {"type": "disabled"}
+            assert "reasoning_effort" not in body
+        elif driver_name == "openai_compatible":
+            assert "thinking" not in body
+        if streaming or deepseek:
+            payload = 'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n'
+            if truncated:
+                truncated -= 1
+            else:
+                payload += 'data: {"choices":[],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}\n\ndata: [DONE]\n\n'
+            return web.Response(text=payload, content_type="text/event-stream")
         return web.json_response({"choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}]})
 
     app = web.Application()
@@ -227,17 +244,23 @@ async def test_driver_reuses_socket_and_reads_rotated_credentials(streaming, dri
                     "account_id": "test", "expires_at": "2099-01-01T00:00:00+00:00"}
 
     credential = Credential()
-    descriptor = replace(BoundChatModelFake(object()).descriptor, driver_id=driver_id)
+    descriptor = replace(BoundChatModelFake(object()).descriptor, driver_id=driver_id, model=model_name)
     driver = await definition().open(
         DriverConnectionDescriptor("test-connection", "local", driver_id,
-                                   f"http://127.0.0.1:{port}/v1", "test", {}),
+                                   f"http://127.0.0.1:{port}/v1", "test", {"max_retries": 1} if driver_name == "openai_compatible" else {}),
         credential,
     )
+    deltas = []
+
+    async def capture(delta):
+        deltas.append(dict(delta))
+
     try:
         bound = driver.bind_chat(descriptor, {})
         request = ModelRequest(
             messages=({"role": "user", "content": "hello"},),
-            on_delta=(lambda _delta: _noop_delta()) if streaming else None,
+            on_delta=capture if streaming else None,
+            disable_reasoning=not streaming,
         )
         assert (await bound.complete(request)).content == "ok"
         credential.token = "second"
@@ -246,6 +269,25 @@ async def test_driver_reuses_socket_and_reads_rotated_credentials(streaming, dri
         if seen[0][0] is not seen[1][0]:
             assert "尾流未结束，关闭连接" in caplog.text
         assert [item[1] for item in seen] == ["Bearer first", "Bearer second"]
+        if driver_name == "openai_compatible" and "deepseek-v4-" in model_name:
+            from agent.plugin_composition.models import TransportError
+            truncated = 1
+            deltas.clear()
+            if streaming:
+                with pytest.raises(TransportError, match="terminal marker") as failure:
+                    await bound.complete(request)
+                assert not failure.value.retryable
+                assert len(seen) == 3, "an observed partial response must not replay"
+                assert deltas == [{"content_delta": "ok"}]
+            else:
+                assert (await bound.complete(request)).content == "ok"
+                assert len(seen) == 4, "unobserved partial bytes may retry without duplicate output"
+                truncated = 2
+                with pytest.raises(TransportError, match="terminal marker") as failure:
+                    await bound.complete(request)
+                assert failure.value.retryable, "the caller can retry after the driver's bounded attempts"
+                assert len(seen) == 6, "a partial response must not become a successful completion"
+                assert deltas == []
         await driver.aclose()
         with pytest.raises(RuntimeError, match="连接已关闭"):
             await bound.complete(request)
@@ -255,7 +297,8 @@ async def test_driver_reuses_socket_and_reads_rotated_credentials(streaming, dri
 
 
 @pytest.mark.asyncio
-async def test_done_does_not_wait_for_a_stalled_http_tail():
+@pytest.mark.parametrize("observe", [False, True])
+async def test_done_does_not_wait_for_a_stalled_http_tail(observe):
     """DONE 后服务端不结束正文时，仍交付已完成结果并关闭该连接。"""
     import httpx
     from plugins.openai_compatible.driver import _consume_stream
@@ -275,7 +318,7 @@ async def test_done_does_not_wait_for_a_stalled_http_tail():
     response = httpx.Response(200, stream=Body())
     try:
         async with asyncio.timeout(1):
-            result = await _consume_stream(response, lambda _delta: _noop_delta())
+            result = await _consume_stream(response, (lambda _delta: _noop_delta()) if observe else None)
         assert result.content == "ok"
         assert waiting.is_set() and cancelled.is_set()
     finally:

--- a/tests/test_wake_gate_contract.py
+++ b/tests/test_wake_gate_contract.py
@@ -119,11 +119,22 @@ async def _start_provider(
         else:
             payload = {"error": {"message": "fixture-provider-body-marker"}}
         body = json.dumps(payload).encode()
+        content_type = "application/json"
+        if status == 200 and request.get("stream") is True:
+            choices = cast(list[dict[str, Any]], payload["choices"])
+            for choice in choices:
+                delta = choice.pop("message")
+                for index, call in enumerate(delta["tool_calls"]):
+                    call["index"] = index
+                choice["delta"] = delta
+            payload["object"] = "chat.completion.chunk"
+            body = b"data: " + json.dumps(payload).encode() + b"\n\ndata: [DONE]\n\n"
+            content_type = "text/event-stream"
         reason = {200: "OK", 400: "Bad Request", 503: "Service Unavailable"}[status]
         writer.write(
             f"HTTP/1.1 {status} {reason}\r\n".encode()
             + f"Content-Length: {len(body)}\r\n".encode()
-            + b"Content-Type: application/json\r\nConnection: close\r\n\r\n"
+            + f"Content-Type: {content_type}\r\nConnection: close\r\n\r\n".encode()
             + body
         )
         await writer.drain()


### PR DESCRIPTION
## 问题与结果

Markdown 学习首个迁入摘要时，把 2,170 条来源消息的历史回放和原始 provider 元数据组成 35.8 MB 请求，持续收到 HTTP 503。缩小输入后，非流式长生成又超过网关约 128 秒等待窗口；让模型回传完整档案与重复的 evidence 文本，还会造成生成截断和条目引用不匹配。关联 #551，问题来自 #586 部署后的真实数据验收。

学习展示保留逐字正文与出处角色，按完整 Turn 分批。模型只返回新增条目及实际消息 ID；Markdown owner 保留旧档案，从同一条目生成完整 v2 草稿和证据表。全部批次通过现有结构与来源校验后，才沿 before-image/receipt writer 提交。DeepSeek V4 即使没有应用层流式观察者，也通过 SSE 完整聚合结果，避免网关的非流式超时。

后台生成还会长期占住普通回复的档案读取锁。本次将完整更新串行与两文件可见性分为两把锁：模型等待期间，普通回复读取完整旧档案；writer 固定按 update → profile 取锁，启动初始化、恢复和最终提交仍受保护。

## Change intent

- change_type: fix；semantic_delta: compatible
- capability_owner: markdown_memory 拥有学习、证据与草稿；openai_compatible 拥有 provider HTTP/SSE。
- consumer_scope: Markdown 后台学习、普通回复材料读取与 DeepSeek V4 Chat Completions。
- runtime_patch: none；Core 不新增来源或模型专属规则。
- authoritative_state_owner: MessageLog 保存原文；compaction 保存摘要来源；MarkdownProfileStore 保存档案与回执。
- client_only_alternative: 不适用，后台学习不经过客户端。
- protected_state: 原始 Message、摘要来源、既有档案事实、旧回执和完整 v2 恢复格式。
- 允许副作用：创建空的 markdown-profile-update.lock；调用现有 DEFAULT 模型；全批次成功后通过既有 writer 增补档案与回执。
- 禁止副作用：减少原文；跳过失败批次或证据校验；提交中间档案；更换模型角色或路由。

## 改动与恢复

- Input/Output/ToolResult 的展示省去 history.transcript/history.record/history.turn_input；history.provenance 展示 schema/role，资格仍读取完整原 Message。
- 32,768 token 是完整 Turn 批次目标；单个 Turn 可以越过目标，但不能超过模型窗口预算，超限明确失败。
- 私有模型响应仅有 additions；插件构建完整草稿及一一对应证据。无新增保留当前档案，旧持久 v2 草稿继续正常恢复。
- 模型输出或证据不合格时，同一批原文和 before-image 只修正一次；仍不合格由原 follower 延时重试。持久数据、原文和内部契约错误不转成模型重试。
- DeepSeek V4（含带命名空间的模型名）无 observer 也使用 SSE，仍要求 DONE、保留 usage/finish/tool calls；未交付的断流可有限重试，耗尽后仍可由 follower 恢复；有 observer 的部分输出不自动重放。其他模型无 observer 继续 JSON。disable_reasoning 发送官方 thinking=disabled 参数，实际网关仍可能计算 reasoning，生成预算采用 provider 声明上限。
- 独立更新锁保证跨 Session/generation 的 writer 串行；既有档案锁只保护快照、恢复与安装。取消释放更新锁，后续 writer 可接替；空锁不被误判为部分档案状态。模型准备只接收 before-image 字符串。
- 没有配置或数据库迁移。恢复点包括改动前 Git bundle、正式数据已验证备份；回退本 PR 代码不会删减权威状态。

## 验证

- 新增读锁修复：旧代码两例在真实 MATERIALS.prepare 确定性超时；修复后模型暂停时读取立即完成，第二 writer 实际阻塞于更新锁，取消接替只提交一次。Markdown 与插件业务校验合计 62 项通过；系统测试 11 项通过（159.79s），包含原 CI 失败的压缩与长期记忆链路。

- 最终 Markdown、模型调用与 Wake 边界合计 73 项通过（58.09s）；其中 Markdown 48 项新增覆盖完整 Turn、巨型迁入包装、后批失败零提交、增量恢复/重试、用户证据、SELF、空档案和畸形外部响应。
- 真实 HTTP fixture 核对 SSE、socket 复用、凭据轮换、无 observer 断流后重试/耗尽、有 observer 不重放及实际 delta，以及 Wake 投递合同；独立 reviewer 重跑 socket/断流 10 项通过。
- tests 项目 Pyright level=error：0 errors；git diff --check 通过。
- 同一批 2,170 条消息只读测量：35,809,460 bytes → 2,514,637 bytes，再按完整 Turn 分批；原始日志没有改写。
- 真实首批 88 个 Turn 一次校验成功：输入 127,990 bytes，120.48s，输出 988 字符，finish=stop；旧档案由 owner 保留。完整历史演练与正式部署回执验收均已通过，见下方实际写入结果。
- 真实已提交 driver、线上原 DEFAULT binding 和原配置只读验证通过：read timeout 90s、max retries 3；一次完整 SSE 生成耗时 161.27s，finish=stop、usage 完整，88 Turn 的新增条目校验通过。没有更换模型、修改超时配置或写入正式档案。
- 最终累计 change-impact Gate 通过，报告 `20260910-043536-84e8fc7d`，plan digest `24c3eed29d130d62d5c30bea7e345350b62a486f20b968f6c800216f0dd9fe83`。
- 旧 head 3d8ccd4d 的 CI 有两例失败：长期记忆 fixture 仍返回旧私有协议，已改为 additions 并通过整个系统测试文件；supervised restart 两参数在原 head 独立复验通过，未修改断言或扩大 timeout。新 head `e45b66c1c351e5216ba94b58fb5d77b035153369` 已推送，完整 CI run `34402573369` 全部通过：Python 1,861 passed / 6 skipped（1023.49s）、Web 101 passed、SDK 2 passed，远端 Gate 6m16s 通过；已合并并部署为 `561ec463a9ae058026228fb778e79ca4b4f06ce7`。

- 真实 driver 完整演练通过：1,162 Turn / 2,170 来源消息，最终整体草稿 validated=true；新增 MEMORY 109 条、SELF 13 条，最终字符数 14,123 / 3,348。全程读取原 DEFAULT binding 和配置，未写正式档案或回执；正式 follower 回执现已推进，见下方正式部署验收。

## 独立概念 Gate

Reviewer: production_fixes_review；model: gpt-5.6-terra；reasoning: xhigh。以 e93aa45c 为基线的最终 6 文件补充 diff 及本 PR 累计行为通过，零未处置 must-fix；Markdown 模块 SHA256 98edbe5964b28dfe2b918c1cdabdf1fe1af7bbad75591b10171e995523d3875e；随后无 observer 断流恢复增补也通过独立评审，driver SHA256 7d38ddfb8c9d670e30f9b9afd0674b5a4d28954912bc21fec583a1730164bbe8。

响应协议属于插件私有模型边界，未新增持久 owner；普通、失败、取消和旧草稿恢复仍沿同一 v2 草稿 → 证据 → 既有 writer 链路。已更新 persistence-state-map 的输入、分批、增量和提交说明；无对应 NOW 条目。

读锁修复及测试 fixture 增补已由同一独立 reviewer 对四文件相邻 diff 和累计调用链复核，零功能性 must-fix；命名锁 docstring 与启动初始化文档已按建议对齐，最终固定 head `e45b66c1c351e5216ba94b58fb5d77b035153369` 已独立确认 PASS，工作树 clean，零 must-fix。

## 正式部署验收状态

2026-09-10 05:11:24 +08:00 通过正式发布流程激活 561ec463；Core/workloads 健康，公网 WSS 收到 server.challenge，51 个插件全部健康（14 个外部插件、无旧版条目）。受保护的 17,539 条消息、325 bindings、642 message_bindings、9 附件关联哈希不变。

新 programmatic E2E 中 Calendar 已返回真实日历，但随后暴露 Core MCP 清理的重复 5 秒 deadline：外层与 client EOF 宽限竞争，使正常升级 TERM 的清理被判为失败。该问题已由 #589 修复并部署；最终完整 E2E 已通过，见下方回执。Markdown 正式 follower 已于 2026-09-10 05:45:17 +08:00 完成首批提交。MEMORY 36 → 136 条、SELF 21 → 25 条；两文件与 applied digest 一致，原条目按序保留，before-image digest 一致，155 个证据 Message ID 均存在。

MCP 清理的后续修复见 #589；其 CI 和最终整轮 E2E 仍在进行。

## 正式部署验收（2026-09-10）

hua-home 已通过正式发布链激活 `4f9173c188a16289f0ac08d786f667e75df185d4`（#590）；运行镜像 revision、进程提交及 Wake/Context 源码哈希与通过 CI 的 tree 一致。

- 连续观察 500.68 秒：Core/Workloads 持续 healthy、零重启、无 OOM，Core 新增 1 次 GitHub 连接重试耗尽 warning，无 error；既有冷却后于 23:26:03 UTC 日志确认 GitHub transport recovered。
- plugin doctor：51 个插件全部 healthy，14 个外部插件；退役安装已卸载，Skill 检查通过。
- 正式 programmatic session `programmatic:pr571-551-final-4f9173c1` 为 learning=excluded。真实 ToolSearch binding 逐项匹配 53 个公开工具；Steam 在线人数、Calendar 日历列表、GitHub Watch runtime info、Scheduler 列表全部成功，整轮 complete。
- Observe 持久游标已追上本轮 E2E；Markdown 的正式 MEMORY +100 / SELF +4 回执、原条目、before-image 和 155 个 Message 引用复核通过。
- 原 17,539 条 Message、325 条 binding、642 条消息绑定与 9 条附件关联逐行哈希保持一致；完整备份已完成恢复核验。
- 公网 WebSocket 实际收到 server.challenge；Host Bridge 与正式服务单元 active。
- Wake 原 100 候选的真实只读模型复验返回 8 个完整有效 ID（总输出 9,628 token）；部署后有效初筛 0 次。最新自然初筛因非法 JSON 参数明确 failure/defer；同批候选只读复验再次选中 8 个有效 ID（总输出 9,148 token）。模型复验未提交决定或发送消息，不作为手机送达证据。窗口后 Telegram 仍有瞬断并自动重试。

Core #571、#586、#587、#588、#589、#590，Calendar #10 和 Fleet #2 均已合并；关联 #551 已关闭。53 项为目录覆盖核验，未执行所有有写入副作用的工具。
