### PR TITLE
[codex] 插件正交化：全量清单复用边界规则并收紧外置验收

### DIFF
--- a/docker/debug/plugin_external_acceptance.py
+++ b/docker/debug/plugin_external_acceptance.py
@@ -15,6 +15,7 @@ import argparse
 import asyncio
 import hashlib
 import importlib
+import importlib.util
 import inspect
 import json
 import os
@@ -50,8 +51,12 @@ def _source_checkout(path_or_url: str, repo_root: Path) -> Path | None:
         raise ValueError(
             "source checkout 在本仓库内；外置验收拒绝把 builtin checkout 当 external artifact"
         )
+    if path.is_file():
+        import subprocess
+        subprocess.run(["git", "bundle", "list-heads", str(path)], check=True, capture_output=True)
+        return path
     if not path.is_dir():
-        raise ValueError(f"external source 不是目录: {path}")
+        raise ValueError(f"external source 不是 Git 目录或 bundle: {path}")
     try:
         import subprocess
 
@@ -85,6 +90,9 @@ def _hide_checkouts(repo_root: Path, source_checkout: Path | None) -> None:
         filtered.append(raw)
     sys.path[:] = filtered
     for module_name, module in tuple(sys.modules.items()):
+        if module_name == "plugins" or module_name.startswith("plugins."):
+            sys.modules.pop(module_name, None)
+            continue
         module_file = getattr(module, "__file__", None)
         if not isinstance(module_file, str):
             continue
@@ -129,6 +137,7 @@ async def _exercise(
     workspace: Path,
     plugins_home: Path,
     capability_service: str | None,
+    core_root: Path | None = None,
 ) -> dict[str, Any]:
     """Install one real checkout and execute its V3 apply path."""
 
@@ -140,6 +149,17 @@ async def _exercise(
     }
     evidence["checks"]["source_checkout_is_external"] = True
     try:
+        if core_root is None or _under(core_root, repo_root) or (core_root / "plugins").exists():
+            raise ValueError("外置验收必须提供仓库之外、不含 plugins 的 Core 制品目录")
+        _hide_checkouts(repo_root, source_checkout)
+        sys.path.insert(0, str(core_root))
+        if importlib.util.find_spec("plugins") is not None:
+            raise ValueError("运行环境仍能解析 checkout 的 plugins 命名空间")
+        for name, module in tuple(sys.modules.items()):
+            if name.split(".")[0] in {"agent", "bootstrap", "bus", "core", "infra", "session", "utils"}:
+                location = getattr(module, "__file__", None)
+                if location is not None and not _under(Path(location), core_root):
+                    raise ValueError(f"Core 模块预先从制品之外加载: {name}: {location}")
         from agent.plugins.install import install_git_plugin
         from agent.plugins.manager import PluginManager
         from agent.plugins.static_manifest import load_static_plugin_manifest
@@ -168,9 +188,6 @@ async def _exercise(
             load_static_plugin_manifest(artifact).name == plugin_id.split("@", 1)[0]
         )
 
-        # Core modules are imported before hiding the checkout.  A plugin's
-        # implementation still must not resolve through either checkout.
-        _hide_checkouts(repo_root, source_checkout)
         event_bus = EventBus()
         manager = PluginManager(
             [],
@@ -223,31 +240,38 @@ async def _exercise(
             evidence["checkout_modules_visible"] = visible
             evidence["checks"]["checkout_invisible"] = not visible
 
-            # This is a real public composition read against the plugin-owned
-            # generation.  Optional --capability-service invokes a named
-            # service only when the external plugin publishes that contract.
-            context = snapshot.composition_root.context
-            services = context.provided_services(plugin_ids=frozenset({plugin_id}))
-            capability = {
-                "operation": "CompositionSnapshotRoot.context.provided_services",
-                "service_keys": sorted(key.name for key in services),
-                "service_count": len(services),
-            }
-            if capability_service:
-                from agent.plugin_composition import ServiceKey
+            # 服务目录只证明注册；指定可调用能力的真实执行单独记录。
+            from agent.plugins.snapshot import lease_runtime_snapshot
 
-                value = context.require(ServiceKey(capability_service))
-                capability["requested_service"] = capability_service
-                capability["requested_type"] = type(value).__name__
-                if callable(value):
-                    called = value()
-                    if inspect.isawaitable(called):
-                        called = await called
-                    capability["call_result_type"] = type(called).__name__
+            async with lease_runtime_snapshot(manager.snapshot_store) as leased:
+                context = leased.composition_root.context
+                services = context.provided_services(plugin_ids=frozenset({plugin_id}))
+                capability = {
+                    "operation": "CompositionSnapshotRoot.context.provided_services",
+                    "service_keys": sorted(key.name for key in services),
+                    "service_count": len(services),
+                }
+                evidence["checks"]["capability_call"] = False
+                if capability_service:
+                    from agent.plugin_composition import ServiceKey
+
+                    key = ServiceKey(capability_service)
+                    if key not in services:
+                        raise ValueError("选定能力不是目标插件提供的服务")
+                    value = context.require(key)
+                    capability["requested_service"] = capability_service
+                    capability["requested_type"] = type(value).__name__
+                    if callable(value):
+                        called = value()
+                        if inspect.isawaitable(called):
+                            called = await called
+                        capability["call_result_type"] = type(called).__name__
+                        evidence["checks"]["capability_call"] = True
+                    else:
+                        raise TypeError("选定能力不可调用；读取对象不能充当行为验收")
                 else:
-                    capability["call_result_type"] = type(value).__name__
-            evidence["capability_call"] = capability
-            evidence["checks"]["capability_call"] = True
+                    capability["status"] = "unverified: 必须提供真实能力调用，服务枚举不是调用"
+                evidence["capability_call"] = capability
         finally:
             try:
                 await manager.terminate_all()
@@ -255,7 +279,7 @@ async def _exercise(
                 await event_bus.aclose()
         checks = evidence["checks"]
         evidence["status"] = "passed" if all(checks.values()) else "failed"
-    except BaseException as error:
+    except Exception as error:
         evidence["status"] = "failed"
         evidence["error"] = f"{type(error).__name__}: {error}"
     return evidence
@@ -314,6 +338,7 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--workspace", type=Path)
     parser.add_argument("--plugins-home", type=Path)
     parser.add_argument("--capability-service")
+    parser.add_argument("--core-root", type=Path, help="已解包、位于 checkout 外且不含业务源码的 Core 制品")
     parser.add_argument("--output", type=Path)
     parser.add_argument("--keep-temporary", action="store_true")
     return parser
@@ -338,11 +363,6 @@ def main(argv: list[str] | None = None) -> int:
     workspace.mkdir(parents=True, exist_ok=True)
     plugins_home.mkdir(parents=True, exist_ok=True)
     repo_root = args.repo_root.resolve(strict=True)
-    # The helper lives under docker/debug; make the selected checkout the
-    # temporary Core import root.  _hide_checkouts removes it immediately
-    # before the external plugin is loaded.
-    if str(repo_root) not in sys.path:
-        sys.path.insert(0, str(repo_root))
 
     reports: list[dict[str, Any]] = []
     try:
@@ -356,6 +376,7 @@ def main(argv: list[str] | None = None) -> int:
                         workspace=workspace,
                         plugins_home=plugins_home,
                         capability_service=args.capability_service,
+                        core_root=args.core_root,
                     )
                 )
             )
@@ -403,6 +424,7 @@ def main(argv: list[str] | None = None) -> int:
                             workspace=workspace / str(entry["package"]),
                             plugins_home=plugins_home / str(entry["package"]),
                             capability_service=args.capability_service,
+                        core_root=args.core_root,
                         )
                     )
                 )
@@ -414,7 +436,7 @@ def main(argv: list[str] | None = None) -> int:
         return 2
     finally:
         if temp_root is not None and not args.keep_temporary:
