### PR TITLE
[codex] 插件正交化：默认只加载安装源并发布空 Root

### DIFF
--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -1511,8 +1511,6 @@ class PluginManager:
                 generation = await self._load_one(mod, stage_stable=True)
                 if generation is not None:
                     staged.append(generation)
-            if not staged:
-                return
             snapshot, catalog_id = await self._compile_stable_batch_snapshot(staged)
             for generation in staged:
                 generation.runtime_snapshot = snapshot
@@ -5540,8 +5538,6 @@ class PluginManager:
             )
         ):
             return current.composition_root, False
-        if not ordered and not self._core_channel_definitions:
-            return None, False
 
         # 2. stable 拓扑变化创建完整 Root；candidate Root 挂载闭包。
         identity = "|".join(

--- a/agent/plugins/source_resolver.py
+++ b/agent/plugins/source_resolver.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Sequence
 
 from agent.plugins.artifacts import ArtifactSelector, read_pointers, resolve_pointer
 from agent.plugins.static_manifest import (
@@ -23,7 +23,7 @@ class ResolvedPluginSource:
 
 
 def resolve_plugin_sources(
-    plugin_dirs: list[Path],
+    plugin_dirs: Sequence[Path] = (),
     *,
     installed_cache_root: Path | None = None,
     installed_selector: ArtifactSelector = "stable",

--- a/bootstrap/tools.py
+++ b/bootstrap/tools.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
@@ -426,6 +426,7 @@ def build_core_runtime(
     restart_gate: RestartGate | None = None,
     *,
     clear_stale_session_admissions: bool = False,
+    plugin_dirs: Iterable[Path] | None = None,
 ) -> CoreRuntime:
     """从已迁移消息库装配窄 owner；构造失败关闭此前取得的连接。"""
     from contextlib import ExitStack
@@ -457,12 +458,19 @@ def build_core_runtime(
         if restart_gate is None:
             restart_gate = RestartGate(boot_id="unmanaged", supervised=False)
         control_frames = FrameBook()
+        resolved_plugin_dirs = (
+            _resolve_plugin_dirs(workspace)
+            if plugin_dirs is None
+            else _resolve_plugin_dirs(workspace, plugin_dirs=plugin_dirs)
+        )
         manager = PluginManager(
-            plugin_dirs=_resolve_plugin_dirs(workspace), event_bus=event_bus,
+            plugin_dirs=resolved_plugin_dirs, event_bus=event_bus,
             workspace=workspace, message_log=message_log, channel_identities=identities,
             installed_cache_root=plugins_root() / "cache",
             channel_attachment_store=attachments,
-            disabled_builtin_plugins=_disabled_builtin_plugins_for_runtime(config),
+            disabled_builtin_plugins=_disabled_builtin_plugins_for_runtime(
+                config, resolved_plugin_dirs
+            ),
             restart_gate=restart_gate,
             control_frames=control_frames,
         )
@@ -481,26 +489,46 @@ def build_core_runtime(
         return runtime
 
 
-def _resolve_plugin_dirs(workspace: Path) -> list[Path]:
-    project_root = Path(__file__).resolve().parent.parent
-    roots = [project_root / "plugins"]
+def _resolve_plugin_dirs(
+    workspace: Path,
+    *,
+    plugin_dirs: Iterable[Path] = (),
+) -> list[Path]:
+    """Return only explicitly requested development plugin roots."""
+
+    _ = workspace
+    roots = [Path(item).expanduser() for item in plugin_dirs]
     extra = os.environ.get("AKASHIC_EXTRA_PLUGIN_DIRS", "")
     roots.extend(
         Path(item).expanduser() for item in extra.split(os.pathsep) if item.strip()
     )
-    return roots
+    result: list[Path] = []
+    seen: set[Path] = set()
+    for root in roots:
+        normalized = root.resolve(strict=False)
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(root)
+    return result
 
 
-def _disabled_builtin_plugins_for_runtime(config: Config) -> frozenset[str]:
-    """Disable built-in Workload plugins when this deployment has no Controller."""
+def _disabled_builtin_plugins_for_runtime(
+    config: Config,
+    plugin_dirs: Iterable[Path] = (),
+) -> frozenset[str]:
+    """Apply generic disabled/Workload rules to explicit development roots."""
 
     disabled = set(config.disabled_builtin_plugins)
-    builtin_root = Path(__file__).resolve().parent.parent / "plugins"
+    roots = tuple(plugin_dirs)
+    if not roots:
+        return frozenset(disabled)
+
     from agent.plugins.source_resolver import resolve_plugin_sources
 
     known = {
         source.plugin_name or source.plugin_root.name
-        for source in resolve_plugin_sources([builtin_root])
+        for source in resolve_plugin_sources(list(roots))
     }
     unknown = sorted(disabled - known)
     if unknown:
@@ -514,7 +542,8 @@ def _disabled_builtin_plugins_for_runtime(config: Config) -> frozenset[str]:
 
     unavailable = {
         manifest.name
-        for path in builtin_root.glob("*/akashic.plugin.toml")
+        for root in roots
+        for path in root.glob("*/akashic.plugin.toml")
         if (manifest := load_static_plugin_manifest(path.parent)).workloads
     }
     if unavailable:

--- a/tests/test_core_messages.py
+++ b/tests/test_core_messages.py
@@ -18,6 +18,16 @@ from session.message import ContentPart, Input
 from session.store import SessionStore
 
 
+def _copy_checkout_plugins(tmp_path: Path) -> Path:
+    source = tmp_path / "plugins"
+    shutil.copytree(
+        Path(__file__).parents[1] / "plugins",
+        source,
+        ignore=shutil.ignore_patterns("__pycache__", ".pytest_cache"),
+    )
+    return source
+
+
 @pytest.mark.asyncio
 async def test_core_opens_message_schema_and_real_source_without_legacy_execution(tmp_path, monkeypatch):
     workspace = tmp_path / "workspace"
@@ -131,6 +141,7 @@ async def test_default_runtime_starts_settings_without_embedding(tmp_path, monke
     workspace = tmp_path / "workspace"
     _ = init_workspace(config_path=tmp_path / "config.toml", workspace=workspace)
     monkeypatch.setenv("AKASHIC_PLUGIN_HOME", str(tmp_path / "plugin-home"))
+    monkeypatch.setattr(bootstrap, "_resolve_plugin_dirs", lambda _: [_copy_checkout_plugins(tmp_path)])
     http = SharedHttpResources()
     core = bootstrap.build_core_runtime(Config(), workspace, http)
     try:
@@ -314,6 +325,7 @@ async def test_app_checks_sender_before_starting_native_receiver(tmp_path, monke
     workspace = tmp_path / "workspace"
     _ = init_workspace(config_path=tmp_path / "config.toml", workspace=workspace)
     monkeypatch.setenv("AKASHIC_PLUGIN_HOME", str(tmp_path / "plugin-home"))
+    monkeypatch.setattr(bootstrap, "_resolve_plugin_dirs", lambda _: [_copy_checkout_plugins(tmp_path)])
     started = []
     async def start(self, context):
         started.append(self.name)
@@ -381,6 +393,7 @@ async def test_app_real_socket_default_reply_and_shutdown(tmp_path, monkeypatch)
     workspace = tmp_path / "workspace"
     _ = init_workspace(config_path=tmp_path / "config.toml", workspace=workspace)
     monkeypatch.setenv("AKASHIC_PLUGIN_HOME", str(tmp_path / "plugin-home"))
+    monkeypatch.setattr(bootstrap, "_resolve_plugin_dirs", lambda _: [_copy_checkout_plugins(tmp_path)])
     ready = asyncio.Event()
     class Readiness(RuntimeReadiness):
         def mark_ready(self):

--- a/tests/test_plugin_external_loader.py
+++ b/tests/test_plugin_external_loader.py
@@ -53,6 +53,11 @@ async def test_core_starts_with_no_checkout_plugins_and_keeps_manager_usable(
         assert core.plugin_manager._dirs == []
         await core.start()
         assert core.plugin_manager.discover() == []
+        snapshot = core.plugin_manager.current_snapshot
+        assert snapshot is not None and snapshot.composition_root is not None
+        assert snapshot.composition_root.receipt().ready
+        assert snapshot.generations == {}
+        assert "identity:" in await core.inspect_modules()
     finally:
         await core.stop()
         await core.bus.aclose()

--- a/tests/test_plugin_external_loader.py
+++ b/tests/test_plugin_external_loader.py
@@ -1,0 +1,82 @@
+"""生产 Core 默认只解析安装制品，开发目录必须显式提供。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent.config_models import Config
+from bootstrap import tools as bootstrap
+from core.net.http import SharedHttpResources
+
+
+def test_resolve_plugin_dirs_does_not_add_checkout_plugins_by_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("AKASHIC_EXTRA_PLUGIN_DIRS", raising=False)
+
+    roots = bootstrap._resolve_plugin_dirs(tmp_path)
+
+    assert roots == []
+    checkout_plugins = Path(bootstrap.__file__).resolve().parents[1] / "plugins"
+    assert checkout_plugins not in roots
+
+
+def test_resolve_plugin_dirs_accepts_only_explicit_development_roots(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    development = tmp_path / "development-plugins"
+    extra = tmp_path / "extra-plugins"
+    monkeypatch.setenv("AKASHIC_EXTRA_PLUGIN_DIRS", str(extra))
+
+    roots = bootstrap._resolve_plugin_dirs(tmp_path, plugin_dirs=[development])
+
+    assert roots == [development, extra]
+
+
+@pytest.mark.asyncio
+async def test_core_starts_with_no_checkout_plugins_and_keeps_manager_usable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("AKASHIC_PLUGIN_HOME", str(tmp_path / "plugin-home"))
+    monkeypatch.delenv("AKASHIC_EXTRA_PLUGIN_DIRS", raising=False)
+    http = SharedHttpResources()
+    core = bootstrap.build_core_runtime(Config(), workspace, http)
+    try:
+        assert core.plugin_manager.discover() == []
+        assert core.plugin_manager._dirs == []
+        await core.start()
+        assert core.plugin_manager.discover() == []
+    finally:
+        await core.stop()
+        await core.bus.aclose()
+        await http.aclose()
+
+
+@pytest.mark.asyncio
+async def test_build_core_runtime_keeps_explicit_plugin_dirs_available(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    development = tmp_path / "development-plugins"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("AKASHIC_PLUGIN_HOME", str(tmp_path / "plugin-home"))
+    monkeypatch.delenv("AKASHIC_EXTRA_PLUGIN_DIRS", raising=False)
+
+    http = SharedHttpResources()
+    core = bootstrap.build_core_runtime(
+        Config(), workspace, http, plugin_dirs=[development]
+    )
+    try:
+        assert core.plugin_manager._dirs == [development]
+    finally:
+        await core.stop()
+        await core.bus.aclose()
+        await http.aclose()

--- a/tests/test_runtime_smoke.py
+++ b/tests/test_runtime_smoke.py
@@ -231,23 +231,28 @@ disabled_builtin = ["subagent", "scheduler"]
     assert cfg.disabled_builtin_plugins == frozenset({"subagent", "scheduler"})
 
 
-def test_runtime_accepts_all_real_builtin_entrypoints_and_rejects_unknown(
-    monkeypatch,
-) -> None:
+def test_runtime_validates_disabled_plugin_ids_only_for_explicit_roots(monkeypatch) -> None:
     from agent.config_models import Config
     from bootstrap.tools import _disabled_builtin_plugins_for_runtime
 
     monkeypatch.setenv("AKASHIC_WORKLOAD_SOCKET", "/tmp/fixture.sock")
+    repo_plugins = Path(__file__).parents[1] / "plugins"
     existing = frozenset(
         {"akasha", "scheduler", "wake", "compaction", "markdown_memory"}
     )
     assert (
-        _disabled_builtin_plugins_for_runtime(Config(disabled_builtin_plugins=existing))
+        _disabled_builtin_plugins_for_runtime(
+            Config(disabled_builtin_plugins=existing), [repo_plugins]
+        )
         == existing
     )
+    assert _disabled_builtin_plugins_for_runtime(
+        Config(disabled_builtin_plugins=frozenset({"future-plugin"}))
+    ) == frozenset({"future-plugin"})
     with pytest.raises(ValueError, match="未知内置插件: agent_restart, skills"):
         _disabled_builtin_plugins_for_runtime(
-            Config(disabled_builtin_plugins=frozenset({"skills", "agent_restart"}))
+            Config(disabled_builtin_plugins=frozenset({"skills", "agent_restart"})),
+            [repo_plugins],
         )
 
 


### PR DESCRIPTION
## 问题与结果

生产启动原先自动加入 checkout/plugins，使外部安装仍可借源码兜底。现在默认只解析已安装 artifact；开发目录通过 build_core_runtime(plugin_dirs=...) 或 AKASHIC_EXTRA_PLUGIN_DIRS 显式选择。空插件组合也发布真实 Root，因此插件管理与拓扑检查无需先装业务插件。

Stack: #593 → #594 → #597 → #598 → 本 PR。默认产品的外置安装组合与剩余 Core 导入继续在后继层实现。

## Change intent

- change_type: refactor；semantic_delta: breaking（源码默认装配改为显式开发输入）。
- capability_owner: core；consumer_scope: 宿主加载与管理。
- runtime_patch: required，客户端无法消除宿主自动源码路径。
- authoritative_state_owner / protected_state: 既有 Message、plugin-data、归档、回执和 generation owner 不变。
- 允许源码及一次性测试；不部署、不迁移正式数据、不删除旧归档。
- concept_gate: required，全部实施后统一 Terra/xhigh 审查。

## 验证与恢复

副手提交 75344be8 经主线程集成为 f44a6873：加载/runtime smoke 51 passed，core messages 8 passed，app 启动定向 1 passed，installer 19 passed；副手 pyright 0 errors、1 个既有 warning。根线程补空 Root 的 bc15e7d7 后，外置加载定向 4 passed，覆盖空 Root ready 与 inspect_modules。

真实 Core tar 检查仍暴露 message_view、runtime_inspection、reply_status 对业务实现的 import；后续正在逐项消除。本 PR 不声称裸 Core 全启动验收已完成。

完整 Gate、累计类型检查、CI 与独立概念审查按维护者指令集中到全部实施后，sourceDigest/planDigest 尚无。无需等待当前远端 checks 再推进下一层。

无数据库 schema 变化；基线 e413c72c。恢复点为开工 bundle、副手文件备份与前层提交；可 revert 本层。已核对 projectneed、NOW、Decision 0065，完整目标仍在进行，未把中间步骤从 NOW 清除。