### PR TITLE
修复 MCP 退出宽限与 generation 清理计时冲突

### DIFF
--- a/agent/plugins/mcp_generation_host.py
+++ b/agent/plugins/mcp_generation_host.py
@@ -42,7 +42,6 @@ HealthCallback = Callable[[str, str, bool, str], Awaitable[None] | None]
 IncidentCallback = Callable[[str, str, str, str], Awaitable[None] | None]
 
 _POLL_SECONDS = 0.02
-_STOP_TIMEOUT_SECONDS = 5.0
 _READINESS_TIMEOUT_SECONDS = 8.0
 _MAX_LOG_LINES = 8
 
@@ -331,17 +330,13 @@ class McpGenerationHost:
         on_health: HealthReporter | None = None,
         on_incident: IncidentReporter | None = None,
         on_failure: FailureCallback | None = None,
-        stop_timeout_seconds: float = _STOP_TIMEOUT_SECONDS,
         readiness_timeout_seconds: float = _READINESS_TIMEOUT_SECONDS,
     ) -> None:
-        if stop_timeout_seconds <= 0:
-            raise ValueError("stop_timeout_seconds must be positive")
         if readiness_timeout_seconds <= 0:
             raise ValueError("readiness_timeout_seconds must be positive")
         self._on_health = on_health
         self._on_incident = on_incident
         self._on_failure = on_failure
-        self._stop_timeout_seconds = stop_timeout_seconds
         self._readiness_timeout_seconds = readiness_timeout_seconds
         self._generations: dict[str, _Generation] = {}
         self._tombstones: dict[str, McpCleanupTombstone] = {}
@@ -831,6 +826,7 @@ class McpGenerationHost:
             ) from errors[0]
 
     async def _cleanup_entry(self, entry: _McpEntry) -> None:
+        """等待 client 完成进程组回收，再发布停止状态。"""
         entry.stopping = True
         watcher = entry.watcher
         if watcher is not None and watcher is not asyncio.current_task():
@@ -838,15 +834,8 @@ class McpGenerationHost:
                 _ = watcher.cancel()
             await _await_task_after_cancellation(watcher)
             entry.watcher = None
-        try:
-            await asyncio.wait_for(
-                entry.client.disconnect(),
-                timeout=self._stop_timeout_seconds,
-            )
-        except TimeoutError as error:
-            raise RuntimeError(
-                f"MCP server {entry.name!r} stop 超时: {self._stop_timeout_seconds}s"
-            ) from error
+        # client 自己限定 EOF、TERM 与 KILL 阶段；外层计时会抢先取消正常回收。
+        await entry.client.disconnect()
         try:
             await self._emit_health(entry.generation_id, entry.name, False, "stopped")
         except (asyncio.CancelledError, Exception) as error:

--- a/docs/design/plugin-mcp-hot-reload-cache-drain.md
+++ b/docs/design/plugin-mcp-hot-reload-cache-drain.md
@@ -166,6 +166,17 @@ promote 不等待调用者自己持有的 S1 lease，也不取消 T。新 turn �
 
 取消不能截断 generation cleanup。scope 继续逆序尝试全部 cleanup，并聚合失败。旧 MCP 未确认退出时保留 process ownership 和结构化失败；不得从 draining registry 提前移除后报告完成。
 
+Linux stdio MCP 退出宽限由 `McpClient` 统一拥有：关闭 stdin 后等待自然退出，再由进程组 owner 完成 TERM → KILL 与存活检查。generation host 直接等待该清理结果，不另加与 EOF 宽限相同的总超时；否则刚进入 TERM 阶段就会被误判为清理失败。真实进程组回收失败仍保留 tombstone，可由原 owner 重试；取消仍先等待回收，再向调用者传播。
+
+```text
+┌─────────────────────┐    ┌─────────────────────────────────┐
+│ generation / scope  │───▶│ McpClient: EOF → TERM → KILL     │
+│ 等结果、保留失败证据 │◀───│ Linux 分阶段有界，确认组已退出  │
+└─────────────────────┘    └─────────────────────────────────┘
+```
+
+`tests/test_mcp_binding_scope.py` 使用成功调用后忽略 EOF 的真实 stdio 子进程，验证普通返回和取消都等待进程组回收，且不会产生虚假的 cleanup tombstone。
+
 MCP 子进程恢复预算耗尽时，`McpGenerationHost` 在对应 generation 上保留不可恢复故障。候选
 generation 因健康检查失败不能晋升；active generation 的后续工具调用明确失败，但该故障不进入
 Core primary task，也不终止无关 turn、其他插件或本地 runtime。只有 Core owner、权威状态或整体