-            shutil.rmtree(temp_root, ignore_errors=True)
+            shutil.rmtree(temp_root)
 
     result = {
         "schema_version": 1,

--- a/docker/debug/plugin_external_acceptance.py
+++ b/docker/debug/plugin_external_acceptance.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""Run a real V3 external-plugin install and isolated runtime smoke.
+
+This helper deliberately refuses a source checkout below the repository and
+never synthesizes a fixture plugin.  ``--all`` consumes a source mapping for
+every manifest inventory row; missing mappings are failed evidence rather than
+an implicit pass.  The normal Core archive is expected to be the module source
+at runtime, so the report compares its bytes with the formally installed
+artifact while separately proving that the checkout is not visible.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import importlib
+import inspect
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import Any, Mapping
+
+
+def _under(path: Path, root: Path) -> bool:
+    try:
+        path.resolve(strict=False).relative_to(root.resolve(strict=False))
+    except ValueError:
+        return False
+    return True
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _source_checkout(path_or_url: str, repo_root: Path) -> Path | None:
+    """Validate a local external checkout; return None for a remote URL."""
+
+    if "://" in path_or_url or path_or_url.startswith("git@"):
+        return None
+    path = Path(path_or_url).expanduser().resolve(strict=True)
+    if _under(path, repo_root):
+        raise ValueError(
+            "source checkout 在本仓库内；外置验收拒绝把 builtin checkout 当 external artifact"
+        )
+    if not path.is_dir():
+        raise ValueError(f"external source 不是目录: {path}")
+    try:
+        import subprocess
+
+        subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as error:
+        raise ValueError(f"external source 不是可复现 Git checkout: {path}") from error
+    return path
+
+
+def _hide_checkouts(repo_root: Path, source_checkout: Path | None) -> None:
+    """Remove checkout roots from import search and purge loaded plugin files."""
+
+    roots = [repo_root.resolve(strict=False)]
+    if source_checkout is not None:
+        roots.append(source_checkout.resolve(strict=False))
+    filtered: list[str] = []
+    for raw in sys.path:
+        try:
+            candidate = Path(raw or os.curdir).resolve(strict=False)
+        except OSError:
+            filtered.append(raw)
+            continue
+        if any(_under(candidate, root) for root in roots):
+            continue
+        filtered.append(raw)
+    sys.path[:] = filtered
+    for module_name, module in tuple(sys.modules.items()):
+        module_file = getattr(module, "__file__", None)
+        if not isinstance(module_file, str):
+            continue
+        path = Path(module_file).resolve(strict=False)
+        if source_checkout is not None and _under(path, source_checkout):
+            sys.modules.pop(module_name, None)
+        elif _under(path, repo_root / "plugins"):
+            sys.modules.pop(module_name, None)
+
+
+def _visible_checkout_modules(
+    repo_root: Path, source_checkout: Path | None
+) -> list[dict[str, str]]:
+    roots = [repo_root / "plugins"]
+    if source_checkout is not None:
+        roots.append(source_checkout)
+    evidence: list[dict[str, str]] = []
+    for module_name, module in sorted(sys.modules.items()):
+        module_file = getattr(module, "__file__", None)
+        if not isinstance(module_file, str):
+            continue
+        path = Path(module_file).resolve(strict=False)
+        for root in roots:
+            if _under(path, root):
+                evidence.append({"module": module_name, "file": str(path)})
+                break
+    return evidence
+
+
+def _plugin_id_from_manifest(artifact: Path, marketplace: str) -> tuple[str, str]:
+    from agent.plugins.static_manifest import load_static_plugin_manifest
+
+    manifest = load_static_plugin_manifest(artifact)
+    return f"{manifest.name}@{marketplace}", manifest.entrypoint
+
+
+async def _exercise(
+    *,
+    source: str,
+    repo_root: Path,
+    marketplace: str,
+    workspace: Path,
+    plugins_home: Path,
+    capability_service: str | None,
+) -> dict[str, Any]:
+    """Install one real checkout and execute its V3 apply path."""
+
+    source_checkout = _source_checkout(source, repo_root)
+    evidence: dict[str, Any] = {
+        "source": source,
+        "source_checkout": None if source_checkout is None else str(source_checkout),
+        "checks": {},
+    }
+    evidence["checks"]["source_checkout_is_external"] = True
+    try:
+        from agent.plugins.install import install_git_plugin
+        from agent.plugins.manager import PluginManager
+        from agent.plugins.static_manifest import load_static_plugin_manifest
+        from bus.event_bus import EventBus
+
+        result = install_git_plugin(
+            workspace=workspace,
+            source=source,
+            marketplace=marketplace,
+            plugins_home=plugins_home,
+        )
+        artifact = result.installed_path.resolve(strict=True)
+        plugin_id, entrypoint = _plugin_id_from_manifest(artifact, marketplace)
+        evidence.update(
+            {
+                "plugin_id": plugin_id,
+                "source_revision": result.source_revision,
+                "installed_artifact": str(artifact),
+                "installed_entrypoint": str(artifact / entrypoint),
+            }
+        )
+        evidence["checks"]["formal_install_artifact"] = artifact.is_relative_to(
+            (plugins_home / "cache").resolve(strict=False)
+        )
+        evidence["checks"]["installed_manifest_identity"] = (
+            load_static_plugin_manifest(artifact).name == plugin_id.split("@", 1)[0]
+        )
+
+        # Core modules are imported before hiding the checkout.  A plugin's
+        # implementation still must not resolve through either checkout.
+        _hide_checkouts(repo_root, source_checkout)
+        event_bus = EventBus()
+        manager = PluginManager(
+            [],
+            event_bus=event_bus,
+            workspace=workspace,
+            installed_cache_root=plugins_home / "cache",
+        )
+        try:
+            await manager.load_all()
+            snapshot = manager.current_snapshot
+            generation = (
+                None if snapshot is None else snapshot.generations.get(plugin_id)
+            )
+            module = (
+                None if generation is None else sys.modules.get(generation.module_path)
+            )
+            module_file = getattr(module, "__file__", None)
+            evidence["generation_id"] = (
+                None if generation is None else generation.generation_id
+            )
+            evidence["module_name"] = None if module is None else module.__name__
+            evidence["module_file"] = module_file
+            evidence["checks"]["apply"] = generation is not None and module is not None
+            if (
+                not isinstance(module_file, str)
+                or generation is None
+                or snapshot is None
+            ):
+                raise RuntimeError("formal install 后未形成 stable generation/module")
+            module_path = Path(module_file).resolve(strict=True)
+            archive_root = (workspace / "runtime" / "plugin-archives").resolve(
+                strict=False
+            )
+            evidence["checks"]["module_file_is_core_archive"] = _under(
+                module_path, archive_root
+            )
+            evidence["checks"]["module_file_not_checkout"] = not any(
+                _under(module_path, root)
+                for root in (repo_root / "plugins", source_checkout)
+                if root is not None
+            )
+            installed_entrypoint = artifact / entrypoint
+            evidence["module_file_sha256"] = _sha256(module_path)
+            evidence["installed_entrypoint_sha256"] = _sha256(installed_entrypoint)
+            evidence["checks"]["module_bytes_match_installed_artifact"] = (
+                evidence["module_file_sha256"]
+                == evidence["installed_entrypoint_sha256"]
+            )
+            visible = _visible_checkout_modules(repo_root, source_checkout)
+            evidence["checkout_modules_visible"] = visible
+            evidence["checks"]["checkout_invisible"] = not visible
+
+            # This is a real public composition read against the plugin-owned
+            # generation.  Optional --capability-service invokes a named
+            # service only when the external plugin publishes that contract.
+            context = snapshot.composition_root.context
+            services = context.provided_services(plugin_ids=frozenset({plugin_id}))
+            capability = {
+                "operation": "CompositionSnapshotRoot.context.provided_services",
+                "service_keys": sorted(key.name for key in services),
+                "service_count": len(services),
+            }
+            if capability_service:
+                from agent.plugin_composition import ServiceKey
+
+                value = context.require(ServiceKey(capability_service))
+                capability["requested_service"] = capability_service
+                capability["requested_type"] = type(value).__name__
+                if callable(value):
+                    called = value()
+                    if inspect.isawaitable(called):
+                        called = await called
+                    capability["call_result_type"] = type(called).__name__
+                else:
+                    capability["call_result_type"] = type(value).__name__
+            evidence["capability_call"] = capability
+            evidence["checks"]["capability_call"] = True
+        finally:
+            try:
+                await manager.terminate_all()
+            finally:
+                await event_bus.aclose()
+        checks = evidence["checks"]
+        evidence["status"] = "passed" if all(checks.values()) else "failed"
+    except BaseException as error:
+        evidence["status"] = "failed"
+        evidence["error"] = f"{type(error).__name__}: {error}"
+    return evidence
+
+
+def _load_source_map(path: Path) -> Mapping[str, str]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("source mapping 必须是 JSON object")
+    result: dict[str, str] = {}
+    for key, value in payload.items():
+        if not isinstance(key, str) or not isinstance(value, str) or not value.strip():
+            raise ValueError("source mapping 的 key/value 必须是非空字符串")
+        result[key] = value
+    return result
+
+
+def _load_inventory(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or not isinstance(payload.get("packages"), list):
+        raise ValueError("inventory JSON 缺少 packages 数组")
+    return payload
+
+
+def _source_for_entry(
+    entry: Mapping[str, Any], sources: Mapping[str, str]
+) -> str | None:
+    package = str(entry.get("package", ""))
+    manifest = entry.get("manifest")
+    manifest_name = manifest.get("name") if isinstance(manifest, Mapping) else None
+    for key in (package, str(manifest_name) if manifest_name else ""):
+        if key in sources:
+            return sources[key]
+    return None
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", help="一个真实 external Git checkout 或 Git URL")
+    parser.add_argument("--plugin", help="单插件结果标签；默认从 manifest 读取")
+    parser.add_argument(
+        "--all", action="store_true", help="按 inventory 对所有 manifest 插件执行"
+    )
+    parser.add_argument(
+        "--inventory", type=Path, help="plugin_inventory.py 生成的 JSON"
+    )
+    parser.add_argument(
+        "--sources-json",
+        type=Path,
+        help="plugin 名称到 external checkout/URL 的 JSON 映射",
+    )
+    parser.add_argument(
+        "--repo-root", type=Path, default=Path(__file__).resolve().parents[2]
+    )
+    parser.add_argument("--marketplace", default="external-acceptance")
+    parser.add_argument("--workspace", type=Path)
+    parser.add_argument("--plugins-home", type=Path)
+    parser.add_argument("--capability-service")
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--keep-temporary", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.all == bool(args.source):
+        print("必须二选一：--source 或 --all", file=sys.stderr)
+        return 2
+    temp_root: Path | None = None
+    if args.workspace is None or args.plugins_home is None:
+        import tempfile
+
+        temp_root = Path(tempfile.mkdtemp(prefix="akashic-external-acceptance-"))
+        root = temp_root
+        workspace = args.workspace or root / "workspace"
+        plugins_home = args.plugins_home or root / "plugins-home"
+    else:
+        workspace = args.workspace
+        plugins_home = args.plugins_home
+    workspace.mkdir(parents=True, exist_ok=True)
+    plugins_home.mkdir(parents=True, exist_ok=True)
+    repo_root = args.repo_root.resolve(strict=True)
+    # The helper lives under docker/debug; make the selected checkout the
+    # temporary Core import root.  _hide_checkouts removes it immediately
+    # before the external plugin is loaded.
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    reports: list[dict[str, Any]] = []
+    try:
+        if args.source:
+            reports.append(
+                asyncio.run(
+                    _exercise(
+                        source=args.source,
+                        repo_root=repo_root,
+                        marketplace=args.marketplace,
+                        workspace=workspace,
+                        plugins_home=plugins_home,
+                        capability_service=args.capability_service,
+                    )
+                )
+            )
+        else:
+            if args.inventory is None or args.sources_json is None:
+                print(
+                    "--all 必须同时提供 --inventory 和 --sources-json", file=sys.stderr
+                )
+                return 2
+            inventory = _load_inventory(args.inventory)
+            sources = _load_source_map(args.sources_json)
+            for entry in inventory["packages"]:
+                if entry.get("classification") != "manifest-plugin":
+                    classification = entry.get("classification")
+                    reports.append(
+                        {
+                            "plugin": entry.get("package"),
+                            "status": "failed",
+                            "checks": {"manifest_plugin": False},
+                            "error": (
+                                "inventory row has an invalid V3 manifest"
+                                if classification == "invalid-manifest"
+                                else "inventory row is a support-package without an install manifest"
+                            ),
+                        }
+                    )
+                    continue
+                source = _source_for_entry(entry, sources)
+                if source is None:
+                    reports.append(
+                        {
+                            "plugin": entry.get("package"),
+                            "status": "failed",
+                            "checks": {"external_source_mapped": False},
+                            "error": "no external source mapping; one example cannot certify the inventory",
+                        }
+                    )
+                    continue
+                reports.append(
+                    asyncio.run(
+                        _exercise(
+                            source=source,
+                            repo_root=repo_root,
+                            marketplace=args.marketplace,
+                            workspace=workspace / str(entry["package"]),
+                            plugins_home=plugins_home / str(entry["package"]),
+                            capability_service=args.capability_service,
+                        )
+                    )
+                )
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(
+            f"external acceptance setup failed: {type(error).__name__}: {error}",
+            file=sys.stderr,
+        )
+        return 2
+    finally:
+        if temp_root is not None and not args.keep_temporary:
+            shutil.rmtree(temp_root, ignore_errors=True)
+
+    result = {
+        "schema_version": 1,
+        "repository": str(repo_root),
+        "workspace": str(workspace),
+        "plugins_home": str(plugins_home),
+        "mode": "all" if args.all else "single",
+        "reports": reports,
+        "status": (
+            "passed"
+            if reports and all(item.get("status") == "passed" for item in reports)
+            else "failed"
+        ),
+    }
+    rendered = json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0 if result["status"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/plugin_inventory.py
+++ b/scripts/plugin_inventory.py
@@ -1,515 +1,102 @@
 #!/usr/bin/env python3
-"""Build an auditable inventory of plugin packages and implementation edges.
-
-The inventory intentionally includes packages without a V3 manifest.  Such a
-package is reported as a support package and is not silently treated as an
-external-installable plugin.  ``--strict`` is a static boundary check: it
-fails on the current historical import debt instead of turning that debt into
-an implicit allowlist.
-"""
-
+"""登记全部插件包与真实导入欠账，复用同一份静态边界规则。"""
 from __future__ import annotations
 
 import argparse
 import ast
 import hashlib
 import json
+from pathlib import Path
 import subprocess
 import sys
-import tomllib
-from pathlib import Path
-from typing import Any
 
-SCHEMA_VERSION = 1
-PLUGIN_ROOT = "plugins"
-CORE_PREFIXES = (
-    "agent",
-    "bootstrap",
-    "bus",
-    "config",
-    "infra",
-    "main",
-    "session",
-)
-PUBLIC_PLUGIN_API_PREFIXES = ("agent.plugin_composition",)
-PROJECT_ROOTS = CORE_PREFIXES + ("plugins",)
-DYNAMIC_IMPORT_NAMES = frozenset(
-    {
-        "__import__",
-        "import_module",
-        "importlib.import_module",
-        "importlib.util.spec_from_file_location",
-        "importlib.machinery.SourceFileLoader",
-    }
-)
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agent.plugins.static_manifest import load_static_plugin_manifest
+from scripts import plugin_boundary as boundary
 
 
-def _relative(path: Path, root: Path) -> str:
-    return path.resolve(strict=False).relative_to(root.resolve(strict=False)).as_posix()
-
-
-def _module_name(path: str) -> str:
-    """Return the import-like name of one source target."""
-
-    return path.replace("/", ".").removesuffix(".py")
-
-
-def _is_prefix(name: str, prefixes: tuple[str, ...]) -> bool:
-    return any(name == prefix or name.startswith(prefix + ".") for prefix in prefixes)
-
-
-def _literal(node: ast.AST | None) -> str | None:
-    if node is None:
-        return None
-    try:
-        value = ast.literal_eval(node)
-    except (TypeError, ValueError, SyntaxError):
-        return None
-    return value if isinstance(value, str) else None
-
-
-def _call_name(node: ast.AST) -> str:
-    if isinstance(node, ast.Name):
-        return node.id
-    if isinstance(node, ast.Attribute):
-        prefix = _call_name(node.value)
-        return f"{prefix}.{node.attr}" if prefix else node.attr
-    return "<dynamic>"
-
-
-def _target_from_import(
-    node: ast.Import | ast.ImportFrom, alias: ast.alias
-) -> tuple[str, str]:
-    if isinstance(node, ast.Import):
-        return alias.name, "import"
-    if node.level:
-        dots = "." * node.level
-        return (
-            f"{dots}{node.module or ''}{('.' + alias.name) if alias.name != '*' else ''}",
-            "relative",
-        )
-    module = node.module or ""
-    return (
-        f"{module}.{alias.name}" if module and alias.name != "*" else module
-    ), "from"
-
-
-def _edge(
-    path: Path, root: Path, node: ast.AST, target: str, kind: str
-) -> dict[str, Any]:
-    return {
-        "file": _relative(path, root),
-        "line": int(getattr(node, "lineno", 0)),
-        "target": target,
-        "kind": kind,
-    }
-
-
-def _scan_python_file(
-    path: Path, root: Path, package: str
-) -> dict[str, list[dict[str, Any]]]:
-    result: dict[str, list[dict[str, Any]]] = {
-        "implementation_dependencies": [],
-        "static_imports": [],
-        "relative_imports": [],
-        "sibling_plugin_imports": [],
-        "core_imports": [],
-        "private_core_imports": [],
-        "dynamic_dependencies": [],
-    }
-    try:
-        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-    except (OSError, SyntaxError, UnicodeError) as error:
-        result["dynamic_dependencies"].append(
-            {
-                "file": _relative(path, root),
-                "line": 0,
-                "kind": "parse_error",
-                "target": type(error).__name__,
-                "detail": str(error),
-            }
-        )
-        return result
-
-    for node in ast.walk(tree):
-        if isinstance(node, (ast.Import, ast.ImportFrom)):
-            aliases = node.names
-            for alias in aliases:
-                target, kind = _target_from_import(node, alias)
-                record = _edge(path, root, node, target, kind)
-                result["static_imports"].append(record)
-                if kind == "relative":
-                    result["relative_imports"].append(record)
-                if target.startswith("plugins."):
-                    result["implementation_dependencies"].append(record)
-                    sibling = target.split(".", 2)[1]
-                    if sibling != package:
-                        result["sibling_plugin_imports"].append(
-                            {**record, "sibling_package": sibling}
-                        )
-                elif _is_prefix(target, CORE_PREFIXES):
-                    result["implementation_dependencies"].append(record)
-                    result["core_imports"].append(record)
-                    if not _is_prefix(target, PUBLIC_PLUGIN_API_PREFIXES):
-                        result["private_core_imports"].append(record)
-                elif target and not target.startswith("."):
-                    # Keep non-stdlib project-looking imports visible without
-                    # guessing whether a third-party package is truly safe.
-                    first = target.split(".", 1)[0]
-                    if first in PROJECT_ROOTS:
-                        result["implementation_dependencies"].append(record)
-
-        if isinstance(node, ast.Call):
-            name = _call_name(node.func)
-            if name in DYNAMIC_IMPORT_NAMES:
-                result["dynamic_dependencies"].append(
-                    {
-                        "file": _relative(path, root),
-                        "line": int(getattr(node, "lineno", 0)),
-                        "kind": "dynamic_import",
-                        "target": _literal(node.args[0]) if node.args else None,
-                        "expression": name,
-                    }
-                )
-        if isinstance(node, ast.Attribute) and node.attr == "path":
-            if isinstance(node.value, ast.Name) and node.value.id == "sys":
-                result["dynamic_dependencies"].append(
-                    {
-                        "file": _relative(path, root),
-                        "line": int(getattr(node, "lineno", 0)),
-                        "kind": "sys_path_mutation_or_read",
-                        "target": "sys.path",
-                    }
-                )
-    return result
-
-
-def _merge_edges(target: list[dict[str, Any]], values: list[dict[str, Any]]) -> None:
-    seen = {
-        (item.get("file"), item.get("line"), item.get("kind"), item.get("target"))
-        for item in target
-    }
-    for value in values:
-        key = (
-            value.get("file"),
-            value.get("line"),
-            value.get("kind"),
-            value.get("target"),
-        )
-        if key not in seen:
-            target.append(value)
-            seen.add(key)
-
-
-def _manifest(root: Path) -> dict[str, Any]:
-    path = root / "akashic.plugin.toml"
-    if not path.exists():
-        return {
-            "path": None,
-            "valid": False,
-            "error": "missing_static_manifest",
-        }
-    try:
-        raw = tomllib.loads(path.read_text(encoding="utf-8"))
-        required = ("schema_version", "name", "version", "api_version", "entrypoint")
-        missing = [key for key in required if key not in raw]
-        if missing:
-            return {
-                "path": path.name,
-                "valid": False,
-                "present": True,
-                "error": f"manifest_missing_fields:{','.join(missing)}",
-            }
-        return {
-            "path": path.name,
-            "valid": True,
-            "present": True,
-            "name": raw.get("name"),
-            "version": raw.get("version"),
-            "api_version": raw.get("api_version"),
-            "entrypoint": raw.get("entrypoint"),
-            "identity_fields": {
-                key: raw.get(key)
-                for key in (
-                    "schema_version",
-                    "name",
-                    "version",
-                    "api_version",
-                    "entrypoint",
-                )
-            },
-        }
-    except (OSError, tomllib.TOMLDecodeError, TypeError) as error:
-        return {
-            "path": path.name,
-            "valid": False,
-            "present": True,
-            "error": f"manifest_parse_error:{type(error).__name__}:{error}",
-        }
-
-
-def _entry_digest(files: list[Path], root: Path) -> str:
-    digest = hashlib.sha256()
-    for path in sorted(files):
-        digest.update(_relative(path, root).encode("utf-8"))
-        digest.update(b"\0")
-        digest.update(path.read_bytes())
-        digest.update(b"\0")
-    return digest.hexdigest()
-
-
-def _inventory_entry(root: Path, package_root: Path) -> dict[str, Any]:
-    package = package_root.name
-    py_files = sorted(package_root.rglob("*.py"))
-    manifest = _manifest(package_root)
-    edges: dict[str, list[dict[str, Any]]] = {
-        "implementation_dependencies": [],
-        "static_imports": [],
-        "relative_imports": [],
-        "sibling_plugin_imports": [],
-        "core_imports": [],
-        "private_core_imports": [],
-        "dynamic_dependencies": [],
-    }
-    for path in py_files:
-        scanned = _scan_python_file(path, root, package)
-        for key, values in scanned.items():
-            _merge_edges(edges[key], values)
-    entrypoint = manifest.get("entrypoint") if manifest.get("valid") else None
-    conventional = [
-        name
-        for name in ("plugin.py", "message_plugin.py")
-        if (package_root / name).is_file()
-    ]
-    if (
-        isinstance(entrypoint, str)
-        and (package_root / entrypoint).is_file()
-        and entrypoint not in conventional
-    ):
-        conventional.append(entrypoint)
-    entrypoint_exists = (
-        isinstance(entrypoint, str) and (package_root / entrypoint).is_file()
-    )
-    return {
-        "package": package,
-        "root": _relative(package_root, root),
-        "classification": (
-            "manifest-plugin"
-            if manifest.get("valid")
-            else "invalid-manifest" if manifest.get("present") else "support-package"
-        ),
-        "manifest": manifest,
-        "declared_entrypoint_exists": entrypoint_exists,
-        "entrypoints": sorted(conventional),
-        "python_files": [_relative(path, root) for path in py_files],
-        "source_digest": _entry_digest(py_files, root),
-        **{
-            key: sorted(
-                values,
-                key=lambda item: (
-                    str(item.get("file")),
-                    int(item.get("line", 0)),
-                    str(item.get("target")),
-                ),
-            )
-            for key, values in edges.items()
-        },
-    }
-
-
-def _core_consumers(root: Path) -> list[dict[str, Any]]:
-    """Record Core-side imports of plugin implementation packages."""
-
-    records: list[dict[str, Any]] = []
-    paths = [root / name for name in CORE_PREFIXES if (root / name).exists()]
-    paths.extend([root / "main.py", root / "config.py"])
-    for base in paths:
-        candidates = [base] if base.is_file() else sorted(base.rglob("*.py"))
-        for path in candidates:
+def build_inventory(repo_root: Path) -> dict[str, object]:
+    """按 Git 跟踪范围登记发布身份、实现依赖和不能静态证明的动态入口。"""
+    root = repo_root.resolve()
+    tracked = subprocess.check_output(["git", "-C", str(root), "ls-files"], text=True).splitlines()
+    files = [name for name in tracked if name.endswith(".py")]
+    sources = {name: (root / name).read_text() for name in files}
+    imports = boundary.collect_imports(files, sources)
+    findings = boundary.import_findings(imports)
+    packages = sorted({name.split("/")[1] for name in tracked
+                       if name.startswith("plugins/") and len(name.split("/")) >= 3})
+    rows = []
+    violations = [{"kind": rule, "file": item.importer, "target": item.module}
+                  for rule, items in findings.items() for item in items]
+    for package in packages:
+        prefix = "plugins/" + package + "/"
+        package_files = [name for name in tracked if name.startswith(prefix)]
+        digest = hashlib.sha256()
+        for name in package_files:
+            digest.update(name.encode() + b"\0" + (root / name).read_bytes() + b"\0")
+        manifest_path = prefix + "akashic.plugin.toml"
+        manifest = None
+        error = None
+        if manifest_path not in tracked:
+            classification = "support-package"
+        else:
             try:
-                tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-            except (OSError, SyntaxError, UnicodeError):
+                parsed = load_static_plugin_manifest(root / prefix)
+                manifest = {"name": parsed.name, "version": parsed.version,
+                            "entrypoint": parsed.entrypoint, "api_version": parsed.api_version}
+                classification = "manifest-plugin"
+            except ValueError as exc:
+                classification, error = "invalid-manifest", str(exc)
+        if classification != "manifest-plugin":
+            violations.append({"kind": "not_installable_artifact", "file": prefix, "error": error})
+        package_imports = [item for item in imports if item.importer.startswith(prefix)]
+        dynamic = []
+        for name in files:
+            if not name.startswith(prefix):
                 continue
+            tree = ast.parse(sources[name])
+            # 字面动态导入由同一 checker 解析；计算式路径仍要求运行时证据。
+            aliases = {"__import__", "import_module"}
+            aliases.update(alias.asname or alias.name for node in ast.walk(tree)
+                           if isinstance(node, ast.ImportFrom) and node.module == "importlib"
+                           for alias in node.names if alias.name == "import_module")
             for node in ast.walk(tree):
-                if not isinstance(node, (ast.Import, ast.ImportFrom)):
-                    continue
-                for alias in node.names:
-                    target, _ = _target_from_import(node, alias)
-                    if target.startswith("plugins."):
-                        records.append(
-                            {
-                                "file": _relative(path, root),
-                                "line": int(getattr(node, "lineno", 0)),
-                                "target": target,
-                            }
-                        )
-    unique = {(item["file"], item["line"], item["target"]): item for item in records}
-    return [
-        unique[key]
-        for key in sorted(unique, key=lambda item: (item[0], item[1], item[2]))
-    ]
+                if isinstance(node, ast.Call) and (
+                    isinstance(node.func, ast.Name) and node.func.id in aliases
+                    or isinstance(node.func, ast.Attribute) and node.func.attr in {"import_module", "spec_from_file_location"}
+                ):
+                    dynamic.append({"file": name, "line": node.lineno,
+                                    "expression": ast.unparse(node)})
+        rows.append({"package": package, "classification": classification, "manifest": manifest,
+                     "manifest_error": error, "source_digest": digest.hexdigest(),
+                     "static_imports": [{"file": item.importer, "target": item.module} for item in package_imports],
+                     "dynamic_dependencies": dynamic,
+                     "implementation_dependencies": [item for item in violations if item["file"].startswith(prefix)]})
+    return {"schema_version": 1, "repository": str(root), "packages": rows,
+            "summary": {"package_count": len(rows),
+                "manifest_plugin_count": sum(row["classification"] == "manifest-plugin" for row in rows),
+                "support_package_count": sum(row["classification"] == "support-package" for row in rows),
+                "static_boundary_violation_count": len(violations)},
+            "core_consumer_imports": [{"file": item.importer, "target": item.module} for item in findings["R1"]],
+            "static_boundary_violations": violations}
 
 
-def build_inventory(repo_root: Path) -> dict[str, Any]:
-    """Build a deterministic inventory from the checkout's current source."""
-
-    root = repo_root.resolve(strict=True)
-    plugin_root = root / PLUGIN_ROOT
-    if not plugin_root.is_dir():
-        raise ValueError(f"插件根目录不存在: {plugin_root}")
-    entries = [
-        _inventory_entry(root, path)
-        for path in sorted(plugin_root.iterdir())
-        if path.is_dir() and not path.name.startswith("__")
-    ]
-    try:
-        commit = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
-            cwd=root,
-            check=True,
-            capture_output=True,
-            text=True,
-        ).stdout.strip()
-    except (OSError, subprocess.CalledProcessError):
-        commit = "unknown"
-    manifest_entries = [
-        entry for entry in entries if entry["classification"] == "manifest-plugin"
-    ]
-    violations: list[dict[str, Any]] = []
-    for entry in entries:
-        if entry["classification"] != "manifest-plugin":
-            violations.append(
-                {
-                    "package": entry["package"],
-                    "kind": "not_installable_artifact",
-                    "reason": (
-                        "package has an invalid static V3 manifest"
-                        if entry["classification"] == "invalid-manifest"
-                        else "package has no static V3 manifest; retained as support-package evidence"
-                    ),
-                }
-            )
-        if entry["manifest"].get("valid") and not entry["declared_entrypoint_exists"]:
-            violations.append(
-                {
-                    "package": entry["package"],
-                    "kind": "missing_entrypoint",
-                    "reason": "manifest declares no existing entrypoint",
-                }
-            )
-        for edge in entry["sibling_plugin_imports"]:
-            violations.append(
-                {
-                    **edge,
-                    "package": entry["package"],
-                    "kind": "sibling_plugin_import",
-                }
-            )
-        for edge in entry["private_core_imports"]:
-            violations.append(
-                {
-                    **edge,
-                    "package": entry["package"],
-                    "kind": "private_core_import",
-                }
-            )
-        for edge in entry["dynamic_dependencies"]:
-            violations.append(
-                {
-                    **edge,
-                    "package": entry["package"],
-                    "kind": "dynamic_implementation_dependency",
-                }
-            )
-    return {
-        "schema_version": SCHEMA_VERSION,
-        "repository": str(root),
-        "git_head": commit,
-        "plugin_root": PLUGIN_ROOT,
-        "packages": entries,
-        "core_consumer_imports": _core_consumers(root),
-        "summary": {
-            "package_count": len(entries),
-            "manifest_plugin_count": len(manifest_entries),
-            "support_package_count": len(entries) - len(manifest_entries),
-            "manifest_plugins": [entry["package"] for entry in manifest_entries],
-            "support_packages": [
-                entry["package"]
-                for entry in entries
-                if entry["classification"] == "support-package"
-            ],
-            "invalid_manifest_packages": [
-                entry["package"]
-                for entry in entries
-                if entry["classification"] == "invalid-manifest"
-            ],
-            "packages_with_sibling_imports": [
-                entry["package"] for entry in entries if entry["sibling_plugin_imports"]
-            ],
-            "packages_with_private_core_imports": [
-                entry["package"] for entry in entries if entry["private_core_imports"]
-            ],
-            "packages_with_dynamic_dependencies": [
-                entry["package"] for entry in entries if entry["dynamic_dependencies"]
-            ],
-            "core_consumer_import_count": len(_core_consumers(root)),
-            "static_boundary_violation_count": len(violations),
-        },
-        "static_boundary_violations": sorted(
-            violations,
-            key=lambda item: (
-                str(item.get("package")),
-                str(item.get("file", "")),
-                int(item.get("line", 0)),
-                str(item.get("kind")),
-            ),
-        ),
-    }
-
-
-def _text_report(report: dict[str, Any]) -> str:
-    summary = report["summary"]
-    lines = [
-        f"inventory head={report['git_head']}",
-        f"packages={summary['package_count']} manifest_plugins={summary['manifest_plugin_count']} support_packages={summary['support_package_count']}",
-        f"static_boundary_violations={summary['static_boundary_violation_count']}",
-    ]
-    for violation in report["static_boundary_violations"]:
-        location = (
-            f"{violation['file']}:{violation['line']}"
-            if "file" in violation
-            else violation["package"]
-        )
-        target = f" target={violation.get('target')}" if violation.get("target") else ""
-        lines.append(f"FAIL {violation['kind']} {location}{target}")
-    return "\n".join(lines) + "\n"
-
-
-def main(argv: list[str] | None = None) -> int:
+def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--repo-root", type=Path, default=Path(__file__).resolve().parents[1]
-    )
+    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[1])
     parser.add_argument("--output", type=Path)
