### PR TITLE
修复 Wake 推理耗尽固定输出预算导致初筛空响应

### DIFF
--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -25,13 +25,6 @@ Session/Message 全身份迁移、配置、Akasha 和 Android 强制全量同步
 - 建立受保护路径 policy：`semantic_delta: none` 的普通实现改动不能同时修改 P0 oracle、mutant 或 coverage baseline 来获得全绿。
 - 建立轻量 `change-intent` 校验，检查实际 diff、允许路径、受保护状态和副作用是否超出声明。
 
-## P1 · Message 日志与回复链插件化
-
-- 用户已批准[完整设计与分层合同](design/0902-reviewed-v4.md)：Message 独立保存，Turn 由普通无状态插件投影，Akasha 是消费者；完整回复链由非特权插件组合，替换旧的执行身份模型。
-- 仓库内重构以 stacked draft PR 交付，持久变化的 yoyo 脚本与引入变化的 PR 同步；禁止灰度、shadow、双 writer 和旧 hook 兼容壳。已核实冗余的删除记录在既有账本，代码删除不授权减少历史消息、学习、附件和插件数据。
-- hua-home 上 Citation、Meme、反馈、诊断、命令和工具检查的功能按设计第 15 节保留并重组。外部插件候选由 Fleet PR #1 固定，各自源码 PR 与 Core PR #563 一起评审；正式 workspace 尚未迁移。
-- 正式切换窗口及线上验收仍是切换前提。Android 原生配套已由 Mobile PR #90 与正式版本 0.8.37 交付。已完成的服务器副本转换、历史摘要/旧效果与联合 E2E 证据见设计末尾的真实副本与联合验收；本地副本证据不授权正式部署。
-
 ## P1 · 工作流扩展
 
 - 按 [`容器与 Host Bridge 非迁移实验合同`](design/akashic-container-host-bridge-experiment-contract.md) 完成 mise/锁文件前置、本机 Local/Bridge/容器分层验证和 hua-home 隔离候选运行时；在 capability matrix、Supervisor 故障注入、OpenCode V4 Flash High 与正式状态零写入证据齐全前，不启动正式 workspace 迁移。

--- a/plugins/context/plugin.py
+++ b/plugins/context/plugin.py
@@ -91,8 +91,8 @@ class ContextBuilder:
         window_start: str | None = None,
     ) -> ModelRequest:
         """纯函数式组装；容量不足明确报错，由调用程序取得更小视图。"""
-        if type(max_output_tokens) is not int or max_output_tokens <= 0:
-            raise ValueError("输出预算必须是正整数")
+        if type(max_output_tokens) is not int or max_output_tokens < 0:
+            raise ValueError("输出预算必须是非负整数")
         # 1. Model owner 保留自身的 call IDs 与 opaque replay，Context 不重造它们。
         snapshot = tuple(snapshot)
         cutoff = _summary_cutoff(snapshot, materials.summary)

--- a/plugins/wake/program.py
+++ b/plugins/wake/program.py
@@ -54,7 +54,8 @@ async def run(ctx: Context, task: Task, reader: MessageReader, request: Request)
             authorize=authorize,
             tool_view=None,
             fixed_bindings=fixed,
