### PR TITLE
[codex] 收紧 Wake 内容兴趣门槛

### DIFF
--- a/plugins/wake/pool.py
+++ b/plugins/wake/pool.py
@@ -6,9 +6,9 @@ from datetime import datetime
 from typing import Any
 
 WAKE_ADMISSION_FLOOR = 0.02
-WAKE_POOL_THRESHOLD = 1.0
+WAKE_POOL_THRESHOLD = 1.5
 
-_FRESHNESS_HALF_LIFE_HOURS = 36.0
+_FRESHNESS_HALF_LIFE_HOURS = 18.0
 _MISSING_PUBLICATION_CONFIDENCE = 0.03
 _INELIGIBLE_CONFIDENCE_MULTIPLIER = 0.01
 
@@ -59,7 +59,7 @@ def measure_pool(
 
 
 def rank_events(events: list[dict[str, Any]], *, now: datetime) -> list[dict[str, Any]]:
-    """Decay fixed scores, then apply source diversity only to page order."""
+    """Square and decay fixed scores, then diversify only the page order."""
 
     scored: list[dict[str, Any]] = []
     for event in events:
@@ -87,7 +87,7 @@ def rank_events(events: list[dict[str, Any]], *, now: datetime) -> list[dict[str
             -math.log(2.0) * age_hours / _FRESHNESS_HALF_LIFE_HOURS
         )
         copied = dict(event)
-        admission_mass = initial * freshness
+        admission_mass = initial**2 * freshness
         copied["_wake_rank_score"] = admission_mass
         copied["_wake_rank_features"] = {
             "initial_score": initial,

--- a/tests/test_wake_pool.py
+++ b/tests/test_wake_pool.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from plugins.wake.pool import build_initial_score, measure_pool, rank_events
+
+NOW = datetime(2026, 9, 11, 0, tzinfo=UTC)
+
+
+def _event(
+    index: int, interest: float, *, age: timedelta = timedelta()
+) -> dict[str, object]:
+    identity = f"content-{index}"
+    return {
+        "id": identity,
+        "source_id": "feed",
+        "published_at": (NOW - age).isoformat(),
+        "_wake_admission_identity": identity,
+        "_wake_initial_score": build_initial_score(
+            interest, has_published_at=True, wake_eligible=True
+        ),
+        "_wake_semantic_interest": interest,
+    }
+
+
+def test_squared_interest_separates_low_and_high_quality_content() -> None:
+    low = [_event(index, 0.1) for index in range(100)]
+    low_result = measure_pool(low, now=NOW, new_item_ids={"content-0"})
+
+    assert low_result.should_wake is False
+    assert low_result.pool_mass == 0.0
+    assert low_result.below_floor == 100
+
+    high = _event(100, 0.8)
+    high_result = measure_pool([high], now=NOW, new_item_ids={"content-100"})
+
+    assert high_result.should_wake is True
+    assert high_result.pool_mass > high_result.threshold
+
+
+def test_freshness_halves_squared_mass_after_eighteen_hours() -> None:
+    fresh = rank_events([_event(1, 0.8)], now=NOW)[0]
+    aged = rank_events([_event(1, 0.8, age=timedelta(hours=18))], now=NOW)[0]
+
+    fresh_mass = fresh["_wake_rank_features"]["admission_mass"]
+    aged_mass = aged["_wake_rank_features"]["admission_mass"]
+    assert aged_mass == pytest.approx(fresh_mass / 2)
+
+
+def test_admission_mass_includes_the_whole_active_pool() -> None:
+    events = [_event(index, 0.2) for index in range(40)]
+
+    result = measure_pool(events, now=NOW, new_item_ids={"content-39"})
+
+    single_mass = rank_events([events[0]], now=NOW)[0]["_wake_rank_features"][
+        "admission_mass"
+    ]
+    assert result.pool_mass == pytest.approx(single_mass * len(events))
+    assert result.should_wake is True


### PR DESCRIPTION
## 改动

- 将 Wake Content admission 的初始质量贡献改为平方，使高兴趣内容更快越阈、低兴趣内容显著收缩
- 将 freshness 半衰期从 36 小时缩短为 18 小时
- 将全池阈值从 1.0 提高到 1.5
- 保留全量 active Content 参与累积，不增加 Top-K 截断
- 添加低/高兴趣、18 小时衰减和全池累积回归测试

## 原因

恢复积压后，约 300 条低分内容的线性贡献长期把 pool mass 保持在 15 以上。任意微弱新内容都能借旧池越过 1.0，造成主动消息集中发送。

## 验证

- `45 passed`：Wake pool、消息、durable delivery、score migration
- Pyright：0 errors
- 生产只读回放：最近 14 个旧公式 admission 点从 14/14 降为 0/14，新质量范围 0.232–0.517
- 构造兴趣 0.8 的新鲜内容贡献 2.590，仍可单独越过 1.5；18 小时后衰减为 1.295
- 按维护者明确授权未运行 change-impact Gate，也不等待远端 CI

## 回滚

回滚本 PR 的合并提交即可恢复 1.0 阈值、36 小时半衰期和线性质量。正式部署前另建 operator recovery point。