-    parser.add_argument("--format", choices=("json", "text"), default="json")
-    parser.add_argument(
-        "--strict", action="store_true", help="静态边界存在一项欠账即返回 1"
-    )
-    args = parser.parse_args(argv)
-    try:
-        report = build_inventory(args.repo_root)
-    except (OSError, ValueError) as error:
-        print(f"inventory failed: {error}", file=sys.stderr)
-        return 2
-    rendered = json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
-    if args.format == "text":
-        rendered = _text_report(report)
+    parser.add_argument("--strict", action="store_true")
+    args = parser.parse_args()
+    report = build_inventory(args.repo_root)
+    rendered = json.dumps(report, ensure_ascii=False, indent=2) + "\n"
     if args.output:
-        args.output.parent.mkdir(parents=True, exist_ok=True)
-        args.output.write_text(rendered, encoding="utf-8")
+        with args.output.open("x") as stream:
+            stream.write(rendered)
     else:
         print(rendered, end="")
-    return 1 if args.strict and report["static_boundary_violations"] else 0
+    return int(args.strict and bool(report["static_boundary_violations"]))
 
 
 if __name__ == "__main__":

--- a/scripts/plugin_inventory.py
+++ b/scripts/plugin_inventory.py
@@ -1,0 +1,516 @@
+#!/usr/bin/env python3
+"""Build an auditable inventory of plugin packages and implementation edges.
+
+The inventory intentionally includes packages without a V3 manifest.  Such a
+package is reported as a support package and is not silently treated as an
+external-installable plugin.  ``--strict`` is a static boundary check: it
+fails on the current historical import debt instead of turning that debt into
+an implicit allowlist.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import json
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+PLUGIN_ROOT = "plugins"
+CORE_PREFIXES = (
+    "agent",
+    "bootstrap",
+    "bus",
+    "config",
+    "infra",
+    "main",
+    "session",
+)
+PUBLIC_PLUGIN_API_PREFIXES = ("agent.plugin_composition",)
+PROJECT_ROOTS = CORE_PREFIXES + ("plugins",)
+DYNAMIC_IMPORT_NAMES = frozenset(
+    {
+        "__import__",
+        "import_module",
+        "importlib.import_module",
+        "importlib.util.spec_from_file_location",
+        "importlib.machinery.SourceFileLoader",
+    }
+)
+
+
+def _relative(path: Path, root: Path) -> str:
+    return path.resolve(strict=False).relative_to(root.resolve(strict=False)).as_posix()
+
+
+def _module_name(path: str) -> str:
+    """Return the import-like name of one source target."""
+
+    return path.replace("/", ".").removesuffix(".py")
+
+
+def _is_prefix(name: str, prefixes: tuple[str, ...]) -> bool:
+    return any(name == prefix or name.startswith(prefix + ".") for prefix in prefixes)
+
+
+def _literal(node: ast.AST | None) -> str | None:
+    if node is None:
+        return None
+    try:
+        value = ast.literal_eval(node)
+    except (TypeError, ValueError, SyntaxError):
+        return None
+    return value if isinstance(value, str) else None
+
+
+def _call_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _call_name(node.value)
+        return f"{prefix}.{node.attr}" if prefix else node.attr
+    return "<dynamic>"
+
+
+def _target_from_import(
+    node: ast.Import | ast.ImportFrom, alias: ast.alias
+) -> tuple[str, str]:
+    if isinstance(node, ast.Import):
+        return alias.name, "import"
+    if node.level:
+        dots = "." * node.level
+        return (
+            f"{dots}{node.module or ''}{('.' + alias.name) if alias.name != '*' else ''}",
+            "relative",
+        )
+    module = node.module or ""
+    return (
+        f"{module}.{alias.name}" if module and alias.name != "*" else module
+    ), "from"
+
+
+def _edge(
+    path: Path, root: Path, node: ast.AST, target: str, kind: str
+) -> dict[str, Any]:
+    return {
+        "file": _relative(path, root),
+        "line": int(getattr(node, "lineno", 0)),
+        "target": target,
+        "kind": kind,
+    }
+
+
+def _scan_python_file(
+    path: Path, root: Path, package: str
+) -> dict[str, list[dict[str, Any]]]:
+    result: dict[str, list[dict[str, Any]]] = {
+        "implementation_dependencies": [],
+        "static_imports": [],
+        "relative_imports": [],
+        "sibling_plugin_imports": [],
+        "core_imports": [],
+        "private_core_imports": [],
+        "dynamic_dependencies": [],
+    }
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (OSError, SyntaxError, UnicodeError) as error:
+        result["dynamic_dependencies"].append(
+            {
+                "file": _relative(path, root),
+                "line": 0,
+                "kind": "parse_error",
+                "target": type(error).__name__,
+                "detail": str(error),
+            }
+        )
+        return result
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            aliases = node.names
+            for alias in aliases:
+                target, kind = _target_from_import(node, alias)
+                record = _edge(path, root, node, target, kind)
+                result["static_imports"].append(record)
+                if kind == "relative":
+                    result["relative_imports"].append(record)
+                if target.startswith("plugins."):
+                    result["implementation_dependencies"].append(record)
+                    sibling = target.split(".", 2)[1]
+                    if sibling != package:
+                        result["sibling_plugin_imports"].append(
+                            {**record, "sibling_package": sibling}
+                        )
+                elif _is_prefix(target, CORE_PREFIXES):
+                    result["implementation_dependencies"].append(record)
+                    result["core_imports"].append(record)
+                    if not _is_prefix(target, PUBLIC_PLUGIN_API_PREFIXES):
+                        result["private_core_imports"].append(record)
+                elif target and not target.startswith("."):
+                    # Keep non-stdlib project-looking imports visible without
+                    # guessing whether a third-party package is truly safe.
+                    first = target.split(".", 1)[0]
+                    if first in PROJECT_ROOTS:
+                        result["implementation_dependencies"].append(record)
+
+        if isinstance(node, ast.Call):
+            name = _call_name(node.func)
+            if name in DYNAMIC_IMPORT_NAMES:
+                result["dynamic_dependencies"].append(
+                    {
+                        "file": _relative(path, root),
+                        "line": int(getattr(node, "lineno", 0)),
+                        "kind": "dynamic_import",
+                        "target": _literal(node.args[0]) if node.args else None,
+                        "expression": name,
+                    }
+                )
+        if isinstance(node, ast.Attribute) and node.attr == "path":
+            if isinstance(node.value, ast.Name) and node.value.id == "sys":
+                result["dynamic_dependencies"].append(
+                    {
+                        "file": _relative(path, root),
+                        "line": int(getattr(node, "lineno", 0)),
+                        "kind": "sys_path_mutation_or_read",
+                        "target": "sys.path",
+                    }
+                )
+    return result
+
+
+def _merge_edges(target: list[dict[str, Any]], values: list[dict[str, Any]]) -> None:
+    seen = {
+        (item.get("file"), item.get("line"), item.get("kind"), item.get("target"))
+        for item in target
+    }
+    for value in values:
+        key = (
+            value.get("file"),
+            value.get("line"),
+            value.get("kind"),
+            value.get("target"),
+        )
+        if key not in seen:
+            target.append(value)
+            seen.add(key)
+
+
+def _manifest(root: Path) -> dict[str, Any]:
+    path = root / "akashic.plugin.toml"
+    if not path.exists():
+        return {
+            "path": None,
+            "valid": False,
+            "error": "missing_static_manifest",
+        }
+    try:
+        raw = tomllib.loads(path.read_text(encoding="utf-8"))
+        required = ("schema_version", "name", "version", "api_version", "entrypoint")
+        missing = [key for key in required if key not in raw]
+        if missing:
+            return {
+                "path": path.name,
+                "valid": False,
+                "present": True,
+                "error": f"manifest_missing_fields:{','.join(missing)}",
+            }
+        return {
+            "path": path.name,
+            "valid": True,
+            "present": True,
+            "name": raw.get("name"),
+            "version": raw.get("version"),
+            "api_version": raw.get("api_version"),
+            "entrypoint": raw.get("entrypoint"),
+            "identity_fields": {
+                key: raw.get(key)
+                for key in (
+                    "schema_version",
+                    "name",
+                    "version",
+                    "api_version",
+                    "entrypoint",
+                )
+            },
+        }
+    except (OSError, tomllib.TOMLDecodeError, TypeError) as error:
+        return {
+            "path": path.name,
+            "valid": False,
+            "present": True,
+            "error": f"manifest_parse_error:{type(error).__name__}:{error}",
+        }
+
+
+def _entry_digest(files: list[Path], root: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(files):
+        digest.update(_relative(path, root).encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _inventory_entry(root: Path, package_root: Path) -> dict[str, Any]:
+    package = package_root.name
+    py_files = sorted(package_root.rglob("*.py"))
+    manifest = _manifest(package_root)
+    edges: dict[str, list[dict[str, Any]]] = {
+        "implementation_dependencies": [],
+        "static_imports": [],
+        "relative_imports": [],
+        "sibling_plugin_imports": [],
+        "core_imports": [],
+        "private_core_imports": [],
+        "dynamic_dependencies": [],
+    }
+    for path in py_files:
+        scanned = _scan_python_file(path, root, package)
+        for key, values in scanned.items():
+            _merge_edges(edges[key], values)
+    entrypoint = manifest.get("entrypoint") if manifest.get("valid") else None
+    conventional = [
+        name
+        for name in ("plugin.py", "message_plugin.py")
+        if (package_root / name).is_file()
+    ]
+    if (
+        isinstance(entrypoint, str)
+        and (package_root / entrypoint).is_file()
+        and entrypoint not in conventional
+    ):
+        conventional.append(entrypoint)
+    entrypoint_exists = (
+        isinstance(entrypoint, str) and (package_root / entrypoint).is_file()
+    )
+    return {
+        "package": package,
+        "root": _relative(package_root, root),
+        "classification": (
+            "manifest-plugin"
+            if manifest.get("valid")
+            else "invalid-manifest" if manifest.get("present") else "support-package"
+        ),
+        "manifest": manifest,
+        "declared_entrypoint_exists": entrypoint_exists,
+        "entrypoints": sorted(conventional),
+        "python_files": [_relative(path, root) for path in py_files],
+        "source_digest": _entry_digest(py_files, root),
+        **{
+            key: sorted(
+                values,
+                key=lambda item: (
+                    str(item.get("file")),
+                    int(item.get("line", 0)),
+                    str(item.get("target")),
+                ),
+            )
+            for key, values in edges.items()
+        },
+    }
+
+
+def _core_consumers(root: Path) -> list[dict[str, Any]]:
+    """Record Core-side imports of plugin implementation packages."""
+
+    records: list[dict[str, Any]] = []
+    paths = [root / name for name in CORE_PREFIXES if (root / name).exists()]
+    paths.extend([root / "main.py", root / "config.py"])
+    for base in paths:
+        candidates = [base] if base.is_file() else sorted(base.rglob("*.py"))
+        for path in candidates:
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            except (OSError, SyntaxError, UnicodeError):
+                continue
+            for node in ast.walk(tree):
+                if not isinstance(node, (ast.Import, ast.ImportFrom)):
+                    continue
+                for alias in node.names:
+                    target, _ = _target_from_import(node, alias)
+                    if target.startswith("plugins."):
+                        records.append(
+                            {
+                                "file": _relative(path, root),
+                                "line": int(getattr(node, "lineno", 0)),
+                                "target": target,
+                            }
+                        )
+    unique = {(item["file"], item["line"], item["target"]): item for item in records}
+    return [
+        unique[key]
+        for key in sorted(unique, key=lambda item: (item[0], item[1], item[2]))
+    ]
+
+
+def build_inventory(repo_root: Path) -> dict[str, Any]:
+    """Build a deterministic inventory from the checkout's current source."""
+
+    root = repo_root.resolve(strict=True)
+    plugin_root = root / PLUGIN_ROOT
+    if not plugin_root.is_dir():
+        raise ValueError(f"插件根目录不存在: {plugin_root}")
+    entries = [
+        _inventory_entry(root, path)
+        for path in sorted(plugin_root.iterdir())
+        if path.is_dir() and not path.name.startswith("__")
+    ]
+    try:
+        commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=root,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        commit = "unknown"
+    manifest_entries = [
+        entry for entry in entries if entry["classification"] == "manifest-plugin"
+    ]
+    violations: list[dict[str, Any]] = []
+    for entry in entries:
+        if entry["classification"] != "manifest-plugin":
+            violations.append(
+                {
+                    "package": entry["package"],
+                    "kind": "not_installable_artifact",
+                    "reason": (
+                        "package has an invalid static V3 manifest"
+                        if entry["classification"] == "invalid-manifest"
+                        else "package has no static V3 manifest; retained as support-package evidence"
+                    ),
+                }
+            )
+        if entry["manifest"].get("valid") and not entry["declared_entrypoint_exists"]:
+            violations.append(
+                {
+                    "package": entry["package"],
+                    "kind": "missing_entrypoint",
+                    "reason": "manifest declares no existing entrypoint",
+                }
+            )
+        for edge in entry["sibling_plugin_imports"]:
+            violations.append(
+                {
+                    **edge,
+                    "package": entry["package"],
+                    "kind": "sibling_plugin_import",
+                }
+            )
+        for edge in entry["private_core_imports"]:
+            violations.append(
+                {
+                    **edge,
+                    "package": entry["package"],
+                    "kind": "private_core_import",
+                }
+            )
+        for edge in entry["dynamic_dependencies"]:
+            violations.append(
+                {
+                    **edge,
+                    "package": entry["package"],
+                    "kind": "dynamic_implementation_dependency",
+                }
+            )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "repository": str(root),
+        "git_head": commit,
+        "plugin_root": PLUGIN_ROOT,
+        "packages": entries,
+        "core_consumer_imports": _core_consumers(root),
+        "summary": {
+            "package_count": len(entries),
+            "manifest_plugin_count": len(manifest_entries),
+            "support_package_count": len(entries) - len(manifest_entries),
+            "manifest_plugins": [entry["package"] for entry in manifest_entries],
+            "support_packages": [
+                entry["package"]
+                for entry in entries
+                if entry["classification"] == "support-package"
+            ],
+            "invalid_manifest_packages": [
+                entry["package"]
+                for entry in entries
+                if entry["classification"] == "invalid-manifest"
+            ],
+            "packages_with_sibling_imports": [
+                entry["package"] for entry in entries if entry["sibling_plugin_imports"]
+            ],
+            "packages_with_private_core_imports": [
+                entry["package"] for entry in entries if entry["private_core_imports"]
+            ],
+            "packages_with_dynamic_dependencies": [
+                entry["package"] for entry in entries if entry["dynamic_dependencies"]
+            ],
+            "core_consumer_import_count": len(_core_consumers(root)),
+            "static_boundary_violation_count": len(violations),
+        },
+        "static_boundary_violations": sorted(
+            violations,
+            key=lambda item: (
+                str(item.get("package")),
+                str(item.get("file", "")),
+                int(item.get("line", 0)),
+                str(item.get("kind")),
+            ),
+        ),
+    }
+
+
+def _text_report(report: dict[str, Any]) -> str:
+    summary = report["summary"]
+    lines = [
+        f"inventory head={report['git_head']}",
+        f"packages={summary['package_count']} manifest_plugins={summary['manifest_plugin_count']} support_packages={summary['support_package_count']}",
+        f"static_boundary_violations={summary['static_boundary_violation_count']}",
+    ]
+    for violation in report["static_boundary_violations"]:
+        location = (
+            f"{violation['file']}:{violation['line']}"
+            if "file" in violation
+            else violation["package"]
+        )
+        target = f" target={violation.get('target')}" if violation.get("target") else ""
+        lines.append(f"FAIL {violation['kind']} {location}{target}")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root", type=Path, default=Path(__file__).resolve().parents[1]
+    )
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--format", choices=("json", "text"), default="json")
+    parser.add_argument(
+        "--strict", action="store_true", help="静态边界存在一项欠账即返回 1"
+    )
+    args = parser.parse_args(argv)
+    try:
+        report = build_inventory(args.repo_root)
+    except (OSError, ValueError) as error:
+        print(f"inventory failed: {error}", file=sys.stderr)
+        return 2
+    rendered = json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if args.format == "text":
+        rendered = _text_report(report)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 1 if args.strict and report["static_boundary_violations"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_external_plugin_runtime.py
+++ b/tests/test_external_plugin_runtime.py
@@ -52,3 +52,15 @@ def test_all_inventory_requires_a_real_source_mapping(tmp_path: Path, capsys) ->
         str(item.get("error", "")) for item in report["reports"]
     )
     assert not capsys.readouterr().out