-            max_output_tokens=4096,
+            # 推理也占用输出预算，阶段不另设会截断工具决定的小上限。
+            max_output_tokens=0,
             max_steps=(
                 3 if phase.stage == "screen" else 1
                 if phase.stage == "alert"

--- a/tests/test_agent_restart_tool.py
+++ b/tests/test_agent_restart_tool.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import shutil
 import subprocess
-from collections.abc import Awaitable, Callable, Iterable, Mapping
+from collections.abc import Awaitable, Callable, Coroutine, Iterable, Mapping
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from pathlib import Path
@@ -13,7 +13,7 @@ from typing import cast
 
 import pytest
 
-from agent.plugin_composition import CompositionOverlay
+from agent.plugin_composition import CompositionOverlay, Context
 from agent.plugin_composition.channels import CHANNEL_INPUT, ChannelInboundMessage
 from agent.plugin_composition.bindings import BINDINGS
 from agent.plugin_composition.messages import MESSAGE_WRITERS
@@ -696,13 +696,6 @@ async def _wait_for_admission_pause(snapshot: RuntimeSnapshot) -> None:
         await asyncio.sleep(0)
 
 
-async def _wait_for_watcher_count(
-    watchers: list[asyncio.Task[None]], count: int,
-) -> None:
-    while len(watchers) < count:
-        await asyncio.sleep(0)
-
-
 @pytest.mark.asyncio
 @pytest.mark.parametrize("supervised", [True, False], ids=["supervised", "unmanaged"])
 async def test_restart_provider_candidate_preserves_formal_root_identity(
@@ -794,41 +787,26 @@ async def test_restart_provider_candidate_preserves_formal_root_identity(
     old_task: asyncio.Task[object] | None = None
     promotion_task: asyncio.Task[dict[str, object]] | None = None
     release_authorize: asyncio.Event | None = None
-    watcher_monitor: asyncio.Task[None] | None = None
-    stop_watcher_monitor: asyncio.Event | None = None
+    watcher_history: list[asyncio.Task[None]] = []
+    watcher_started: asyncio.Queue[asyncio.Task[None]] = asyncio.Queue()
+    spawn = Context.spawn
+
+    async def observe_spawn(
+        context: Context, coroutine: Coroutine[object, object, object], *, name: str,
+    ) -> asyncio.Task[object]:
+        """在真实任务创建完成时记录，避免忙轮询阻碍清理线程。"""
+        task = await spawn(context, coroutine, name=name)
+        if name == "agent-restart-watcher":
+            watcher = cast(asyncio.Task[None], task)
+            watcher_history.append(watcher)
+            watcher_started.put_nowait(watcher)
+        return task
+
+    monkeypatch.setattr(Context, "spawn", observe_spawn)
     try:
         await host.load_all()
         runtime_runner = asyncio.create_task(host.run_runtime_services())
-
-        async def watcher_task() -> asyncio.Task[None]:
-            async def find() -> asyncio.Task[None]:
-                while True:
-                    for task in asyncio.all_tasks():
-                        if task.get_name() == "plugin-task:agent-restart-watcher":
-                            return cast(asyncio.Task[None], task)
-                    await asyncio.sleep(0)
-
-            return await asyncio.wait_for(find(), 2)
-
-        old_watcher: asyncio.Task[None] | None = None
-        watcher_history: list[asyncio.Task[None]] = []
-        stop_watcher_monitor: asyncio.Event | None = None
-
-        async def monitor_watchers() -> None:
-            while not stop_watcher_monitor.is_set():
-                for task in asyncio.all_tasks():
-                    if (
-                        task.get_name() == "plugin-task:agent-restart-watcher"
-                        and task not in watcher_history
-                    ):
-                        watcher_history.append(cast(asyncio.Task[None], task))
-                await asyncio.sleep(0)
-
-        if supervised:
-            old_watcher = await watcher_task()
-            watcher_history.append(old_watcher)
-            stop_watcher_monitor = asyncio.Event()
-            watcher_monitor = asyncio.create_task(monitor_watchers())
+        old_watcher = await asyncio.wait_for(watcher_started.get(), 2) if supervised else None
         stable = host.current_snapshot
         assert stable is not None
         stable_generation_ids = {
@@ -994,11 +972,7 @@ async def test_restart_provider_candidate_preserves_formal_root_identity(
         assert commits == []
         assert gate.permit_count == 0
         if supervised:
-            await asyncio.wait_for(_wait_for_watcher_count(watcher_history, 2), 2)
-            assert stop_watcher_monitor is not None
-            stop_watcher_monitor.set()
-            assert watcher_monitor is not None
-            await watcher_monitor
+            await asyncio.wait_for(watcher_started.get(), 2)
             new_watchers = [task for task in watcher_history if task is not old_watcher]
             assert new_watchers
             assert new_watchers[-1] is not old_watcher
@@ -1021,10 +995,6 @@ async def test_restart_provider_candidate_preserves_formal_root_identity(
         if "runtime_runner" in locals():
             runtime_runner.cancel()
             await asyncio.gather(runtime_runner, return_exceptions=True)
-        if watcher_monitor is not None and not watcher_monitor.done():
-            assert stop_watcher_monitor is not None
-            stop_watcher_monitor.set()
-            await watcher_monitor
         await host.terminate_all()
         artifact_store.close()
         log.close()

--- a/tests/test_context_compaction_contract.py
+++ b/tests/test_context_compaction_contract.py
@@ -52,6 +52,15 @@ def test_context_overflow_keeps_real_messages_and_model_continuation() -> None:
     assert caught.value.request.continuation is projection.continuation
     assert projection.seen == snapshot
     assert snapshot[0].body.parts[0].value == "large"
+    request = ContextBuilder().build(
+        snapshot,
+        materials=Materials("trusted"),
+        model=projection,
+        max_output_tokens=0,
+    )
+    assert request.max_output_tokens == 0
+    assert request.continuation is projection.continuation
+    assert projection.seen == snapshot
 
 
 def test_summary_request_stops_at_current_soft_watermark() -> None:

--- a/tests/test_wake_gate_contract.py
+++ b/tests/test_wake_gate_contract.py
@@ -182,7 +182,7 @@ async def test_wake_provider_200_keeps_v3_request_and_delivery_contract(
     for request in requests:
         assert request["model"] == "deepseek-v4-flash"
         assert request["reasoning_effort"] == "max"
-        assert request["max_tokens"] == 4096
+        assert "max_tokens" not in request
     tool_sets = [
         {
             cast(dict[str, object], tool["function"])["name"]

--- a/tests/test_wake_messages.py
+++ b/tests/test_wake_messages.py
@@ -376,6 +376,7 @@ async def test_content_screen_and_investigation_keep_original_refs_until_provide
         task = await source.start(original.flow_id)
         assert await asyncio.wait_for(task.join(), 10) == "shared"
         assert len(control["calls"]) == 2 + truncated_id and len(control["sent"]) == 1
+        assert all(call.max_output_tokens == 0 for call in control["calls"])
         rows = log.reader(original.session_id).snapshot()
         expected = [Input, Input] + [Output, ToolResult] * (1 + truncated_id) + [Output, Input, Output, ToolResult, Output]
         assert [type(row.body) for row in rows] == expected


### PR DESCRIPTION
## 问题与结果

Wake 线上初筛只生成推理，没有生成 screen_content：实际调用 input 68,641、output 4,097、reasoning 4,097。固定 4,096 输出预算被推理耗尽，流程正确记录可重试失败，但无法完成筛选。关联 #551，为 #571 正式部署后的真实链路验收修复。

ContextBuilder 恢复 RUN-006 / decision 0010、0030 已有的 0 语义：不预留固定输出空间，provider 请求省略输出上限字段。Wake 使用该默认值，仍由 provider/model 自身输出边界限制。保留阶段 max_steps、原工具 binding、终结工具、候选 ID 校验和失败回执；显式正整数预算继续预留并发送。

## Change intent

- change_type: fix；semantic_delta: compatible；capability_owner: plugin。
- consumer_scope: ContextBuilder 的已有 provider 默认预算合同，以及 Wake 各阶段模型请求。
- runtime_patch: none；runtime_patch_reason: 只改普通 Context / Wake 插件；client_only_alternative: 客户端不能修复服务器模型请求。
- authoritative_state_owner: 模型能力与请求协议仍由 models/provider 拥有；Wake 仍拥有阶段和决定。
- protected_state: 既有 Message、绑定、Markdown、附件、候选池与 delivery 回执；没有 schema/migration。
- 允许副作用: 原 Wake 流程正常推理、筛选与经过原策略批准的投递；模型可能使用超过 4,096 的输出。
- 禁止副作用: 改正式模型/推理配置、强制筛选/发送、重放外部效果、减少持久事实、取消无关内部任务预算。

## 验证与恢复

- targeted: Context compaction、Wake message、Wake provider wire、Reply program 共 48 passed（94.52s）。
- Pyright 两个生产模块 0 errors / 0 warnings；git diff --check 通过。
- 同一 900/1,000 输入窗口：显式 200 保持 ContextOverflow；0 保持原消息/continuation 并通过，不借 capability 猜测预留值。
- 既有 Wake 两阶段真实 provider 协议 fixture 核对 max_tokens 缺席，仍完成 delivered；候选截短先错误再纠正并仅投递一次。
- 预算与文档版 Gate `20260910-061807-c5699f8a` 通过；随后完整 CI `34411517297` 为 1 failed / 1,862 passed / 6 skipped。失败是 restart 候选测试的 5 秒清理超时，本地也复现；未合并失败版本。
- 诊断确认测试的 all_tasks/sleep(0) 忙轮询拖慢了清理线程的 rmtree。以真实 Context.spawn 返回值记录 watcher，保留原 5 秒期限、lease 等待与两代 Root 身份断言；移除轮询与其管理代码。恢复阶段由 4.745s 降至 0.020s，整个 restart 模块 13 passed（12.31s）。生产清理代码未改。
- 最终 head `4b1fd809ae9f0376d3dd7a6cd471130d06ef8482` 的 Gate 全部通过：报告 `20260910-064632-e498becf`，plan `db3a1b4cead3bae1d7df9f35d5edc06184559a6eba0517448798a9a29c35febc`，source `88bdecf40220ad6c562dc05acc351cd1760f92c143b306c293b60a6854548de9`；完整 CI `34413859146` 全部通过：Python 1,863 passed / 6 skipped（1000.52s）、Web 101 passed、SDK 2 passed、远端 Gate 通过。
- 重启测试按仓库 tests Pyright 配置检查为 0 errors / 92 warnings，与基线相同；预算的两个生产模块仍为 0 errors / 0 warnings。
- 真实 provider 只读复验原失败 flow 的全部 100 个候选：返回 screen_content / 8 个完整有效 ID，input 66,424、output 9,628、reasoning 8,711，82.75s；未调用工具、未提交 Wake 决定、未产生投递。说明固定 4,096 不足，不能把此模型复验称为正式发送成功。
- 已合并为 `4f9173c188a16289f0ac08d786f667e75df185d4`；合并 tree 与最终固定 head 一致。正式部署与部署后 E2E / 500 秒观察已完成，见下方回执。
- 恢复点: pre-wake-provider-budget.bundle、五文件 before-image、已验证正式完整备份；先前线上提交 1473f035。

## 正交性与工作手册

无新增概念、模型绑定或生命周期 owner；不把 capability 上界复制为请求默认值。正常/失败链仍为 Wake → run_reply → Context → provider → 工具或 Control.failure。
已核对 RUN-006、RUN-009、RUN-011、decision 0010/0030；本修复恢复已有合同。另以独立文档提交删除 NOW 中已完成正式切换验收的 Message/回复链插件化节，其他未完成合同原样保留。
独立 production_fixes_review / gpt-5.6-terra / xhigh 已通过预算和 NOW 版本 71938fe2；已固定最终 head 4b1fd809ae9f0376d3dd7a6cd471130d06ef8482 通过确定性测试修复复核，零 must-fix。真实 spawn 完整执行后才记录 Task，两代 watcher、旧 lease、正式 Root 身份和原 5 秒期限均保留。

## 正式部署验收（2026-09-10）

hua-home 已通过正式发布链激活 `4f9173c188a16289f0ac08d786f667e75df185d4`（#590）；运行镜像 revision、进程提交及 Wake/Context 源码哈希与通过 CI 的 tree 一致。

- 连续观察 500.68 秒：Core/Workloads 持续 healthy、零重启、无 OOM，Core 新增 1 次 GitHub 连接重试耗尽 warning，无 error；既有冷却后于 23:26:03 UTC 日志确认 GitHub transport recovered。
- plugin doctor：51 个插件全部 healthy，14 个外部插件；退役安装已卸载，Skill 检查通过。
- 正式 programmatic session `programmatic:pr571-551-final-4f9173c1` 为 learning=excluded。真实 ToolSearch binding 逐项匹配 53 个公开工具；Steam 在线人数、Calendar 日历列表、GitHub Watch runtime info、Scheduler 列表全部成功，整轮 complete。
- Observe 持久游标已追上本轮 E2E；Markdown 的正式 MEMORY +100 / SELF +4 回执、原条目、before-image 和 155 个 Message 引用复核通过。
- 原 17,539 条 Message、325 条 binding、642 条消息绑定与 9 条附件关联逐行哈希保持一致；完整备份已完成恢复核验。
- 公网 WebSocket 实际收到 server.challenge；Host Bridge 与正式服务单元 active。
- Wake 原 100 候选的真实只读模型复验返回 8 个完整有效 ID（总输出 9,628 token）；部署后有效初筛 0 次。最新自然初筛因非法 JSON 参数明确 failure/defer；同批候选只读复验再次选中 8 个有效 ID（总输出 9,148 token）。模型复验未提交决定或发送消息，不作为手机送达证据。窗口后 Telegram 仍有瞬断并自动重试。

Core #571、#586、#587、#588、#589、#590，Calendar #10 和 Fleet #2 均已合并；关联 #551 已关闭。53 项为目录覆盖核验，未执行所有有写入副作用的工具。