--- a/tests/test_mcp_binding_scope.py
+++ b/tests/test_mcp_binding_scope.py
@@ -422,3 +422,63 @@ async def test_candidate_scoped_mcp_uses_candidate_environment_and_tool_permissi
             assert (await route.call("mutate", {})).output == "formal"
     finally:
         await owner.terminate_all()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cancel", [False, True])
+async def test_scoped_mcp_waits_for_eof_grace_and_process_group_cleanup(tmp_path, monkeypatch, cancel):
+    """成功调用后，忽略 EOF 的真实进程仍完成 TERM 回收，取消不遗留资源。"""
+    import agent.mcp.client as client_module
+    from utils.process_group import process_group_exists
+
+    plugins = tmp_path / "plugins"
+    write_plugin(plugins / "probe")
+    script = plugins / "probe/first/server.py"
+    script.write_text(script.read_text().replace(
+        "for raw in sys.stdin:", "own_count = int(count.read_text())\nfor raw in sys.stdin:"
+    ) + '''
+if own_count > 1:
+    import signal
+    count.with_suffix(".eof-pid").write_text(str(os.getpid()))
+    signal.pause()
+''')
+    owner = manager(tmp_path, [plugins])
+    log = MessageLog(tmp_path / "messages.db")
+    waiting_for_exit = asyncio.Event()
+    original_wait = client_module._wait_for_leader_exit
+
+    async def wait_for_exit(process):
+        waiting_for_exit.set()
+        return await original_wait(process)
+
+    monkeypatch.setattr(client_module, "_wait_for_leader_exit", wait_for_exit)
+    try:
+        # 1. 正式进程正常退出；只有绑定调用创建的第二个进程忽略 EOF。
+        await owner.load_all()
+        snapshot = owner.current_snapshot
+        data = snapshot.generations["probe"].data_dir
+        bindings = Bindings(log, owner._archive, owner.open_binding)
+        async with lease_runtime_snapshot(owner.snapshot_store):
+            identity = bindings.bind(SERVICE, {})
+
+        async def call():
+            async with bindings.open(identity, SERVICE) as (open_server, _):
+                async with open_server() as server:
+                    async with server.route() as route:
+                        assert (await route.call("ping", {})).output == "fixed A"
+
+        # 2. 在真实 EOF 清理阶段取消；正常和取消路径都必须等进程组消失。
+        task = asyncio.create_task(call())
+        await asyncio.wait_for(waiting_for_exit.wait(), 10)
+        if cancel:
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        else:
+            await task
+        assert not process_group_exists(int((data / "first.eof-pid").read_text()))
+        assert owner.resource_failures() == ()
+        assert owner.current_snapshot is snapshot
+    finally:
+        await owner.terminate_all()
+        log.close()


### PR DESCRIPTION
## 问题与结果

正式 E2E 中 Calendar 已成功返回日历数据，随后整轮却因 MCP 清理超过 5 秒而失败。generation host 的总计时与 client 自己的 5 秒 EOF 宽限同时到期，提前取消了本来应继续执行的 TERM → KILL 回收。关联 #551，发现于 #588 正式部署后的实际调用验收。

移除 generation host 的重复计时和无消费者的内部参数，直接等待 McpClient 的分阶段清理。超时数值没有变化；真实进程组回收失败仍保留 tombstone，取消仍等清理结束后再传播。Calendar 插件及其端口修复无需改动。

## Change intent

- change_type: fix；semantic_delta: compatible
- capability_owner: McpClient 拥有 stdin EOF 和进程组退出宽限；McpGenerationHost 拥有 generation、清理结果和失败重试记录。
- consumer_scope: stdio MCP 的绑定调用、候选与 generation 退出。
- runtime_patch: required；runtime_patch_reason: 失败由 Core 两层内部清理 deadline 冲突产生；client_only_alternative: 客户端与外部插件不能控制这个计时。
- authoritative_state_owner: MessageLog 与外部工具服务不变；只调整进程生命周期等待。
- protected_state: 成功 ToolResult、Message、binding、正式 snapshot、plugin-data 和 artifact。
- 允许副作用：依现有协议关闭本 generation 的 stdio 及进程组；记录真实清理失败。
- 禁止副作用：重放已完成调用、吞掉清理失败、改变模型或插件、减少持久原文、提前释放未回收资源。