+
+
+def test_source_check_cannot_substitute_for_packaged_core(tmp_path):
+    import asyncio
+    from docker.debug.plugin_external_acceptance import _exercise
+
+    evidence = asyncio.run(_exercise(source="https://example.invalid/plugin.git",
+        repo_root=Path(__file__).parents[1], marketplace="test", workspace=tmp_path / "workspace",
+        plugins_home=tmp_path / "home", capability_service=None))
+    assert evidence["status"] == "failed"
+    assert "Core 制品" in evidence["error"]
+    assert not evidence["checks"].get("capability_call", False)

--- a/tests/test_external_plugin_runtime.py
+++ b/tests/test_external_plugin_runtime.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from docker.debug.plugin_external_acceptance import _source_checkout, main
+from scripts.plugin_inventory import build_inventory
+
+
+def test_external_runtime_rejects_repository_checkout() -> None:
+    repo_root = Path(__file__).parents[1].resolve()
+
+    try:
+        _source_checkout(str(repo_root / "plugins" / "content"), repo_root)
+    except ValueError as error:
+        assert "本仓库内" in str(error)
+    else:
+        raise AssertionError("repository plugin source was accepted as external")
+
+
+def test_all_inventory_requires_a_real_source_mapping(tmp_path: Path, capsys) -> None:
+    repo_root = Path(__file__).parents[1]
+    inventory_path = tmp_path / "inventory.json"
+    inventory_path.write_text(
+        json.dumps(build_inventory(repo_root), ensure_ascii=False),
+        encoding="utf-8",
+    )
+    sources_path = tmp_path / "sources.json"
+    sources_path.write_text("{}\n", encoding="utf-8")
+    report_path = tmp_path / "external-report.json"
+
+    result = main(
+        [
+            "--all",
+            "--inventory",
+            str(inventory_path),
+            "--sources-json",
+            str(sources_path),
+            "--repo-root",
+            str(repo_root),
+            "--output",
+            str(report_path),
+        ]
+    )
+
+    assert result == 1
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["status"] == "failed"
+    assert report["reports"]
+    assert all(item["status"] == "failed" for item in report["reports"])
+    assert "one example" in " ".join(
+        str(item.get("error", "")) for item in report["reports"]
+    )
+    assert not capsys.readouterr().out

