### PR TITLE
[codex] 恢复 Workbench 重构前完整样式

### DIFF
--- a/frontend/plugins/workbench_ui/src/index.tsx
+++ b/frontend/plugins/workbench_ui/src/index.tsx
@@ -1,16 +1,17 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
+import { ChevronDown, ChevronLeft, ChevronRight, X } from "lucide-react";
+import { MaterialIconButton } from "@akashic/web-ui-v1";
 import type { WebEntryView, WebHostContextV1, WebUiDisposer } from "@akashic/web-ui-v1";
 import type { WorkbenchUi } from "@akashic/workbench-ui-v2";
-import type { FetchPageResult, PluginConfig, PluginDispatch, PluginState, SortOrder } from "./types";
+import type { DashboardColumn, FetchPageResult, PluginConfig, PluginDispatch, PluginState, SortOrder } from "./types";
 import { api, bindApiRequest } from "./api";
-import { formatSessionKeyForTable, shortTs, stripMarkdown } from "./format";
+import { formatSessionKeyForTable, relativeTime, roleClass, shortTs, stripMarkdown } from "./format";
 import { akashicBrandIcon } from "./brand";
 import { PluginDetail, PluginMain, mountPluginDom } from "./PluginDetail";
-import { Chip as WorkbenchChip, Grid, JsonView } from "./ui";
+import { Btn, Chip as WorkbenchChip, Grid, JsonView, Markdown } from "./ui";
 import { MetricTile, Sparkline, TrendChart } from "./charts";
 import "./style.css";