## 验证与恢复

- 真实 stdio 子进程完成 tools/call 后忽略 EOF；旧代码的普通返回与取消两例都复现相同 stop 5.0s 错误（14.95s）。
- 修复后两个 MCP 测试文件 21 项通过（31.56s）；核对 PID/PGID 消失、无虚假清理失败、正式 snapshot 不变，并保留原真实失败重试与恢复合同。
- tests 项目 Pyright：0 errors / 0 warnings；git diff --check 通过。
- Core、fleet 源码与正式安装 cache 未发现被移除的内部 stop_timeout_seconds 参数消费者；唯一生产 McpGenerationHost 构造者使用默认调用。
- 最终 change-impact Gate 全部场景通过：报告 `20260910-052620-d70d9d43`，plan `04bce4887bb58fbbb9777656afb49d0f747e9c3db049d3aeb83d1618762437d9`；source `9a2fbe2ca4a4a053c6842ec27fd831954ebc583c6a6d46aaf1bdc9fa58aff3be` 与当前源码匹配。
- 当前 head `503af16e7b48ca33550fd3f29ef40686cd2d171f`，工作树 clean；独立固定 head 复核通过，零 must-fix；远端 CI run `34407426089` 全部通过：Python 1,863 passed / 6 skipped（1037.27s）、Web 101 passed、SDK 2 passed、远端 Gate 6m15s 通过。
- 恢复点：完整源码 bundle 已验证，正式数据完整备份已验证，上一运行提交为 561ec463。回退本 PR 不修改或减少持久状态。

已合并为 `1473f03535d7512ee1c9dacd509a5b6030265009`，合并 tree 与通过验证的 head 一致，已通过正式发布流程部署；最终 E2E 与 500 秒观察已完成，见下方回执。

已更新 MCP 热更新/清理设计中的退出职责和回归证据；无对应 NOW 条目。reviewer 为 production_fixes_review，gpt-5.6-terra / xhigh，固定 head `503af16e7b48ca33550fd3f29ef40686cd2d171f` 最终复核 PASS，零 must-fix。

## 正式部署验收（2026-09-10）

hua-home 已通过正式发布链激活 `4f9173c188a16289f0ac08d786f667e75df185d4`（#590）；运行镜像 revision、进程提交及 Wake/Context 源码哈希与通过 CI 的 tree 一致。

- 连续观察 500.68 秒：Core/Workloads 持续 healthy、零重启、无 OOM，Core 新增 1 次 GitHub 连接重试耗尽 warning，无 error；既有冷却后于 23:26:03 UTC 日志确认 GitHub transport recovered。
- plugin doctor：51 个插件全部 healthy，14 个外部插件；退役安装已卸载，Skill 检查通过。
- 正式 programmatic session `programmatic:pr571-551-final-4f9173c1` 为 learning=excluded。真实 ToolSearch binding 逐项匹配 53 个公开工具；Steam 在线人数、Calendar 日历列表、GitHub Watch runtime info、Scheduler 列表全部成功，整轮 complete。
- Observe 持久游标已追上本轮 E2E；Markdown 的正式 MEMORY +100 / SELF +4 回执、原条目、before-image 和 155 个 Message 引用复核通过。
- 原 17,539 条 Message、325 条 binding、642 条消息绑定与 9 条附件关联逐行哈希保持一致；完整备份已完成恢复核验。
- 公网 WebSocket 实际收到 server.challenge；Host Bridge 与正式服务单元 active。
- Wake 原 100 候选的真实只读模型复验返回 8 个完整有效 ID（总输出 9,628 token）；部署后有效初筛 0 次。最新自然初筛因非法 JSON 参数明确 failure/defer；同批候选只读复验再次选中 8 个有效 ID（总输出 9,148 token）。模型复验未提交决定或发送消息，不作为手机送达证据。窗口后 Telegram 仍有瞬断并自动重试。

Core #571、#586、#587、#588、#589、#590，Calendar #10 和 Fleet #2 均已合并；关联 #551 已关闭。53 项为目录覆盖核验，未执行所有有写入副作用的工具。