--- a/tests/test_plugin_inventory.py
+++ b/tests/test_plugin_inventory.py
@@ -1,42 +1,24 @@
-from __future__ import annotations
-
-from pathlib import Path
+"""清单不能通过独立的一套宽泛公开目录规则隐藏实现依赖。"""
+import subprocess
 
 from scripts.plugin_inventory import build_inventory
 
 
-def test_inventory_covers_manifest_plugins_and_support_packages() -> None:
-    report = build_inventory(Path(__file__).parents[1])
-    packages = {entry["package"]: entry for entry in report["packages"]}
-
-    assert report["schema_version"] == 1
-    assert report["summary"]["package_count"] == len(packages)
-    assert report["summary"]["manifest_plugin_count"] >= 1
-    assert report["summary"]["support_package_count"] >= 1
-    assert packages["akasha"]["classification"] == "manifest-plugin"
-    assert packages["content"]["classification"] == "support-package"
-    assert all(entry["source_digest"] for entry in packages.values())
-    assert all("static_imports" in entry for entry in packages.values())
-
-
-def test_inventory_keeps_current_boundary_debt_as_failure_evidence() -> None:
-    report = build_inventory(Path(__file__).parents[1])
-    violations = report["static_boundary_violations"]
-    kinds = {item["kind"] for item in violations}
-
-    # This is intentionally a red baseline on the pre-migration tree.  The
-    # inventory must expose debt instead of granting a blanket historical
-    # allowlist or claiming one external example proves the fleet.
-    assert violations
-    assert "not_installable_artifact" in kinds
-    assert "sibling_plugin_import" in kinds
-    assert "private_core_import" in kinds
-
-
-def test_inventory_records_core_side_plugin_consumers() -> None:
-    report = build_inventory(Path(__file__).parents[1])
-    consumers = report["core_consumer_imports"]
-
-    assert consumers
-    assert all({"file", "line", "target"} <= set(item) for item in consumers)
-    assert any(item["target"].startswith("plugins.") for item in consumers)
+def test_inventory_includes_support_packages_and_uses_frozen_boundary_rules(tmp_path):
+    files = {
+        "plugins/one/plugin.py": "from agent.plugin_composition.future_private import Hidden\nfrom plugins.two.impl import run\n",
+        "plugins/two/impl.py": "def run(): pass\n",
+        "bootstrap/app.py": "from plugins.two.impl import run\n",
+    }
+    for name, content in files.items():
+        path = tmp_path / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+    subprocess.run(["git", "init", str(tmp_path)], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(tmp_path), "add", "."], check=True, capture_output=True)
+    report = build_inventory(tmp_path)
+    assert {item["package"] for item in report["packages"]} == {"one", "two"}
+    assert report["summary"]["support_package_count"] == 2
+    assert {item["kind"] for item in report["static_boundary_violations"]} == {
+        "R1", "R2", "R3", "not_installable_artifact"}
+    assert report["core_consumer_imports"] == [{"file": "bootstrap/app.py", "target": "plugins.two.impl"}]

