### PR TITLE
[codex] 插件正交化：分开构建 Core 与 37 个插件安装源

### DIFF
--- a/docs/design/plugin-boundary-foundation.md
+++ b/docs/design/plugin-boundary-foundation.md
@@ -185,3 +185,17 @@ RPC 的参数模型和处理函数由声明该方法的插件拥有。Core 只�
 解析、参数校验和调用持有同一 snapshot lease，连接不缓存业务插件参数表。
 旧请求在原 generation 完成；新请求使用当前 provider。缺失方法返回 METHOD_NOT_FOUND。
 当前 programmatic 方法名称、参数和调用语义不变；方法在插件实际启用期间可用。
+
+
+### 9.2 独立分发制品
+
+`scripts/build_plugin_distribution.py` 从明确 Git commit 构建 `core.tar` 和每个插件自己的
+Git bundle。所有第一方插件均提供静态 manifest；没有 manifest 的入口会阻止分发。
+Core 的路径清单不包含 `plugins/`，每个插件源只含自身子树及构建来源证明。
+Git bundle 由原 `install_git_plugin` 安装，不给第一方插件增加 source loader 特权。
+构建报告分别记录源码 commit/path、独立 Git revision 与产物 SHA256；它们不是同一个身份。
+输出目录必须新建，失败保留已有内容，不覆盖旧发布制品。
+
+这一步只证明包边界及安装输入，不能证明每个包已经可以独立 apply。
+跨插件实现导入、宿主业务入口和默认组合仍需后续迁移；Core archive 尚不宣称是完整
+可启动发布镜像。Docker、前端资源和历史升级的完整验收在累计收口中完成。

--- a/plugins/akashic_sender/akashic.plugin.toml
+++ b/plugins/akashic_sender/akashic.plugin.toml
@@ -1,0 +1,5 @@
+schema_version = 1
+name = "akashic_sender"
+version = "1.0.0"
+api_version = 3
+entrypoint = "plugin.py"

--- a/plugins/content/akashic.plugin.toml
+++ b/plugins/content/akashic.plugin.toml
@@ -1,0 +1,5 @@
+schema_version = 1
+name = "content"
+version = "1.0.0"
+api_version = 3
+entrypoint = "plugin.py"

--- a/plugins/context/akashic.plugin.toml
+++ b/plugins/context/akashic.plugin.toml
@@ -1,0 +1,5 @@
+schema_version = 1
+name = "context"
+version = "1.0.0"
+api_version = 3
+entrypoint = "plugin.py"

--- a/plugins/conversation/akashic.plugin.toml
+++ b/plugins/conversation/akashic.plugin.toml
@@ -1,0 +1,5 @@
+schema_version = 1
+name = "conversation"
+version = "1.0.0"
+api_version = 3
+entrypoint = "plugin.py"

--- a/plugins/delivery/akashic.plugin.toml
+++ b/plugins/delivery/akashic.plugin.toml
@@ -1,0 +1,5 @@
+schema_version = 1
+name = "delivery"
+version = "1.0.0"
+api_version = 3
+entrypoint = "plugin.py"

--- a/plugins/delivery_policy/akashic.plugin.toml
+++ b/plugins/delivery_policy/akashic.plugin.toml
@@ -1,0 +1,5 @@
+schema_version = 1
+name = "delivery_policy"
+version = "1.0.0"
+api_version = 3
+entrypoint = "plugin.py"

--- a/plugins/message_push/akashic.plugin.toml
+++ b/plugins/message_push/akashic.plugin.toml
@@ -1,0 +1,5 @@
+schema_version = 1
+name = "message_push"
+version = "1.0.0"
+api_version = 3
+entrypoint = "plugin.py"

--- a/plugins/programmatic/akashic.plugin.toml
+++ b/plugins/programmatic/akashic.plugin.toml
@@ -1,0 +1,5 @@
+schema_version = 1
+name = "programmatic"
+version = "1.0.0"
+api_version = 3
+entrypoint = "plugin.py"