-import "./messages.css";
 
 const WORKBENCH_UI = {
   Chip: WorkbenchChip,
@@ -162,6 +163,7 @@ interface SessionRow {
   first_message_content: string;
   attributes: { visibility: "listed" | "internal"; learning: string };
 }
+
 interface MessageRow {
   id: string;
   session_id: string;
@@ -171,20 +173,119 @@ interface MessageRow {
   source: string;
   body: { kind: string; parts?: { kind: string; value?: unknown }[] };
 }
-interface SessionPage { items: SessionRow[]; total: number; next_cursor: [string, string] | null }
-interface MessagePage { items: MessageRow[]; through_seq: number; next_before_seq: number | null; has_more: boolean }
 
-function Messages({ selected, select }: { selected: string | null; select(key: string): void }): React.ReactElement {
+interface SessionPage {
+  items: SessionRow[];
+  total: number;
+  next_cursor: [string, string] | null;
+}
+
+interface MessagePage {
+  items: MessageRow[];
+  through_seq: number;
+  next_before_seq: number | null;
+  has_more: boolean;
+}
+
+interface NavigationProps {
+  currentPluginId: string | null;
+  sessionsCount: number;
+  plugins: PluginConfig[];
+  counts: Record<string, number | null>;
+  onSelect(pluginId: string | null): void;
+}
+
+function Brand(): React.ReactElement {
+  return <div className="brand">
+    <img className="brand-mark" src={akashicBrandIcon} alt="" />
+    <div><div className="brand-title">Akashic</div><div className="brand-sub">Dashboard</div></div>
+  </div>;
+}
+
+function ModuleSwitcher(props: NavigationProps): React.ReactElement {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const current = props.plugins.find((plugin) => plugin.id === props.currentPluginId) ?? null;
+  const currentLabel = current?.label ?? "Sessions";
+  const currentCount = current ? props.counts[current.id] ?? 0 : props.sessionsCount;
+
+  useEffect(() => {
+    if (!open) return;
+    const closeOutside = (event: PointerEvent): void => {
+      if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    const closeOnEscape = (event: KeyboardEvent): void => {
+      if (event.key !== "Escape") return;
+      setOpen(false);
+      triggerRef.current?.focus();
+    };
+    document.addEventListener("pointerdown", closeOutside);
+    document.addEventListener("keydown", closeOnEscape);
+    return () => {
+      document.removeEventListener("pointerdown", closeOutside);
+      document.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [open]);
+
+  const select = (pluginId: string | null): void => {
+    props.onSelect(pluginId);
+    setOpen(false);
+    queueMicrotask(() => triggerRef.current?.focus());
+  };
+
+  return <div className="module-switcher" ref={rootRef}>
+    <button ref={triggerRef} className="module-switcher-trigger" type="button" aria-expanded={open}
+      aria-controls="workbench-module-options" onClick={() => setOpen((current) => !current)}>
+      <span className="module-switcher-label">{currentLabel}</span>
+      <span className="module-switcher-meta"><span className="module-switcher-count">{currentCount}</span>
+        <ChevronDown className={open ? "open" : ""} size={16} aria-hidden="true" /></span>
+    </button>
+    <div id="workbench-module-options" className="module-switcher-options" hidden={!open}>
+      <button className={`module-switcher-option ${props.currentPluginId === null ? "active" : ""}`} type="button"
+        aria-current={props.currentPluginId === null ? "page" : undefined} onClick={() => select(null)}>
+        <span>Sessions</span><span>{props.sessionsCount}</span>
+      </button>
+      {props.plugins.map((plugin) => <button key={plugin.id}
+        className={`module-switcher-option ${props.currentPluginId === plugin.id ? "active" : ""}`} type="button"
+        aria-current={props.currentPluginId === plugin.id ? "page" : undefined} onClick={() => select(plugin.id)}>
+        <span>{plugin.label}</span><span>{props.counts[plugin.id] ?? 0}</span>
+      </button>)}
+    </div>
+  </div>;
+}
+
+function SessionNavItem(props: { session: SessionRow; active: boolean; onSelect(): void }): React.ReactElement {
+  const title = stripMarkdown(props.session.first_message_content).trim() || formatSessionKeyForTable(props.session.key);
+  return <button className={`session-item ${props.active ? "active" : ""}`} type="button"
+    aria-current={props.active ? "page" : undefined} title={`${title}\n${props.session.key}`} onClick={props.onSelect}>
+    <div className="nav-item-row"><span className="nav-item-name">{title}</span>
+      <span className="nav-item-count" title={`${props.session.message_count} 条消息`}>{props.session.message_count}</span></div>
+    <div className="nav-item-desc"><span>{props.session.attributes.visibility === "internal" ? "内部" : props.session.key.split(":", 1)[0]}</span>
+      <span aria-hidden="true">·</span><span>{relativeTime(props.session.updated_at)}</span></div>
+  </button>;
+}
+
+function messageText(message: MessageRow): string {
+  return message.body.parts
+    ?.filter((part) => part.kind === "text" && typeof part.value === "string")
+    .map((part) => String(part.value))
+    .join("\n") ?? "";
+}
+
+function Messages(props: NavigationProps & { selected: string | null; select(key: string | null): void }): React.ReactElement {
   const [sessions, setSessions] = useState<SessionPage>({ items: [], total: 0, next_cursor: null });
   const [prefix, setPrefix] = useState("");
   const [visibility, setVisibility] = useState("");
   const [page, setPage] = useState<MessagePage | null>(null);
+  const [activeMessage, setActiveMessage] = useState<MessageRow | null>(null);
   const [error, setError] = useState<string | null>(null);
   const sessionRequest = useRef<AbortController | null>(null);
   const messageRequest = useRef<AbortController | null>(null);
   const report = useCallback((error: unknown): void => {
     if (!isAbortError(error)) setError(error instanceof Error ? error.message : String(error));
   }, []);
+
   const loadSessions = useCallback(async (cursor: [string, string] | null = null) => {
     sessionRequest.current?.abort();
     const controller = new AbortController();
@@ -204,9 +305,13 @@ function Messages({ selected, select }: { selected: string | null; select(key: s
       setError(null);
     }
   }, [prefix, visibility]);
+
   const loadMessages = useCallback(async (older: MessagePage | null = null) => {
     messageRequest.current?.abort();
-    if (selected === null) { setPage(null); return; }
+    if (props.selected === null) {
+      setPage(null);
+      return;
+    }
     const controller = new AbortController();
     messageRequest.current = controller;
     const query = new URLSearchParams({ limit: "50" });
@@ -216,7 +321,7 @@ function Messages({ selected, select }: { selected: string | null; select(key: s
     }
     let result: MessagePage;
     try {
-      result = await api<MessagePage>(`/api/dashboard/sessions/${encodeURIComponent(selected)}/messages?${query}`, { signal: controller.signal });
+      result = await api<MessagePage>(`/api/dashboard/sessions/${encodeURIComponent(props.selected)}/messages?${query}`, { signal: controller.signal });
     } catch (error) {
       if (!controller.signal.aborted) throw error;
       return;
@@ -225,65 +330,126 @@ function Messages({ selected, select }: { selected: string | null; select(key: s
       setPage({ ...result, items: older ? [...result.items, ...older.items] : result.items });
       setError(null);
     }
-  }, [selected]);
-  useEffect(() => { void loadSessions().catch(report); return () => sessionRequest.current?.abort(); }, [loadSessions, report]);
-  useEffect(() => { setPage(null); void loadMessages().catch(report); return () => messageRequest.current?.abort(); }, [loadMessages, report]);
-  return <div className="message-inspector">
-    <aside className="message-sessions" aria-label="会话目录">
-      <label>会话前缀<input value={prefix} placeholder="例如 akashic:" onChange={(event) => setPrefix(event.target.value)} /></label>
-      <label>可见范围<select value={visibility} onChange={(event) => setVisibility(event.target.value)}>
-        <option value="">全部会话</option><option value="listed">普通会话</option><option value="internal">内部会话</option>
-      </select></label>
-      <div className="message-toolbar"><span>{sessions.total} 个会话</span><button onClick={() => void loadSessions().catch(report)}>刷新</button></div>
-      {sessions.items.map((session) => <button type="button" key={session.key} aria-current={selected === session.key ? "true" : undefined}
-        className="message-session" onClick={() => select(session.key)}>
-        <strong>{session.first_message_content || session.key}</strong>
-        <small>{session.key}</small><small>{session.message_count} 条 · {shortTs(session.updated_at)} · {session.attributes.visibility === "internal" ? "内部" : "普通"}</small>
-      </button>)}
-      {sessions.next_cursor && <button onClick={() => void loadSessions(sessions.next_cursor).catch(report)}>更多会话</button>}
+  }, [props.selected]);
+
+  useEffect(() => {
+    void loadSessions().catch(report);
+    return () => sessionRequest.current?.abort();
+  }, [loadSessions, report]);
+  useEffect(() => {
+    setPage(null);
+    setActiveMessage(null);
+    void loadMessages().catch(report);
+    return () => messageRequest.current?.abort();
+  }, [loadMessages, report]);
+
+  const messageColumns = "64px 86px minmax(220px, 1fr) 110px 92px 104px";
+  return <div className="shell">
+    <aside className="sessions-pane" aria-label="会话目录">
+      <Brand />
+      <ModuleSwitcher {...props} sessionsCount={sessions.total} />
+      <div className="explorer-body">
+        <div className="filters-stack session-filters">
+          <label className="search search-small"><span aria-hidden="true">⌕</span>
+            <input aria-label="会话前缀" value={prefix} placeholder="例如 akashic:" onChange={(event) => setPrefix(event.target.value)} />
+          </label>
+          <select aria-label="可见范围" value={visibility} onChange={(event) => setVisibility(event.target.value)}>
+            <option value="">全部范围</option><option value="listed">普通</option><option value="internal">内部</option>
+          </select>
+        </div>
+        <div className="session-list">
+          <button className={`all-messages-row ${props.selected === null ? "active" : ""}`} type="button"
+            onClick={() => props.select(null)}><span>全部会话</span><strong>{sessions.total}</strong></button>
+          {sessions.items.map((session) => <SessionNavItem key={session.key} session={session}
+            active={props.selected === session.key} onSelect={() => props.select(session.key)} />)}
+          {sessions.next_cursor && <Btn size="sm" variant="ghost" onClick={() => void loadSessions(sessions.next_cursor).catch(report)}>更多会话</Btn>}
+        </div>
+      </div>
     </aside>
-    <main className="message-records">
-      <div className="message-toolbar"><h2>{selected ?? "选择会话"}</h2>
-        {selected && <button onClick={() => void loadMessages().catch(report)}>读取最新消息</button>}</div>
-      <p className="message-note">消息按原始顺序保存。编辑、撤销和删除尚未接入；历史摘要记录保持保留。</p>
-      {error && <p role="alert" className="message-error">{error}</p>}
-      {page?.has_more && <button onClick={() => void loadMessages(page).catch(report)}>读取更早消息</button>}
-      {page?.items.map((message) => <article className="message-record" key={message.id}>
-        <div className="message-toolbar"><strong>#{message.seq} · {message.author}</strong>
-          <span>{message.source} · {message.body.kind} · {shortTs(message.timestamp)}</span></div>
-        {message.body.parts?.filter((part) => part.kind === "text" && typeof part.value === "string")
-          .map((part, index) => <p className="message-text" key={index}>{String(part.value)}</p>)}
-        <details><summary>原始 Message · {message.id}</summary><JsonView value={message} /></details>
-      </article>)}
-      {selected && page?.items.length === 0 && <p>此会话没有消息。</p>}
-    </main>
+    <section className="content-shell">
+      <header className="content-toolbar">
+        <div className="content-filters"><div className="filter-row">
+          {props.selected ? <div className="active-session-chip"><span>Session</span><code>{props.selected}</code>
+            <button aria-label="清除 Session 筛选" type="button" onClick={() => props.select(null)}>×</button></div>
+            : <span className="muted-text">从左侧选择一个 Session 查看原始消息</span>}
+        </div></div>
+        <div className="content-toolbar-actions"><Btn size="sm" variant="ghost" onClick={() => void loadSessions().catch(report)}>刷新会话</Btn>
+          {props.selected && <Btn size="sm" variant="secondary" onClick={() => void loadMessages().catch(report)}>读取最新消息</Btn>}</div>
+      </header>
+      {error && <div role="alert" className="plugin-entry-error"><strong>请求失败</strong><span>{error}</span></div>}
+      <main className="workspace">
+        <section className="messages-pane">
+          <div className="table-head" style={{ gridTemplateColumns: messageColumns }}>
+            <div>Seq</div><div>Author</div><div>Content</div><div>Source</div><div>Kind</div><div>Timestamp</div>
+          </div>
+          <div className="table-body">
+            {page?.has_more && <div className="pane-head"><Btn size="sm" variant="ghost" onClick={() => void loadMessages(page).catch(report)}>读取更早消息</Btn></div>}
+            {page?.items.map((message) => <div className="table-row-wrap" key={message.id}>
+              <button className={`table-row table-row ${activeMessage?.id === message.id ? "active" : ""}`} style={{ gridTemplateColumns: messageColumns }}
+                type="button" aria-expanded={activeMessage?.id === message.id} onClick={() => setActiveMessage((current) => current?.id === message.id ? null : message)}>
+                <span className="cell-seq mono">#{message.seq}</span>
+                <span><span className={`role-pill ${roleClass(message.author)}`}>{message.author}</span></span>
+                <span className="content-preview">{stripMarkdown(messageText(message))}</span>
+                <span className="cell-source">{message.source}</span>
+                <span className="cell-type">{message.body.kind}</span>
+                <span className="cell-time mono">{shortTs(message.timestamp)}</span>
+              </button>
+            </div>)}
+            {props.selected && page?.items.length === 0 && <div className="empty-state">此会话没有消息。</div>}
+            {!props.selected && <div className="empty-state">选择 Session 后，这里会显示按原始顺序保存的 Message。</div>}
+          </div>
+          <footer className="table-foot"><div>{page ? `已读取 ${page.items.length} 条` : "消息只读视图"}</div>
+            <div className="muted-text">编辑、撤销和删除尚未接入；历史摘要保持保留</div></footer>
+        </section>
+        <aside className={`detail-pane ${activeMessage ? "is-open" : ""}`} aria-label="详情">
+          {activeMessage ? <MessageDetail message={activeMessage} onClose={() => setActiveMessage(null)} />
+            : <div className="detail-empty"><div className="detail-empty-title">详情</div><div className="detail-empty-text">点开一条消息后，这里会显示完整正文和原始字段。</div></div>}
+        </aside>
+      </main>
+    </section>
+  </div>;
+}
+
+function MessageDetail({ message, onClose }: { message: MessageRow; onClose(): void }): React.ReactElement {
+  return <div className="detail-wrap">
+    <div className="detail-toolbar"><div><div className="detail-title">消息详情</div>
+      <div className="detail-subtext">{message.session_id} · #{message.seq}</div></div>
+      <MaterialIconButton variant="standard" label="关闭详情" onClick={onClose}><X size={18} aria-hidden="true" /></MaterialIconButton></div>
+    <div className="detail-grid">
+      {detailRow("author", <span className={`role-pill ${roleClass(message.author)}`}>{message.author}</span>)}
+      {detailRow("source", <code>{message.source}</code>)}
+      {detailRow("time", <code>{message.timestamp}</code>)}
+      {detailRow("id", <code>{message.id}</code>)}
+    </div>
+    <div className="detail-block"><div className="detail-label">Content</div><Markdown className="detail-content">{messageText(message)}</Markdown></div>
+    <div className="detail-block"><div className="detail-label">Raw Message</div><JsonView value={message} /></div>
   </div>;
 }
 
 type SlotRenderer = (host: HTMLElement, dispatch: PluginDispatch) => void | WebUiDisposer;
-function Slot({ plugin, render, dispatch }: { plugin: PluginConfig; render: SlotRenderer; dispatch: PluginDispatch }): React.ReactElement {
+
+function Slot({ plugin, render, dispatch, slot }: { plugin: PluginConfig; render: SlotRenderer; dispatch: PluginDispatch; slot: string }): React.ReactElement {
   const ref = useRef<HTMLDivElement>(null);
   useLayoutEffect(() => ref.current ? plugin.applyStyle(ref.current) : undefined, [plugin]);
   const filters = JSON.stringify(dispatch.filters);
   useEffect(() => {
-    if (ref.current) {
-      const host = ref.current;
-      return mountPluginDom(host, plugin.id, "slot", () => render(host, dispatch));
-    }
-  }, [plugin, render, dispatch, filters, dispatch.sortBy, dispatch.sortOrder]);
+    if (!ref.current) return;
+    const host = ref.current;
+    return mountPluginDom(host, plugin.id, slot, () => render(host, dispatch));
+  }, [plugin, render, dispatch, filters, dispatch.sortBy, dispatch.sortOrder, slot]);
   return <div ref={ref} />;
 }
 
-function Panel({ plugin }: { plugin: PluginConfig }): React.ReactElement {
+function Panel(props: { plugin: PluginConfig } & NavigationProps): React.ReactElement {
+  const { plugin } = props;
   const [state, setState] = useState<PluginState>({ page: 1, pageSize: plugin.pageSize ?? 25,
     total: 0, items: [], activeRowKey: null, activeDetail: null, filters: {},
     sortBy: plugin.defaultSortBy ?? "", sortOrder: plugin.defaultSortOrder ?? "desc", selectedIds: new Set() });
+  const [detailLoading, setDetailLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const readState = useLatestReader(state);
   const request = useRef<AbortController | null>(null);
   const detailRequest = useRef<AbortController | null>(null);
-  const ref = useRef<HTMLDivElement>(null);
-  useLayoutEffect(() => ref.current ? plugin.applyStyle(ref.current) : undefined, [plugin]);
   const startRead = useCallback(() => {
     request.current?.abort();
     detailRequest.current?.abort();
@@ -296,6 +462,7 @@ function Panel({ plugin }: { plugin: PluginConfig }): React.ReactElement {
   }, []);
   const closeDetail = useCallback(() => {
     detailRequest.current?.abort();
+    setDetailLoading(false);
     setState((state) => ({ ...state, activeRowKey: null, activeDetail: null }));
   }, []);
   const applyPage = useCallback((update: (state: PluginState) => PluginState) => {
@@ -316,22 +483,33 @@ function Panel({ plugin }: { plugin: PluginConfig }): React.ReactElement {
       return;
     }
     if (!controller.signal.aborted) {
-      detailRequest.current?.abort();
       setState((state) => ({ ...state, ...result, page: page ?? current.page, activeRowKey: null, activeDetail: null, selectedIds: new Set() }));
+      setDetailLoading(false);
       setError(null);
     }
   }, [plugin, readState, startRead]);
+
   useEffect(() => {
     void load().catch(report);
     const refresh = () => void load().catch(report);
     window.addEventListener("akashic-dashboard-refresh", refresh);
-    return () => { request.current?.abort(); detailRequest.current?.abort(); window.removeEventListener("akashic-dashboard-refresh", refresh); };
+    return () => {
+      request.current?.abort();
+      detailRequest.current?.abort();
+      window.removeEventListener("akashic-dashboard-refresh", refresh);
+    };
   }, [load, report]);
+
   const open = async (item: Record<string, unknown>) => {
+    const key = String(item[plugin.rowKey] ?? "");
+    if (readState().activeRowKey === key) {
+      closeDetail();
+      return;
+    }
     detailRequest.current?.abort();
     const controller = new AbortController();
     detailRequest.current = controller;
-    const key = String(item[plugin.rowKey]);
+    setDetailLoading(true);
     setState((state) => ({ ...state, activeRowKey: key, activeDetail: null }));
     setError(null);
     try {
@@ -342,63 +520,136 @@ function Panel({ plugin }: { plugin: PluginConfig }): React.ReactElement {
         setState((state) => ({ ...state, activeRowKey: null, activeDetail: null }));
         report(error);
       }
+    } finally {
+      if (!controller.signal.aborted) setDetailLoading(false);
     }
   };
-  const columns = [
-    ...(plugin.batchActions?.length ? ["40px"] : []),
-    ...plugin.columns.map((column) => column.flex ? "minmax(0, 1fr)"
-      : column.width ? `minmax(0, ${column.width}px)` : "minmax(0, auto)"),
-  ].join(" ");
-  return <div ref={ref} className="message-panel">
-    <div className="message-toolbar"><h2>{plugin.viewLabel ?? plugin.label}</h2><span>{plugin.countTitle?.(state.total) ?? `${state.total} 条`}</span>
-      <button onClick={() => void load().catch(report)}>刷新</button>
-      {plugin.renderTopbarAction && <Slot plugin={plugin} render={plugin.renderTopbarAction} dispatch={dispatch} />}</div>
-    {error && <p role="alert" className="message-error">{error}</p>}
-    {plugin.renderNavBody && <Slot plugin={plugin} render={plugin.renderNavBody} dispatch={dispatch} />}
-    {plugin.renderFilters && <Slot plugin={plugin} render={plugin.renderFilters} dispatch={dispatch} />}
-    {plugin.layout === "workbench" && plugin.renderMain ? <PluginMain plugin={plugin} dispatch={dispatch} /> : <>
-      <div className="message-toolbar">{plugin.batchActions?.map((action) => <button key={action.label} className={action.className}
-        disabled={!state.selectedIds.size} onClick={() => {
-          if (window.confirm(`${action.label}：已选择 ${state.selectedIds.size} 项，是否继续？`)) {
-            void action.run([...state.selectedIds]).then(() => load()).catch(report);
-          }
-        }}>{action.label}</button>)}</div>
-      <div className="message-table-scroll"><table role="table"><thead role="rowgroup"><tr role="row" style={{ gridTemplateColumns: columns }}>
-        {plugin.batchActions?.length ? <th>选择</th> : null}
-        {plugin.columns.map((column) => <th key={column.key} style={{ textAlign: column.align }}>
-          {!column.sortable ? column.label : <button onClick={() => dispatch.setSort(column.key)}>{column.label}{state.sortBy === column.key ? state.sortOrder === "asc" ? " ↑" : " ↓" : ""}</button>}
-        </th>)}
-      </tr></thead><tbody>{state.items.map((item) => <tr role="row" key={String(item[plugin.rowKey])} style={{ gridTemplateColumns: columns }} className={plugin.rowClass?.(item)}>
-        {plugin.batchActions?.length ? <td><input type="checkbox" aria-label={`选择 ${String(item[plugin.rowKey])}`} checked={state.selectedIds.has(String(item[plugin.rowKey]))}
-          onChange={(event) => setState((state) => {
-            const selectedIds = new Set(state.selectedIds);
-            if (event.target.checked) selectedIds.add(String(item[plugin.rowKey])); else selectedIds.delete(String(item[plugin.rowKey]));
-            return { ...state, selectedIds };
-          })} /></td> : null}
-        {plugin.columns.map((column, index) => {
-          const value = item[column.key];
-          const format = plugin.formatters?.[column.fmt ?? ""] ?? WORKBENCH_FORMATTERS[column.fmt ?? "text"];
-          // v2 的自定义 renderer 自己转义 HTML；普通 formatter 仍是文本。
-          const cell = column.renderCell
-            ? <span dangerouslySetInnerHTML={{ __html: column.renderCell(value, item) }} />
-            : format ? format(value, item) : String(value ?? "");
-          return <td key={column.key} className={column.cellClass} style={{ textAlign: column.align }} title={column.rawTitle ? String(value) : undefined}>
-            {index === 0 ? <button onClick={() => void open(item).catch(report)}>{cell}</button> : cell}</td>;
-        })}
-      </tr>)}</tbody></table></div>
-      {!state.items.length && <p>{plugin.emptyMessage ?? "没有记录。"}</p>}
-      <div className="message-toolbar"><button disabled={state.page <= 1} onClick={() => void load(state.page - 1).catch(report)}>上一页</button>
-        <span>第 {state.page} 页</span><button disabled={state.page * state.pageSize >= state.total} onClick={() => void load(state.page + 1).catch(report)}>下一页</button></div>
-    </>}
-    {state.activeRowKey && <section className="message-panel-detail"><button onClick={closeDetail}>关闭详情</button>
-      {state.activeDetail ? plugin.renderDetail ? <PluginDetail plugin={plugin} item={state.activeDetail} dispatch={dispatch} /> : <JsonView value={state.activeDetail} /> : <p>正在读取…</p>}
-    </section>}
+
+  const hasBatch = Boolean(plugin.batchActions?.length);
+  const columns = `${hasBatch ? "32px " : ""}${gridTemplate(plugin.columns)}`;
+  const pageCount = Math.max(1, Math.ceil(state.total / state.pageSize));
+  const workbenchLayout = plugin.layout === "workbench" && plugin.renderMain;
+  return <div className="shell">
+    <aside className="sessions-pane">
+      <Brand />
+      <ModuleSwitcher {...props} sessionsCount={props.sessionsCount} />
+      <div className="explorer-body">{plugin.renderNavBody
+        ? <Slot plugin={plugin} render={plugin.renderNavBody} dispatch={dispatch} slot="navigation" />
+        : <div className="detail-empty"><div className="detail-empty-title">{plugin.label}</div>
+          <div className="detail-empty-text">此面板没有额外导航。</div></div>}</div>
+    </aside>
+    <section className="content-shell">
+      <header className="content-toolbar">
+        <div className="content-filters">{plugin.renderFilters
+          ? <Slot plugin={plugin} render={plugin.renderFilters} dispatch={dispatch} slot="filters" />
+          : <div className="filter-row"><strong>{plugin.viewLabel ?? plugin.label}</strong></div>}</div>
+        <div className="content-toolbar-actions"><span className="muted-text">{plugin.countTitle?.(state.total) ?? `${state.total} 条`}</span>
+          <Btn size="sm" variant="ghost" onClick={() => void load().catch(report)}>刷新</Btn>
+          {plugin.renderTopbarAction && <Slot plugin={plugin} render={plugin.renderTopbarAction} dispatch={dispatch} slot="topbar action" />}</div>
+      </header>
+      {error && <div role="alert" className="plugin-entry-error"><strong>请求失败</strong><span>{error}</span></div>}
+      <main className={`workspace ${workbenchLayout ? "plugin-workbench-mode" : ""}`}>
+        {workbenchLayout ? <section className="plugin-workbench-pane"><PluginMain plugin={plugin} dispatch={dispatch} /></section> : <>
+          <section className="messages-pane">
+            {state.selectedIds.size > 0 && <div className="batch-bar"><span>已选 {state.selectedIds.size} 条</span>
+              {plugin.batchActions?.map((action) => <Btn key={action.label} size="sm" variant="secondary" className={action.className}
+                onClick={() => void action.run([...state.selectedIds]).then(() => load()).catch(report)}>{action.label}</Btn>)}
+              <Btn size="sm" variant="ghost" onClick={() => setState((state) => ({ ...state, selectedIds: new Set() }))}>取消选择</Btn></div>}
+            <div className="table-head" style={{ gridTemplateColumns: columns }}>
+              {hasBatch && <div />}
+              {plugin.columns.map((column) => column.sortable
+                ? <SortHead key={column.key} label={column.label} active={state.sortBy === column.key} order={state.sortOrder}
+                    onClick={() => dispatch.setSort(column.key)} />
+                : <div key={column.key}>{column.label}</div>)}
+            </div>
+            <div className="table-body">{state.items.length ? state.items.map((item) => {
+              const key = String(item[plugin.rowKey] ?? "");
+              const selected = state.selectedIds.has(key);
+              return <div className="table-row-wrap" key={key}>
+                {hasBatch && <label className="checkbox-cell"><input type="checkbox" aria-label={`选择 ${key}`} checked={selected}
+                  onChange={(event) => setState((state) => {
+                    const selectedIds = new Set(state.selectedIds);
+                    if (event.target.checked) selectedIds.add(key); else selectedIds.delete(key);
+                    return { ...state, selectedIds };
+                  })} /></label>}
+                <button className={`table-row table-row ${state.activeRowKey === key ? "active" : ""} ${selected ? "selected" : ""} ${plugin.rowClass?.(item) ?? ""}`}
+                  style={{ gridTemplateColumns: columns }} type="button" aria-expanded={state.activeRowKey === key}
+                  onClick={() => void open(item).catch(report)}>
+                  {hasBatch && <span aria-hidden="true" />}
+                  {plugin.columns.map((column) => column.renderCell
+                    ? <span key={column.key} className={columnCellClass(column)} title={column.rawTitle ? String(item[column.key] ?? "") : undefined}
+                        dangerouslySetInnerHTML={{ __html: column.renderCell(item[column.key], item) }} />
+                    : <span key={column.key} className={columnCellClass(column)} title={column.rawTitle ? String(item[column.key] ?? "") : undefined}>
+                        {formatPluginCell(plugin, column, item)}</span>)}
+                </button>
+              </div>;
+            }) : <div className="empty-state">{plugin.emptyMessage ?? "暂无记录。"}</div>}</div>
+            <footer className="table-foot"><div>{plugin.countTitle?.(state.total) ?? `共 ${state.total} 条`}</div>
+              <div className="pager"><MaterialIconButton variant="standard" label="上一页" disabled={state.page <= 1}
+                onClick={() => void load(state.page - 1).catch(report)}><ChevronLeft size={18} aria-hidden="true" /></MaterialIconButton>
+                <span>{state.page} / {pageCount}</span>
+                <MaterialIconButton variant="standard" label="下一页" disabled={state.page >= pageCount}
+                  onClick={() => void load(state.page + 1).catch(report)}><ChevronRight size={18} aria-hidden="true" /></MaterialIconButton></div></footer>
+          </section>
+          <aside className={`detail-pane ${state.activeRowKey ? "is-open" : ""}`} aria-label="详情">
+            {state.activeRowKey && <button className="detail-close-btn" type="button" aria-label="关闭详情" onClick={closeDetail}>
+              <X size={18} aria-hidden="true" />
+            </button>}
+            {detailLoading ? <DetailLoading /> : state.activeRowKey
+              ? plugin.renderDetail ? <PluginDetail plugin={plugin} item={state.activeDetail} dispatch={dispatch} />
+                : <div className="detail-wrap"><div className="detail-toolbar"><div className="detail-title">详情</div></div>
+                    <JsonView value={state.activeDetail} /></div>
+              : <div className="detail-empty"><div className="detail-empty-title">详情</div><div className="detail-empty-text">点开一条记录后，这里会显示完整字段。</div></div>}
+          </aside>
+        </>}
+      </main>
+    </section>
   </div>;
+}
+
+function SortHead(props: { label: string; active: boolean; order: SortOrder; onClick(): void }): React.ReactElement {
+  return <button className={`table-sort-btn ${props.active ? "active" : ""}`} type="button" onClick={props.onClick}>
+    <span>{props.label}</span><span className="table-sort-arrow">{props.active ? props.order === "asc" ? "↑" : "↓" : ""}</span>
+  </button>;
+}
+
+function DetailLoading(): React.ReactElement {
+  return <div className="detail-loading" role="status" aria-label="正在加载详情">
+    {React.createElement("md-linear-progress", { className: "detail-loading-progress", indeterminate: true, "aria-label": "正在加载详情" })}
+    <div className="detail-loading-line detail-loading-line-short" /><div className="detail-loading-line detail-loading-line-title" />
+    <div className="detail-loading-block" /><div className="detail-loading-line" /><div className="detail-loading-line" />
+  </div>;
+}
+
+function detailRow(label: string, value: React.ReactNode): React.ReactElement {
+  return <div className="detail-row"><div className="detail-row-label">{label}</div><div className="detail-row-val">{value}</div></div>;
+}
+
+function gridTemplate(columns: DashboardColumn[]): string {
+  return columns.map((column) => column.flex ? "minmax(0, 1fr)"
+    : column.width ? `minmax(0, ${column.width}px)` : "minmax(0, auto)").join(" ");
+}
+
+function formatPluginCell(plugin: PluginConfig, column: DashboardColumn, item: Record<string, unknown>): string {
+  const value = item[column.key];
+  const formatter = plugin.formatters?.[column.fmt ?? ""] ?? WORKBENCH_FORMATTERS[column.fmt ?? "text"];
+  return formatter ? formatter(value, item) : String(value ?? "");
+}
+
+function columnCellClass(column: DashboardColumn): string {
+  const classes = [column.cellClass ?? ""];
+  if (!column.cellClass && column.fmt === "text-preview") classes.push("content-preview");
+  if (!column.cellClass && (column.fmt === "mono-session" || column.fmt === "mono-time")) {
+    classes.push(column.fmt === "mono-session" ? "mono cell-session" : "mono cell-time");
+  }
+  if (column.align === "right") classes.push("align-right");
+  return classes.filter(Boolean).join(" ");
 }
 
 function DashboardWorkspace({ initialPlugins }: { initialPlugins: PluginConfig[] }): React.ReactElement {
   const [pluginId, setPluginId] = useState<string | null>(null);
   const [session, setSession] = useState<string | null>(null);
+  const [sessionCount, setSessionCount] = useState(0);
   const [counts, setCounts] = useState<Record<string, number | null>>({});
   const [error, setError] = useState<string | null>(null);
   useEffect(() => {
@@ -407,25 +658,37 @@ function DashboardWorkspace({ initialPlugins }: { initialPlugins: PluginConfig[]
       void plugin.getCount({ signal: controller.signal }).then((count) => {
         if (count !== null && (!Number.isFinite(count) || count < 0)) throw new Error(`${plugin.id} 返回无效计数`);
         if (!controller.signal.aborted) setCounts((counts) => ({ ...counts, [plugin.id]: count }));
-      }).catch((error: unknown) => { if (!controller.signal.aborted && !isAbortError(error)) setError(error instanceof Error ? error.message : String(error)); });
+      }).catch((error: unknown) => {
+        if (!controller.signal.aborted && !isAbortError(error)) setError(error instanceof Error ? error.message : String(error));
+      });
     }
+    void api<SessionPage>("/api/dashboard/sessions?limit=1", { signal: controller.signal }).then((result) => {
+      if (!controller.signal.aborted) setSessionCount(result.total);
+    }).catch((error: unknown) => {
+      if (!controller.signal.aborted && !isAbortError(error)) setError(error instanceof Error ? error.message : String(error));
+    });
     const jump = (event: Event) => {
       const key = (event as CustomEvent<unknown>).detail;
       if (typeof key !== "string" || !key) return;
-      setSession(key); setPluginId(null);
+      setSession(key);
+      setPluginId(null);
     };
     window.addEventListener("akashic:goto-session", jump);
-    return () => { controller.abort(); window.removeEventListener("akashic:goto-session", jump); };
+    return () => {
+      controller.abort();
+      window.removeEventListener("akashic:goto-session", jump);
+    };
   }, [initialPlugins]);
-  const current = initialPlugins.find((plugin) => plugin.id === pluginId);
-  return <div className="workbench-root message-workbench">
-    <header className="message-workbench-nav"><img src={akashicBrandIcon} alt="" /><strong>工作台</strong>
-      <button aria-current={pluginId === null ? "page" : undefined} onClick={() => setPluginId(null)}>消息</button>
-      {initialPlugins.filter((plugin) => counts[plugin.id] !== null).map((plugin) => <button key={plugin.id}
-        aria-current={pluginId === plugin.id ? "page" : undefined} onClick={() => setPluginId(plugin.id)}>{plugin.label}</button>)}
-    </header>
-    {error && <p role="alert" className="message-error">{error}</p>}
-    {current ? <Panel key={current.id} plugin={current} /> : <Messages selected={session} select={setSession} />}
+  const plugins = initialPlugins.filter((plugin) => counts[plugin.id] !== null);
+  const current = plugins.find((plugin) => plugin.id === pluginId) ?? null;
+  const navigation = { currentPluginId: pluginId, sessionsCount: sessionCount, plugins, counts, onSelect: setPluginId };
+  return <div className="workbench-root">
+    {current ? <Panel key={current.id} plugin={current} {...navigation} />
+      : <Messages {...navigation} selected={session} select={setSession} />}
+    {error && <div className="workbench-modal-backdrop"><div className="workbench-modal" role="alert">
+      <div className="workbench-modal-title">工作台加载失败</div><div className="workbench-modal-sub">{error}</div>
+      <div className="workbench-modal-actions"><Btn onClick={() => setError(null)}>关闭</Btn></div>
+    </div></div>}
   </div>;
 }
 

--- a/frontend/plugins/workbench_ui/src/verify-browser.mjs
+++ b/frontend/plugins/workbench_ui/src/verify-browser.mjs
@@ -1,11 +1,15 @@
 import { build } from 'esbuild';
 import { chromium } from 'playwright-core';
-import {existsSync,mkdtempSync,readFileSync,rmSync} from 'node:fs';
+import autoprefixer from 'autoprefixer';
+import postcss from 'postcss';
+import tailwindcss from 'tailwindcss';
+import {existsSync,mkdtempSync,readFileSync,rmSync,writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {createServer} from 'node:http';
 import assert from 'node:assert/strict';
 import { fileURLToPath } from 'node:url';
+import webUiPreset from '../../../../packages/akashic-web-ui-v1/tailwind-preset.mjs';
 
 // 运行：node frontend/plugins/workbench_ui/src/verify-browser.mjs
 const repoRoot = fileURLToPath(new URL('../../../../', import.meta.url));
@@ -15,8 +19,10 @@ if (!executablePath) throw new Error('请设置 AKASHIC_PERF_CHROMIUM 指向隔�
 const root=mkdtempSync(join(tmpdir(),'workbench-panel-check-'));
 const source = `
 import {activate} from './frontend/plugins/workbench_ui/src/index.tsx';
+import {initializeTheme} from './frontend/theme/src/theme-runtime.ts';
+initializeTheme();
 const pending=new Map();
-window.fixture={calls:[],batches:[],resolve:(key,value)=>pending.get(key).resolve(value),reject:(key)=>pending.get(key).reject(new Error('late '+key))};
+window.fixture={calls:[],httpCalls:[],batches:[],resolve:(key,value)=>pending.get(key).resolve(value),reject:(key)=>pending.get(key).reject(new Error('late '+key))};
 const wait=(key)=>new Promise((resolve,reject)=>pending.set(key,{resolve,reject}));
 const rows=[{id:'slow',text:'one'},{id:'error',text:'two'},{id:'fine',text:'three'}];
 const panel={id:'fixture',label:'扩展面板',rowKey:'id',pageSize:2,columns:[{key:'id',label:'记录',width:120,renderCell:v=>'<b data-cell>'+v+'</b>'},{key:'text',label:'正文',sortable:true,flex:true}],getCount:async()=>3,
@@ -26,44 +32,60 @@ renderDetail:(row,host)=>{host.textContent='DETAIL '+row.id},
 renderFilters:(host,dispatch)=>{host.replaceChildren();for(const value of ['slow','fast','all']){const b=document.createElement('button');b.textContent='filter '+value;b.onclick=()=>dispatch.setFilter('scope',value);host.append(b)}return()=>host.replaceChildren()},
 renderNavBody:host=>{host.textContent='导航扩展'},renderTopbarAction:(host,dispatch)=>{const b=document.createElement('button');b.textContent='插件刷新';b.onclick=()=>dispatch.refresh();host.append(b);return()=>host.replaceChildren()},
 batchActions:[{label:'处理选中',className:'',run:async ids=>window.fixture.batches.push(ids)}]};
-activate({http:{request:async()=>new Response(JSON.stringify({items:[],total:0,next_cursor:null}))},ui:{inject:(_,register)=>register({register:entry=>entry.render(document.getElementById('root'),{child:()=>({entries:[panel],style:()=>()=>{}})})})}});
+const request=async path=>{window.fixture.httpCalls.push(path);return new Response(JSON.stringify(path.includes('/messages?')
+  ? {items:[{id:'message-1',session_id:'web:fixture',seq:7,timestamp:'2026-09-10T12:00:00Z',author:'assistant',source:'conversation',body:{kind:'output',parts:[{kind:'text',value:'fixture message'}]}}],through_seq:7,next_before_seq:null,has_more:false}
+  : {items:[{key:'web:fixture',created_at:'2026-09-10T11:00:00Z',updated_at:'2026-09-10T12:00:00Z',message_count:1,head_seq:7,first_message_content:'fixture session',attributes:{visibility:'listed',learning:'enabled'}}],total:1,next_cursor:null}))};
+activate({http:{request},ui:{inject:(_,register)=>register({register:entry=>entry.render(document.getElementById('root'),{child:()=>({entries:[panel],style:()=>()=>{}})})})}});
 `;
 await build({stdin:{contents:source,resolveDir:repoRoot,sourcefile:'fixture.js'},alias:{'@akashic/web-ui-v1':join(repoRoot,'frontend/theme/src/material-react.tsx')},bundle:true,format:'esm',outfile:join(root,'bundle.js'),define:{'process.env.NODE_ENV':'"production"'}});
-const server=createServer((req,res)=>{if(req.url==='/'){res.setHeader('Content-Type','text/html');res.end('<!doctype html><html><head><link rel="stylesheet" href="/bundle.css"></head><body><div id="root"></div><script type="module" src="/bundle.js"></script></body></html>')}else if(!['/bundle.js','/bundle.css'].includes(req.url)){res.writeHead(404);res.end()}else{res.setHeader('Content-Type',req.url.endsWith('.css')?'text/css':'text/javascript');res.end(readFileSync(join(root,req.url.slice(1))))}});
+const cssPath=join(root,'bundle.css');
+const cssSource=readFileSync(join(repoRoot,'frontend/plugins/workbench_ui/src/style.css'),'utf8');
+const css=await postcss([tailwindcss({config:{content:[join(repoRoot,'frontend/plugins/workbench_ui/src/**/*.{ts,tsx}')],presets:[webUiPreset]}}),autoprefixer()])
+  .process(cssSource,{from:join(repoRoot,'frontend/plugins/workbench_ui/src/style.css'),to:cssPath});
+writeFileSync(cssPath,css.css);
+const server=createServer((req,res)=>{if(req.url==='/'){res.setHeader('Content-Type','text/html');res.end('<!doctype html><html><head><link rel="stylesheet" href="/bundle.css"><style>html,body,#root{height:100%;margin:0}body{font-family:var(--md-ref-typeface-plain,system-ui);background:var(--ak-color-bg-canvas);color:var(--ak-color-text-primary)}</style></head><body><div id="root"></div><script type="module" src="/bundle.js"></script></body></html>')}else if(!['/bundle.js','/bundle.css'].includes(req.url)){res.writeHead(404);res.end()}else{res.setHeader('Content-Type',req.url.endsWith('.css')?'text/css':'text/javascript');res.end(readFileSync(join(root,req.url.slice(1))))}});
 await new Promise(resolve=>server.listen(0,'127.0.0.1',resolve));
 const browser=await chromium.launch({executablePath,headless:true,args:['--no-sandbox']});
 const page=await browser.newPage();const errors=[];page.on('pageerror',e=>errors.push(String(e)));
 try{
 await page.goto('http://127.0.0.1:'+server.address().port);
-await page.getByRole('button',{name:'扩展面板',exact:true}).click();
+await page.getByRole('button',{name:/fixture session/}).click();
+await page.locator('.table-row').filter({hasText:'fixture message'}).click();
+await page.getByText('Raw Message',{exact:true}).waitFor();
+await page.getByRole('button',{name:'关闭详情',exact:true}).click();
+await page.getByRole('button',{name:/Sessions/}).click();
+await page.getByRole('button',{name:/扩展面板/}).click();
 await page.locator('b[data-cell]').filter({hasText:'slow'}).waitFor();
 assert.equal(await page.getByRole('button',{name:'记录',exact:true}).count(),0);
-const widths = await page.locator('tbody tr').first().locator('td').evaluateAll(cells=>cells.map(cell=>cell.getBoundingClientRect().width));
+assert.equal(await page.locator('.shell > .sessions-pane').count(),1);
+assert.equal(await page.locator('.content-shell > .content-toolbar').count(),1);
+assert.equal(await page.locator('.workspace > .messages-pane').count(),1);
+const widths = await page.locator('.table-row').first().locator(':scope > span').evaluateAll(cells=>cells.map(cell=>cell.getBoundingClientRect().width));
 assert.equal(widths[1],120);
 assert.ok(widths[2]>widths[1]);
 await page.getByText('导航扩展',{exact:true}).waitFor();
 await page.getByRole('checkbox',{name:'选择 slow',exact:true}).check();
-await page.getByRole('button',{name:'slow',exact:true}).click();
-await page.getByText('正在读取…',{exact:true}).waitFor();
+await page.locator('.table-row').filter({hasText:'slow'}).click();
+await page.getByRole('status',{name:'正在加载详情'}).waitFor();
 await page.getByRole('button',{name:'filter fast',exact:true}).click();
-await page.getByRole('button',{name:'fine',exact:true}).waitFor();
-assert.equal(await page.getByRole('button',{name:'处理选中',exact:true}).isEnabled(),false);
+await page.locator('.table-row').filter({hasText:'fine'}).waitFor();
+assert.equal(await page.getByRole('button',{name:'处理选中',exact:true}).count(),0);
 await page.evaluate(()=>window.fixture.reject('detail'));
-await page.getByRole('button',{name:'fine',exact:true}).click();
+await page.locator('.table-row').filter({hasText:'fine'}).click();
 await page.getByText('DETAIL fine',{exact:true}).waitFor();
 assert.equal(await page.getByRole('alert').count(),0);
 await page.getByRole('button',{name:'关闭详情',exact:true}).click();
 await page.getByRole('button',{name:'filter all',exact:true}).click();
-await page.getByRole('button',{name:'error',exact:true}).click();
+await page.locator('.table-row').filter({hasText:'error'}).click();
 await page.getByRole('alert').filter({hasText:'detail failed'}).waitFor();
-assert.equal(await page.getByText('正在读取…',{exact:true}).count(),0);
+assert.equal(await page.getByRole('status',{name:'正在加载详情'}).count(),0);
 await page.getByRole('button',{name:'下一页',exact:true}).click();
-await page.getByRole('button',{name:'fine',exact:true}).waitFor();
+await page.locator('.table-row').filter({hasText:'fine'}).waitFor();
 assert.equal(await page.getByRole('alert').count(),0);
 await page.getByRole('button',{name:'filter slow',exact:true}).click();
 await page.waitForFunction(()=>window.fixture.calls.some(x=>x.filters.scope==='slow'));
 await page.getByRole('button',{name:'filter fast',exact:true}).click();
-await page.waitForFunction(()=>document.querySelector('tbody')?.textContent.includes('fine'));
+await page.waitForFunction(()=>document.querySelector('.table-body')?.textContent.includes('fine'));
 await page.evaluate(()=>window.fixture.reject('page'));
 await page.getByRole('button',{name:'正文',exact:true}).click();
 await page.waitForFunction(()=>window.fixture.calls.at(-1).sortBy==='text');
@@ -74,5 +96,6 @@ await page.getByRole('button',{name:'处理选中',exact:true}).click();
 await page.waitForFunction(()=>window.fixture.batches.length===1);
 assert.deepEqual(await page.evaluate(()=>window.fixture.batches),[['fine']]);
 assert.equal(errors.length,0);
+if(process.env.AKASHIC_WORKBENCH_SCREENSHOT)await page.screenshot({path:process.env.AKASHIC_WORKBENCH_SCREENSHOT,fullPage:true});
 console.log(JSON.stringify({passed:true,calls:await page.evaluate(()=>window.fixture.calls),errors,root},null,2));
 }finally{await browser.close();await new Promise(resolve=>server.close(resolve));rmSync(root,{recursive:true,force:true})}


### PR DESCRIPTION
## 结果

恢复 PR #563 重构前的完整 Workbench 视觉与交互壳层，同时保留重构后的 Session/Message API、`workbench.panels.v2` 动态面板来源、插件样式隔离和 AbortSignal 生命周期。

## 根因

PR #563 内部提交 `f989efbc` 将原 1510 行 Workbench 页面替换为 471 行最小页面。历史 `style.css` 被原样保留，但它依赖的品牌栏、模块切换器、Explorer、工具栏、表格、分页、批量操作和详情面板 DOM 结构被移除，导致页面退化为未完整套用品牌样式的简化布局。

## 修改

- 恢复重构前的 `shell → explorer/content → table/detail` 完整结构与类名。
- 新 Session/Message API 数据继续作为唯一业务输入，不恢复旧 Turn/attempt 或旧删除语义。
- 保留普通插件面板、过滤、排序、分页、批量动作、详情与取消请求。
- 扩大浏览器回归，覆盖 Session/Message 页面和恢复后的结构、布局及插件行为。

## 验证

- `npm run typecheck`：通过。
- `node frontend/plugins/workbench_ui/src/verify-browser.mjs`：通过。
- `npm run test:web`：101/101 通过。
- `npm run build:web-plugins`：通过；生成 bundle 未纳入提交。
- change-impact Gate：按维护者明确要求不等待，运行中主动终止；不声称通过。

## 恢复点

- 本地完整 Git bundle：`pre-restore-workbench-style-20260910.bundle`。
- 回滚本 PR 的单一提交即可恢复合并前源码；不涉及数据库、workspace、协议或持久数据迁移。