--- a/tests/test_plugin_inventory.py
+++ b/tests/test_plugin_inventory.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.plugin_inventory import build_inventory
+
+
+def test_inventory_covers_manifest_plugins_and_support_packages() -> None:
+    report = build_inventory(Path(__file__).parents[1])
+    packages = {entry["package"]: entry for entry in report["packages"]}
+
+    assert report["schema_version"] == 1
+    assert report["summary"]["package_count"] == len(packages)
+    assert report["summary"]["manifest_plugin_count"] >= 1
+    assert report["summary"]["support_package_count"] >= 1
+    assert packages["akasha"]["classification"] == "manifest-plugin"
+    assert packages["content"]["classification"] == "support-package"
+    assert all(entry["source_digest"] for entry in packages.values())
+    assert all("static_imports" in entry for entry in packages.values())
+
+
+def test_inventory_keeps_current_boundary_debt_as_failure_evidence() -> None:
+    report = build_inventory(Path(__file__).parents[1])
+    violations = report["static_boundary_violations"]
+    kinds = {item["kind"] for item in violations}
+
+    # This is intentionally a red baseline on the pre-migration tree.  The
+    # inventory must expose debt instead of granting a blanket historical
+    # allowlist or claiming one external example proves the fleet.
+    assert violations
+    assert "not_installable_artifact" in kinds
+    assert "sibling_plugin_import" in kinds
+    assert "private_core_import" in kinds
+
+
+def test_inventory_records_core_side_plugin_consumers() -> None:
+    report = build_inventory(Path(__file__).parents[1])
+    consumers = report["core_consumer_imports"]
+
+    assert consumers
+    assert all({"file", "line", "target"} <= set(item) for item in consumers)
+    assert any(item["target"].startswith("plugins.") for item in consumers)