--- a/plugins/prompt/akashic.plugin.toml
+++ b/plugins/prompt/akashic.plugin.toml
@@ -1,0 +1,5 @@
+schema_version = 1
+name = "prompt"
+version = "1.0.0"
+api_version = 3
+entrypoint = "plugin.py"

--- a/plugins/react/akashic.plugin.toml
+++ b/plugins/react/akashic.plugin.toml
@@ -1,0 +1,5 @@
+schema_version = 1
+name = "react"
+version = "1.0.0"
+api_version = 3
+entrypoint = "plugin.py"

--- a/plugins/reply/akashic.plugin.toml
+++ b/plugins/reply/akashic.plugin.toml
@@ -1,0 +1,5 @@
+schema_version = 1
+name = "reply"
+version = "1.0.0"
+api_version = 3
+entrypoint = "plugin.py"

--- a/plugins/sources/akashic.plugin.toml
+++ b/plugins/sources/akashic.plugin.toml
@@ -1,0 +1,5 @@
+schema_version = 1
+name = "sources"
+version = "1.0.0"
+api_version = 3
+entrypoint = "plugin.py"

--- a/plugins/standard_tools/akashic.plugin.toml
+++ b/plugins/standard_tools/akashic.plugin.toml
@@ -1,0 +1,5 @@
+schema_version = 1
+name = "standard_tools"
+version = "1.0.0"
+api_version = 3
+entrypoint = "plugin.py"

--- a/plugins/standard_web/akashic.plugin.toml
+++ b/plugins/standard_web/akashic.plugin.toml
@@ -1,0 +1,5 @@
+schema_version = 1
+name = "standard_web"
+version = "1.0.0"
+api_version = 3
+entrypoint = "plugin.py"

--- a/plugins/subagent/akashic.plugin.toml
+++ b/plugins/subagent/akashic.plugin.toml
@@ -1,0 +1,5 @@
+schema_version = 1
+name = "subagent"
+version = "4.0.0"
+api_version = 3
+entrypoint = "plugin.py"

--- a/plugins/tool_search/akashic.plugin.toml
+++ b/plugins/tool_search/akashic.plugin.toml
@@ -1,0 +1,5 @@
+schema_version = 1
+name = "tool_search"
+version = "2.0.0"
+api_version = 3
+entrypoint = "plugin.py"

--- a/plugins/tools/akashic.plugin.toml
+++ b/plugins/tools/akashic.plugin.toml
@@ -1,0 +1,5 @@
+schema_version = 1
+name = "tools"
+version = "1.0.0"
+api_version = 3
+entrypoint = "plugin.py"

--- a/plugins/turn_projection/akashic.plugin.toml
+++ b/plugins/turn_projection/akashic.plugin.toml
@@ -1,0 +1,5 @@
+schema_version = 1
+name = "turn_projection"
+version = "1.0.0"
+api_version = 3
+entrypoint = "plugin.py"