### PR DESCRIPTION
## 问题与结果

完整外置需要覆盖所有包，并明确区分注册、真实调用和制品隔离。本层增加全量插件清单与可失败的外置检查工具；清单复用 scripts/plugin_boundary.py 的冻结规则，不维护另一套宽泛公开目录。验收要求 checkout 外、不含业务 plugins 的 Core 制品，拒绝预先从源码加载的 Core 与残留 plugins 命名空间；服务枚举不能算调用成功。

Stack: #593 → #594 → #597 → #598 → #599 → #600 → 本 PR。

## Change intent

- change_type: feature；semantic_delta: compatible；capability_owner: not_applicable（诊断与验收工具）。
- consumer_scope: 全部第一方包和明确提供的外部安装源；runtime_patch: none。
- protected_state / authoritative_state_owner: 既有运行数据与 owner 不变，工具验收使用一次性 workspace。
- 允许源码、临时报告与 Git/PR；禁止正式部署/数据迁移。
- concept_gate: required，完整实施后统一概念审查。

## 证据与限制

当前清单覆盖 37 个包、37 个 manifest；静态欠账 543 条，其中 Core 实现导入 36 条。严格模式仍失败，准确反映尚未完成的迁移。

4 项定向测试通过：无 manifest 支撑包不能遗漏，未来 public 目录私有模块不能被放行，拒绝仓库内安装源，完整清单缺 source mapping 必须失败，没有 Core 制品不能借 source 检查冒充外置成功。

helper 接受正式 Git 源或 bundle。只有目标插件实际提供的 callable 经当前 snapshot lease 调用才记录 capability_call；没有指定实际调用保持失败/未验证。该 smoke 不能代替默认产品、替换和恢复的行为 oracle。完整合法依赖组合、真实制品执行矩阵继续在后续实现。

完整类型/Gate/CI及 Terra/xhigh 独立审查按维护者要求集中处理；sourceDigest/planDigest 未生成。根线程已修正副手初稿中把目录枚举当能力调用、预加载源码当Core制品和重复扫描政策的问题。

基线 7b2d4c39，交付 52c8157a；无 schema 变化。恢复通过前层提交/revert及开工备份。已核对 projectneed、NOW、Decision 0065，整体目标仍在实施。