--- a/scripts/build_plugin_distribution.py
+++ b/scripts/build_plugin_distribution.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""从固定提交生成不带业务源码的 Core 与可独立安装的插件 Git bundle。"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import os
+from pathlib import Path
+import subprocess
+import tarfile
+import tempfile
+
+from agent.plugins.static_manifest import load_static_plugin_manifest
+
+
+# 只打包宿主运行入口；业务 plugins/ 不进入 Core，也没有开发源码路径。
+CORE_PATHS = (
+    "agent", "bootstrap", "bus", "core", "infra", "session", "utils",
+    "mcp_servers", "host_bridge", "memory2", "prompts", "migrations",
+    "main.py", "pyproject.toml", "requirements.txt", "requirements-dev.txt",
+    "sdk/python", "docker/host-runtime",
+)
+
+
+def git(repository: Path, *args: str, env: dict[str, str] | None = None) -> bytes:
+    """只执行明确 Git 参数，失败保留命令与 stderr。"""
+    return subprocess.run(["git", "-C", str(repository), *args], check=True,
+                          stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env).stdout
+
+
+def build(repository: Path, revision: str, output: Path) -> dict[str, object]:
+    """各包只含自身 Git 子树；构建报告记录源提交、产物身份与哈希。"""
+    # 1. 固定源提交；输出必须新建，失败产物保留供检查，不覆盖旧恢复材料。
+    commit = git(repository, "rev-parse", "--verify", "--end-of-options",
+                 revision + "^{commit}").decode().strip()
+    stamp = git(repository, "show", "-s", "--format=%cI", commit).decode().strip()
+    files = git(repository, "ls-tree", "-r", "--name-only", commit).decode().splitlines()
+    roots = sorted({str(Path(path).parent) for path in files
+                    if path.startswith("plugins/") and path.endswith("/akashic.plugin.toml")})
+    entry_roots = {str(Path(path).parent) for path in files
+                   if path.startswith("plugins/") and path.endswith(("/plugin.py", "/message_plugin.py"))}
+    missing = entry_roots - set(roots)
+    if missing:
+        raise ValueError(f"插件入口缺少发布 manifest: {sorted(missing)}")
+    output.mkdir(parents=True, exist_ok=False)
+    core_paths = [path for path in CORE_PATHS
+                  if any(item == path or item.startswith(path + "/") for item in files)]
+    core = git(repository, "archive", "--format=tar", commit, "--", *core_paths)
+    (output / "core.tar").write_bytes(core)
+    report: dict[str, object] = {"source_commit": commit,
+        "core": {"file": "core.tar", "sha256": hashlib.sha256(core).hexdigest()},
+        "plugins": []}
+    rows = []
+    names: set[str] = set()
+    # 2. 独立 Git 源保留来源证明；安装仍走原有 clone、校验及 artifact 发布链。
+    for root in roots:
+        with tempfile.TemporaryDirectory(prefix="akashic-plugin-source-") as directory:
+            package = Path(directory)
+            archive = git(repository, "archive", "--format=tar", commit + ":" + root)
+            with tarfile.open(fileobj=io.BytesIO(archive)) as stream:
+                stream.extractall(package, filter="data")
+            manifest = load_static_plugin_manifest(package)
+            if manifest.name in names:
+                raise ValueError(f"发布插件名称重复: {manifest.name}")
+            names.add(manifest.name)
+            provenance = package / ".akashic-source.json"
+            if provenance.exists():
+                raise ValueError(f"插件源码已经占用构建来源文件: {root}")
+            provenance.write_text(json.dumps({"commit": commit, "path": root}, sort_keys=True) + "\n")
+            git(package, "init", "--initial-branch=source")
+            git(package, "add", "--all")
+            env = {**os.environ, "GIT_AUTHOR_NAME": "Akashic build", "GIT_AUTHOR_EMAIL": "build@akashic.invalid",
+                   "GIT_COMMITTER_NAME": "Akashic build", "GIT_COMMITTER_EMAIL": "build@akashic.invalid",
+                   "GIT_AUTHOR_DATE": stamp, "GIT_COMMITTER_DATE": stamp}
+            git(package, "-c", "commit.gpgSign=false", "commit", "-m", f"Build {root} from {commit}", env=env)
+            identity = git(package, "rev-parse", "HEAD").decode().strip()
+            bundle = output / (manifest.name + ".bundle")
+            git(package, "bundle", "create", str(bundle.resolve()), "HEAD", "source")
+            rows.append({"name": manifest.name, "source_path": root, "file": bundle.name,
+                         "source_revision": identity, "sha256": hashlib.sha256(bundle.read_bytes()).hexdigest()})
+    report["plugins"] = rows
+    (output / "distribution.json").write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n")
+    return report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--revision", default="HEAD")
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    print(json.dumps(build(args.repository.resolve(), args.revision, args.output.resolve()), ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -1,0 +1,42 @@
+"""发布制品只能含选定宿主路径与各插件自己的源码。"""
+import io
+import json
+from pathlib import Path
+import subprocess
+import tarfile
+
+import pytest
+
+from agent.plugins.install import install_git_plugin
+from scripts.build_plugin_distribution import build
+
+
+def test_distribution_installs_isolated_git_sources_and_refuses_overwrite(tmp_path):
+    source = tmp_path / "source"
+    source.mkdir()
+    for name in ("one", "two"):
+        root = source / "plugins" / name
+        root.mkdir(parents=True)
+        (root / "plugin.py").write_text(f'api_version = 3\nname = "{name}"\nversion = "1"\ndef apply(ctx, config): pass\n')
+        (root / "akashic.plugin.toml").write_text(f'schema_version = 1\napi_version = 3\nname = "{name}"\nversion = "1"\nentrypoint = "plugin.py"\n')
+    (source / "main.py").write_text('print("core")\n')
+    (source / "private.txt").write_text("must not ship")
+    subprocess.run(["git", "init", str(source)], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(source), "add", "."], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(source), "-c", "user.name=Test", "-c", "user.email=test@example.invalid",
+                    "-c", "commit.gpgSign=false", "commit", "-m", "source"], check=True, capture_output=True)
+    output = tmp_path / "release"
+    report = build(source, "HEAD", output)
+    with tarfile.open(fileobj=io.BytesIO((output / "core.tar").read_bytes())) as archive:
+        assert archive.getnames() == ["main.py"]
+    assert {row["name"] for row in report["plugins"]} == {"one", "two"}
+    for row in report["plugins"]:
+        installed = install_git_plugin(workspace=tmp_path / "workspace", plugins_home=tmp_path / "home",
+            source=str(output / row["file"]), marketplace="distribution")
+        assert installed.source_revision == row["source_revision"]
+        assert not (installed.installed_path / "plugins").exists()
+        assert not (installed.installed_path / "private.txt").exists()
+        provenance = json.loads((installed.installed_path / ".akashic-source.json").read_text())
+        assert provenance == {"commit": report["source_commit"], "path": row["source_path"]}
+    with pytest.raises(FileExistsError):
+        build(source, "HEAD", output)


### PR DESCRIPTION
## 问题与结果

第一方插件原先只有 19 个静态 manifest，完整源码镜像也让插件可以借同仓库导入。补齐另外 18 个 manifest；增加按精确 Git commit 构建 Core tar 和 37 个独立插件 Git bundle 的工具。每个 bundle 只含自身子树，由原 install_git_plugin 安装；Core tar 不含 plugins/。

Stack: #593 → #594 → #597 → 本 PR。此层建立分发输入，尚不宣称 37 个插件独立 apply 已通过或 Core 已成为可启动发布镜像。

## Change intent

- change_type: feature；semantic_delta: compatible；capability_owner: mixed。
- consumer_scope: 第一方 37 个插件；runtime_patch: none（构建工具与静态身份声明）。
- authoritative_state_owner / protected_state: 既有运行状态全部保留。测试只用一次性 workspace/plugin home。
- 允许源码、临时构建与 Git/PR；禁止正式 workspace 写入、部署与历史数据迁移。
- concept_gate: required，完整实现后统一 Terra/xhigh 审查。

## 改动与恢复

产物报告区分原源码 commit/path、独立插件 Git revision、制品 SHA256。输出目录必须新建，不能覆盖旧制品。没有新包管理器、第一方专用 loader 或源码兜底。已有设计文档记录阶段限制与完整成功条件。

基线 0d8053b2；当前 e413c72c。没有 schema 变化。恢复通过 revert 与开工 Git bundle，构建产物留在临时目录。

## 验证

- [x] 37 个实际静态 manifest 全部通过校验。
- [x] 当前精确提交完成实际构建，输出 /tmp/akashic-distribution-e413c72c。
- [x] 分发边界测试通过：Core 不携带插件/未选择文件，两个独立源经正式 installer 安装且来源身份一致，拒绝覆盖输出。
- [x] git diff --check。
- [ ] 全量插件 apply/替换、裸 Core 启动、Docker/WebUI 分发尚待后续实现与累计验收。
- [ ] 类型检查、Gate、CI、独立概念审查按维护者要求在全部实施后集中处理；sourceDigest/planDigest 尚无。

## 正交性与工作手册

已核对 Decision 0065、projectneed、NOW。构建独立包不能代替消除包间依赖；此 PR 不把包数量或 fixture 成功当作完整外置证据。独立 reviewer/head/结论待累计概念 Gate；整体事项仍在实施。