### PR TITLE
refactor: resolve plugin message displays within page leases

### DIFF
--- a/agent/control/protocol/router.py
+++ b/agent/control/protocol/router.py
@@ -256,7 +256,7 @@ class ConnectionRouter:
         if method == "session/list":
             return self._service.list_sessions(values["cursor"], values["limit"])
         if method == "message/read":
-            return self._service.read_messages(values["session_id"], values["after_seq"],
+            return await self._service.read_messages(values["session_id"], values["after_seq"],
                                                 values["through_seq"], values["limit"])
         if method == "message/send":
             return await self._service.send_message(cast(MessageSendParams, params))

--- a/agent/control/service.py
+++ b/agent/control/service.py
@@ -15,7 +15,7 @@ from agent.control.protocol.errors import JsonRpcError, UNAUTHORIZED
 from agent.control.protocol.models import InitializeParams, MessageSendParams
 from agent.control.protocol.method import RpcMethod
 from agent.plugin_composition.channels import ChannelInboundMessage
-from infra.channels.message_view import follow_messages, message_rows, session_row
+from infra.channels.message_view import MessageDisplayReader, follow_messages, read_message_rows, session_row
 from session.artifacts import AttachmentRef
 from session.log import MessageCatalog
 from session.message import Message
@@ -44,10 +44,12 @@ class ControlService:
         plugin_uninstall: PluginAction | None = None,
         workspace_token: str | None = None, boot_id: str | None = None,
         ready: Callable[[], bool] | None = None,
+        message_display: MessageDisplayReader | None = None,
         methods: Mapping[str, RpcMethod] | None = None,
         resolve_method: Callable[[str], AbstractAsyncContextManager[RpcMethod | None]] | None = None,
         control_frames: FrameBook | None = None,
     ) -> None:
+        self._message_display = message_display
         self.messages = messages
         self.workspace = workspace.resolve()
         self._accept = accept
@@ -95,12 +97,12 @@ class ControlService:
         return {"version": 2, "items": [session_row(entry) for entry in page.items],
                 "total": page.total, "next_cursor": page.next_cursor}
 
-    def read_messages(self, session_id: str, after_seq: int, through_seq: int | None,
+    async def read_messages(self, session_id: str, after_seq: int, through_seq: int | None,
                       limit: int) -> dict[str, object]:
         page = self.messages.reader(session_id).read_page(
             after_seq=after_seq, through_seq=through_seq, limit=limit,
         )
-        return {"version": 2, "session_id": session_id, "items": message_rows(page),
+        return {"version": 2, "session_id": session_id, "items": await read_message_rows(page, reader=self._message_display),
                 "after_seq": after_seq, "through_seq": page.through_seq,
                 "next_after_seq": page.messages[-1].seq if page.messages else after_seq,
                 "has_more": page.has_more}
@@ -144,7 +146,7 @@ class ControlService:
         queue: asyncio.Queue[dict[str, object]] = asyncio.Queue(1)
 
         async def messages() -> None:
-            async with aclosing(follow_messages(self.messages.reader(session_id), after_seq=after_seq)) as feed:
+            async with aclosing(follow_messages(self.messages.reader(session_id), after_seq=after_seq, reader_display=self._message_display)) as feed:
                 async for page in feed:
                     await queue.put({"type": "messages.appended", **page})
 

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -17,6 +17,7 @@ from agent.config_models import Config
 from bootstrap.channel_host import ChannelHost
 from bootstrap.channels import start_channels
 from bootstrap.chat_api import build_chat_server
+from bootstrap.message_display import RuntimeMessageDisplay
 from bootstrap.cleanup import run_cleanup_steps
 from bootstrap.dashboard_api import build_dashboard_server
 from bootstrap.web_runtime import (
@@ -250,6 +251,7 @@ class AppRuntime:
             channel_attachment_store = self.core.channel_attachment_store
             messages = MessageCatalog(self.core.message_log)
             reply_status = RuntimeReplyStatus(manager.snapshot_store).follow
+            message_display = RuntimeMessageDisplay(manager.snapshot_store)
             if self.config.app_server.enabled:
                 assert app_server_endpoint is not None
                 self.app_server = SocketAppServer(
@@ -300,6 +302,7 @@ class AppRuntime:
                     self.workspace,
                 )
                 self.mobile_gateway_runtime.channel.bind_messages(messages, reply_status)
+                self.mobile_gateway_runtime.channel.bind_message_display(message_display)
                 self.mobile_gateway_runtime.channel.bind_runtime_inspection(
                     runtime_inspection
                 )
@@ -440,6 +443,7 @@ class AppRuntime:
                     model_control=model_control,
                     messages=messages,
                     reply_status=reply_status,
+                    message_display=message_display,
                 )
                 self.chat_task = asyncio.create_task(
                     self.chat_server.serve(),

--- a/bootstrap/app_server.py
+++ b/bootstrap/app_server.py
@@ -17,6 +17,7 @@ from bootstrap.tools import CoreRuntime, build_core_runtime
 from bootstrap.workspace_lock import WorkspaceInstanceLock
 from core.net.http import SharedHttpResources
 from infra.control.stdio import StdioAppServer
+from bootstrap.message_display import RuntimeMessageDisplay
 from session.log import MessageCatalog
 from session.message import Message
 
@@ -78,6 +79,7 @@ def build_control_service(
         MessageCatalog(core.message_log), core.workspace, accept=accept,
         attachments=core.channel_attachment_store.resolve_refs,
         reply_status=RuntimeReplyStatus(manager.snapshot_store).follow,
+        message_display=RuntimeMessageDisplay(manager.snapshot_store),
         plugin_install=install, plugin_status=manager.candidate_status,
         plugin_update=lambda identity: asdict(manager.read_update(identity)),
         plugin_promote=promote, plugin_discard=discard, plugin_drain=drain,

--- a/bootstrap/chat_api.py
+++ b/bootstrap/chat_api.py
@@ -29,7 +29,7 @@ from agent.plugins.model_catalog import (
     default_chat_model_id,
     project_chat_runtimes,
 )
-from infra.channels.message_view import MessageDisplayProviders, message_rows, session_row
+from infra.channels.message_view import MessageDisplayReader, read_message_rows, session_row
 from infra.channels.base import AttachmentStore
 from infra.channels.artifacts import ChannelAttachmentArtifactStore
 from infra.channels.web_chat_channel import (
@@ -85,7 +85,7 @@ def create_chat_app(
     channel: WebChatChannel,
     mobile_pairing_admin: MobilePairingAdmin | None = None,
     runtime_inspection: RuntimeInspectionService | None = None,
-    message_display: MessageDisplayProviders | None = None,
+    message_display: MessageDisplayReader | None = None,
     plugin_ui_provider: MobileUiProvider | None = None,
     web_ui_provider: WebUiProvider | None = None,
     model_catalog_reader: Callable[[], Awaitable[ModelCatalogSnapshot]] | None = None,
@@ -339,7 +339,7 @@ def create_chat_app(
             raise _runtime_http_error(error) from error
 
     @app.get("/api/chat/sessions/{session_key:path}/messages")
-    def list_messages(
+    async def list_messages(
         session_key: str,
         page_size: int = Query(50, ge=1, le=200),
         before_seq: int | None = Query(default=None, ge=0),
@@ -354,10 +354,10 @@ def create_chat_app(
             raise HTTPException(status_code=404, detail="会话不存在") from error
         except InvalidPage as error:
             raise HTTPException(status_code=422, detail=str(error)) from error
-        items = message_rows(
+        items = await read_message_rows(
             page,
             display_only=True,
-            providers=channel.message_display,
+            reader=channel.message_display,
         )
         return {"version": 2, "items": items, "through_seq": page.through_seq,
                 "has_more": page.has_more,
@@ -484,7 +484,7 @@ def build_chat_server(
     channel: WebChatChannel,
     mobile_pairing_admin: MobilePairingAdmin | None = None,
     runtime_inspection: RuntimeInspectionService | None = None,
-    message_display: MessageDisplayProviders | None = None,
+    message_display: MessageDisplayReader | None = None,
     plugin_ui_provider: MobileUiProvider | None = None,
     web_ui_provider: WebUiProvider | None = None,
     model_catalog_reader: Callable[[], Awaitable[ModelCatalogSnapshot]] | None = None,

--- a/bootstrap/chat_api.py
+++ b/bootstrap/chat_api.py
@@ -29,7 +29,7 @@ from agent.plugins.model_catalog import (
     default_chat_model_id,
     project_chat_runtimes,
 )
-from infra.channels.message_view import message_rows, session_row
+from infra.channels.message_view import MessageDisplayProviders, message_rows, session_row
 from infra.channels.base import AttachmentStore
 from infra.channels.artifacts import ChannelAttachmentArtifactStore
 from infra.channels.web_chat_channel import (
@@ -85,6 +85,7 @@ def create_chat_app(
     channel: WebChatChannel,
     mobile_pairing_admin: MobilePairingAdmin | None = None,
     runtime_inspection: RuntimeInspectionService | None = None,
+    message_display: MessageDisplayProviders | None = None,
     plugin_ui_provider: MobileUiProvider | None = None,
     web_ui_provider: WebUiProvider | None = None,
     model_catalog_reader: Callable[[], Awaitable[ModelCatalogSnapshot]] | None = None,
@@ -94,6 +95,8 @@ def create_chat_app(
 ) -> FastAPI:
     if messages is not None:
         channel.bind_message_readers(messages, reply_status)
+    if message_display is not None:
+        channel.bind_message_display(message_display)
     channel.bind_attachment_store(AttachmentStore(workspace / "uploads"))
     metadata_store: ArtifactStore | None = None
     if channel.artifact_store is None and channel._ctx is not None:
@@ -351,7 +354,11 @@ def create_chat_app(
             raise HTTPException(status_code=404, detail="会话不存在") from error
         except InvalidPage as error:
             raise HTTPException(status_code=422, detail=str(error)) from error
-        items = message_rows(page, display_only=True)
+        items = message_rows(
+            page,
+            display_only=True,
+            providers=channel.message_display,
+        )
         return {"version": 2, "items": items, "through_seq": page.through_seq,
                 "has_more": page.has_more,
                 "before_seq": page.messages[0].seq if page.has_more else None}
@@ -477,6 +484,7 @@ def build_chat_server(
     channel: WebChatChannel,
     mobile_pairing_admin: MobilePairingAdmin | None = None,
     runtime_inspection: RuntimeInspectionService | None = None,
+    message_display: MessageDisplayProviders | None = None,
     plugin_ui_provider: MobileUiProvider | None = None,
     web_ui_provider: WebUiProvider | None = None,
     model_catalog_reader: Callable[[], Awaitable[ModelCatalogSnapshot]] | None = None,
@@ -491,6 +499,7 @@ def build_chat_server(
             channel=channel,
             mobile_pairing_admin=mobile_pairing_admin,
             runtime_inspection=runtime_inspection,
+            message_display=message_display,
             plugin_ui_provider=plugin_ui_provider,
             web_ui_provider=web_ui_provider,
             model_catalog_reader=model_catalog_reader,

--- a/bootstrap/message_display.py
+++ b/bootstrap/message_display.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import cast
+
+from agent.plugin_composition import ServiceKey
+from agent.plugins.snapshot import RuntimeSnapshotStore, lease_runtime_snapshot
+from infra.channels.message_view import MessageDisplayProviders, PartDisplayProvider, message_rows
+from session.log import MessagePage
+
+
+class RuntimeMessageDisplay:
+    """每页解析并调用同代投影；连接和下载票据不持有插件实现。"""
+
+    def __init__(self, store: RuntimeSnapshotStore):
+        self._store = store
+
+    async def __call__(self, page: MessagePage, *, display_only: bool) -> list[dict[str, object]]:
+        """插件以内容 kind 声明展示；重复 key 沿用组合层冲突语义。"""
+        async with lease_runtime_snapshot(self._store) as snapshot:
+            root = snapshot.composition_root
+            if root is None:
+                raise RuntimeError("消息展示需要已发布的插件 Root")
+            providers = root.provided_services()
+            renderers = {
+                key.name.removeprefix("message.display:"): cast(PartDisplayProvider, value)
+                for key, value in providers.items()
+                if key.name.startswith("message.display:")
+            }
+            tool_name = root.context.get(ServiceKey[Callable[[str], str]]("tools.display-name.v1"))
+            return message_rows(page, display_only=display_only, providers=MessageDisplayProviders(
+                tool_name=tool_name, part_display=renderers,
+            ))

--- a/docs/design/plugin-boundary-foundation.md
+++ b/docs/design/plugin-boundary-foundation.md
@@ -222,3 +222,16 @@ reply 或 react 实现。客户端线上 JSON 字段不变；Python 服务 ABI �
 来源插件只使用本地 SourceSession 结构，不导入 conversation 实现。
 `MessageReader` 通过既有公开 messages 模块提供；它读取 Core 权威 Message 日志，
 不授予任意 SQL、删除或外部发送能力，也不包含业务投影。
+
+
+### 9.5 消息展示由内容 owner 提供
+
+客户端页面通过 `message.display:<kind>` 消费该内容的只读展示函数。内容插件分别
+提供自己拥有的 kind，不增加 Core 业务列表；同一 key 的冲突由已有组合层拒绝。
+插件选择可以公开的字段，未知内容明确标记 unavailable，不把内部 continuation 直传客户端。
+工具名称沿用工具插件的只读 binding 描述能力，不重开工具或按当前名称重新绑定。
+
+Web、Mobile 和控制端每次页面或正文投影在同一个 snapshot lease 内解析并调用，
+完成后释放；长连接、下载票据和频道对象不缓存业务 provider。新一页使用当前代，
+单页不串代。历史事实与下载摘要检查保持原约束；提供者变化导致表示不匹配时仍明确拒绝，
+不放宽摘要条件。展示测试覆盖新 kind、提供者替换、提供者移除和每页 lease 释放。

--- a/infra/channels/message_view.py
+++ b/infra/channels/message_view.py
@@ -1,15 +1,40 @@
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator, Mapping
+from collections.abc import AsyncGenerator, Callable, Mapping
 from contextlib import aclosing
-from dataclasses import asdict
-from typing import cast
+from dataclasses import asdict, dataclass, field
+from typing import Protocol, cast
 
-from plugins.models.projection import display_facts
-from plugins.tools.api import display_name
 from session.log import MessagePage, MessageReader, SessionEntry
 from session.message import ContentPart, Control, Input, Message, Output, ToolCall
 from session.message_codec import json_value
+
+
+class PartDisplayProvider(Protocol):
+    """尝试投影一个插件拥有的内容块；不属于该插件时返回 None。"""
+
+    def __call__(self, part: ContentPart) -> Mapping[str, object] | None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class MessageDisplayProviders:
+    """绑定同一展示请求的插件只读投影回调。
+
+    回调由调用者从 exact generation 取得；Core 只保存本次请求的不可变快照。
+    缺少 provider 时仍返回消息类型与 ``unavailable``，不会猜测业务字段。
+    """
+
+    tool_name: Callable[[str], str] | None = None
+    part_display: tuple[PartDisplayProvider, ...] = field(default_factory=tuple)
+
+
+    def __post_init__(self) -> None:
+        if self.tool_name is not None and not callable(self.tool_name):
+            raise TypeError("tool_name provider 必须可调用")
+        providers = tuple(self.part_display)
+        if any(not callable(provider) for provider in providers):
+            raise TypeError("part_display provider 必须可调用")
+        object.__setattr__(self, "part_display", providers)
 
 
 def session_row(entry: SessionEntry) -> dict[str, object]:
@@ -29,13 +54,29 @@ def session_row(entry: SessionEntry) -> dict[str, object]:
     }
 
 
-def message_rows(page: MessagePage, *, display_only: bool = False) -> list[dict[str, object]]:
+def message_rows(
+    page: MessagePage,
+    *,
+    display_only: bool = False,
+    providers: MessageDisplayProviders | None = None,
+) -> list[dict[str, object]]:
     """把固定消息页转为两端共用的展示数据，不读取或修改运行状态。"""
-    return [_message_row(message, page, display_only=display_only) for message in page.messages]
+    display = MessageDisplayProviders() if providers is None else providers
+    return [
+        _message_row(message, page, display_only=display_only, providers=display)
+        for message in page.messages
+    ]
 
 
-async def follow_messages(reader: MessageReader, *, after_seq: int, display_only: bool = False) -> AsyncGenerator[dict[str, object], None]:
+async def follow_messages(
+    reader: MessageReader,
+    *,
+    after_seq: int,
+    display_only: bool = False,
+    providers: MessageDisplayProviders | None = None,
+) -> AsyncGenerator[dict[str, object], None]:
     """从 seq 续读完整展示页；唤醒通知不携带第二份消息正文。"""
+    display = MessageDisplayProviders() if providers is None else providers
     # 1. 先注册日志通知，再按页补齐附件和 binding 展示字段。
     async with aclosing(reader.follow(after_seq=after_seq)) as follower:
         async for message in follower:
@@ -45,7 +86,7 @@ async def follow_messages(reader: MessageReader, *, after_seq: int, display_only
             while page.messages:
                 next_seq = page.messages[-1].seq
                 yield {"version": 2, "session_id": reader.session_id,
-                       "items": message_rows(page, display_only=display_only), "after_seq": after_seq,
+                       "items": message_rows(page, display_only=display_only, providers=display), "after_seq": after_seq,
                        "through_seq": page.through_seq, "next_after_seq": next_seq,
                        "has_more": page.has_more}
                 after_seq = next_seq
@@ -55,7 +96,13 @@ async def follow_messages(reader: MessageReader, *, after_seq: int, display_only
                 page = reader.read_page(after_seq=after_seq, through_seq=page.through_seq, limit=50)
 
 
-def _message_row(message: Message, page: MessagePage, *, display_only: bool) -> dict[str, object]:
+def _message_row(
+    message: Message,
+    page: MessagePage,
+    *,
+    display_only: bool,
+    providers: MessageDisplayProviders,
+) -> dict[str, object]:
     """保留真实类型、顺序和引用，页面不推断执行结果或重新分配作者。"""
     # 1. 身份和消息用途分别呈现；Control 与晚到结果仍是独立行。
     body = message.body
@@ -73,7 +120,12 @@ def _message_row(message: Message, page: MessagePage, *, display_only: bool) -> 
         row["body"] = {"kind": "control", "action": body.action,
                        "through_seq": body.through_seq, "reason": body.reason}
         return row
-    parts = [_part(part, page.bindings, display_only=display_only) for part in body.parts]
+    parts = [
+        _part(part, display_only=display_only, providers=providers)
+        if isinstance(part, ContentPart)
+        else _tool_call(part, providers=providers)
+        for part in body.parts
+    ]
     if isinstance(body, Input):
         row["body"] = {"kind": "input", "parts": parts}
     elif isinstance(body, Output):
@@ -84,19 +136,35 @@ def _message_row(message: Message, page: MessagePage, *, display_only: bool) -> 
     return row
 
 
-def _part(part: ContentPart | ToolCall, bindings: Mapping[str, Mapping[str, object]], *, display_only: bool) -> dict[str, object]:
+def _tool_call(part: ToolCall, *, providers: MessageDisplayProviders) -> dict[str, object]:
+    """只通过工具 owner 的名称回调展示 binding，不解析或重开工具。"""
+    name_reader = providers.tool_name
+    if name_reader is None:
+        return {
+            "kind": "tool_call",
+            "binding_id": part.binding_id,
+            "display": "unavailable",
+        }
+    return {
+        "kind": "tool_call",
+        "binding_id": part.binding_id,
+        "name": name_reader(part.binding_id),
+        "arguments": json_value(part.arguments),
+    }
+
+
+def _part(
+    part: ContentPart,
+    *,
+    display_only: bool,
+    providers: MessageDisplayProviders,
+) -> dict[str, object]:
     """只公开展示合同允许的字段，未知内容保留类型与不可展示的明确状态。"""
-    # 1. 名称由原工具 binding 提供，模型事实由其 owner 限定字段。
-    if isinstance(part, ToolCall):
-        descriptor = bindings[part.binding_id]
-        metadata = descriptor["metadata"]
-        if not isinstance(metadata, Mapping):
-            raise ValueError("工具 binding metadata 无效")
-        return {"kind": "tool_call", "binding_id": part.binding_id,
-                "name": display_name(cast(Mapping[str, object], metadata)),
-                "arguments": json_value(part.arguments)}
-    if part.kind == "model.facts":
-        return {"kind": part.kind, "value": display_facts(part)}
+    # 1. 业务字段由插件 callback 选择；Core 不识别模型或工具的字段名。
+    for provider in providers.part_display:
+        rendered = provider(part)
+        if rendered is not None:
+            return {"kind": part.kind, "value": json_value(rendered)}
     # 2. 展示端保留原 part 下标；不可展示的归档只传类型，权威正文不变。
     if display_only and part.kind in {"history.provenance", "history.record", "history.turn_input"}:
         return {"kind": part.kind, "display": "unavailable"}

--- a/infra/channels/message_view.py
+++ b/infra/channels/message_view.py
@@ -4,37 +4,41 @@ from collections.abc import AsyncGenerator, Callable, Mapping
 from contextlib import aclosing
 from dataclasses import asdict, dataclass, field
 from typing import Protocol, cast
+from types import MappingProxyType
 
 from session.log import MessagePage, MessageReader, SessionEntry
 from session.message import ContentPart, Control, Input, Message, Output, ToolCall
 from session.message_codec import json_value
 
 
-class PartDisplayProvider(Protocol):
-    """尝试投影一个插件拥有的内容块；不属于该插件时返回 None。"""
-
-    def __call__(self, part: ContentPart) -> Mapping[str, object] | None: ...
+PartDisplayProvider = Callable[[ContentPart], Mapping[str, object]]
 
 
 @dataclass(frozen=True, slots=True)
 class MessageDisplayProviders:
-    """绑定同一展示请求的插件只读投影回调。
-
-    回调由调用者从 exact generation 取得；Core 只保存本次请求的不可变快照。
-    缺少 provider 时仍返回消息类型与 ``unavailable``，不会猜测业务字段。
-    """
+    """一次页面投影使用的只读回调；调用者负责同代 lease。"""
 
     tool_name: Callable[[str], str] | None = None
-    part_display: tuple[PartDisplayProvider, ...] = field(default_factory=tuple)
-
+    part_display: Mapping[str, PartDisplayProvider] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        if self.tool_name is not None and not callable(self.tool_name):
-            raise TypeError("tool_name provider 必须可调用")
-        providers = tuple(self.part_display)
-        if any(not callable(provider) for provider in providers):
-            raise TypeError("part_display provider 必须可调用")
-        object.__setattr__(self, "part_display", providers)
+        object.__setattr__(self, "part_display", MappingProxyType(dict(self.part_display)))
+
+
+class MessageDisplayReader(Protocol):
+    """在自己的资源作用域内投影一页，不让客户端持有插件回调。"""
+
+    async def __call__(self, page: MessagePage, *, display_only: bool) -> list[dict[str, object]]: ...
+
+
+async def read_message_rows(
+    page: MessagePage, *, display_only: bool = False,
+    reader: MessageDisplayReader | None = None,
+) -> list[dict[str, object]]:
+    """展示缺少业务 provider 时保留明确的 unavailable 状态。"""
+    if reader is None:
+        return message_rows(page, display_only=display_only)
+    return await reader(page, display_only=display_only)
 
 
 def session_row(entry: SessionEntry) -> dict[str, object]:
@@ -73,10 +77,9 @@ async def follow_messages(
     *,
     after_seq: int,
     display_only: bool = False,
-    providers: MessageDisplayProviders | None = None,
+    reader_display: MessageDisplayReader | None = None,
 ) -> AsyncGenerator[dict[str, object], None]:
     """从 seq 续读完整展示页；唤醒通知不携带第二份消息正文。"""
-    display = MessageDisplayProviders() if providers is None else providers
     # 1. 先注册日志通知，再按页补齐附件和 binding 展示字段。
     async with aclosing(reader.follow(after_seq=after_seq)) as follower:
         async for message in follower:
@@ -86,7 +89,7 @@ async def follow_messages(
             while page.messages:
                 next_seq = page.messages[-1].seq
                 yield {"version": 2, "session_id": reader.session_id,
-                       "items": message_rows(page, display_only=display_only, providers=display), "after_seq": after_seq,
+                       "items": await read_message_rows(page, display_only=display_only, reader=reader_display), "after_seq": after_seq,
                        "through_seq": page.through_seq, "next_after_seq": next_seq,
                        "has_more": page.has_more}
                 after_seq = next_seq
@@ -161,10 +164,9 @@ def _part(
 ) -> dict[str, object]:
     """只公开展示合同允许的字段，未知内容保留类型与不可展示的明确状态。"""
     # 1. 业务字段由插件 callback 选择；Core 不识别模型或工具的字段名。
-    for provider in providers.part_display:
-        rendered = provider(part)
-        if rendered is not None:
-            return {"kind": part.kind, "value": json_value(rendered)}
+    provider = providers.part_display.get(part.kind)
+    if provider is not None:
+        return {"kind": part.kind, "value": json_value(provider(part))}
     # 2. 展示端保留原 part 下标；不可展示的归档只传类型，权威正文不变。
     if display_only and part.kind in {"history.provenance", "history.record", "history.turn_input"}:
         return {"kind": part.kind, "display": "unavailable"}

--- a/infra/channels/web_chat_channel.py
+++ b/infra/channels/web_chat_channel.py
@@ -46,7 +46,7 @@ from bus.events_lifecycle import (
 from infra.channels.base import AttachmentStore
 from infra.channels.artifacts import ChannelAttachmentArtifactStore
 from infra.channels.contract import ChannelContext
-from infra.channels.message_view import MessageDisplayProviders, follow_messages
+from infra.channels.message_view import MessageDisplayReader, follow_messages
 from session.log import MessageCatalog, MessageConflict
 
 logger = logging.getLogger(__name__)
@@ -212,7 +212,7 @@ class WebChatChannel:
         self._v3_adapters: dict[str, WebNativeChannelAdapter] = {}
         self._messages: MessageCatalog | None = None
         self._reply_status: Callable[[str], AsyncGenerator[dict[str, object], None]] | None = None
-        self._message_display: MessageDisplayProviders | None = None
+        self._message_display: MessageDisplayReader | None = None
         self._followers: dict[WebSocket, tuple[str, asyncio.Task[None]]] = {}
         self._stopping = False
 
@@ -226,18 +226,16 @@ class WebChatChannel:
         self._messages = messages
         self._reply_status = reply_status
 
-    def bind_message_display(self, providers: MessageDisplayProviders) -> None:
-        """绑定一个 exact generation 的只读消息展示回调快照。"""
-        if not isinstance(providers, MessageDisplayProviders):
-            raise TypeError("消息展示 provider 类型无效")
+    def bind_message_display(self, providers: MessageDisplayReader) -> None:
+        """绑定逐页取得插件 lease 的只读投影入口。"""
         if self._message_display is not None and self._message_display != providers:
             raise RuntimeError("Web 消息展示 provider 已绑定")
         self._message_display = providers
 
     @property
-    def message_display(self) -> MessageDisplayProviders:
+    def message_display(self) -> MessageDisplayReader | None:
         """返回当前展示请求使用的 provider；未绑定时显式显示 unavailable。"""
-        return self._message_display or MessageDisplayProviders()
+        return self._message_display
 
     @staticmethod
     def _socket_id(websocket: WebSocket) -> str:
@@ -841,7 +839,7 @@ class WebChatChannel:
         async with asyncio.TaskGroup() as tasks:
             _ = tasks.create_task(send("messages.appended", follow_messages(
                 self._messages.reader(session_id), after_seq=after_seq, display_only=True,
-                providers=self.message_display)))
+                reader_display=self.message_display)))
             if self._reply_status is None:
                 await websocket.send_json({"type": "reply.status", "version": 2,
                     "session_id": session_id, "snapshot_id": None, "available": False, "items": []})

--- a/infra/channels/web_chat_channel.py
+++ b/infra/channels/web_chat_channel.py
@@ -46,7 +46,7 @@ from bus.events_lifecycle import (
 from infra.channels.base import AttachmentStore
 from infra.channels.artifacts import ChannelAttachmentArtifactStore
 from infra.channels.contract import ChannelContext
-from infra.channels.message_view import follow_messages
+from infra.channels.message_view import MessageDisplayProviders, follow_messages
 from session.log import MessageCatalog, MessageConflict
 
 logger = logging.getLogger(__name__)
@@ -212,6 +212,7 @@ class WebChatChannel:
         self._v3_adapters: dict[str, WebNativeChannelAdapter] = {}
         self._messages: MessageCatalog | None = None
         self._reply_status: Callable[[str], AsyncGenerator[dict[str, object], None]] | None = None
+        self._message_display: MessageDisplayProviders | None = None
         self._followers: dict[WebSocket, tuple[str, asyncio.Task[None]]] = {}
         self._stopping = False
 
@@ -224,6 +225,19 @@ class WebChatChannel:
             raise RuntimeError("Web 消息读取已绑定")
         self._messages = messages
         self._reply_status = reply_status
+
+    def bind_message_display(self, providers: MessageDisplayProviders) -> None:
+        """绑定一个 exact generation 的只读消息展示回调快照。"""
+        if not isinstance(providers, MessageDisplayProviders):
+            raise TypeError("消息展示 provider 类型无效")
+        if self._message_display is not None and self._message_display != providers:
+            raise RuntimeError("Web 消息展示 provider 已绑定")
+        self._message_display = providers
+
+    @property
+    def message_display(self) -> MessageDisplayProviders:
+        """返回当前展示请求使用的 provider；未绑定时显式显示 unavailable。"""
+        return self._message_display or MessageDisplayProviders()
 
     @staticmethod
     def _socket_id(websocket: WebSocket) -> str:
@@ -826,7 +840,8 @@ class WebChatChannel:
 
         async with asyncio.TaskGroup() as tasks:
             _ = tasks.create_task(send("messages.appended", follow_messages(
-                self._messages.reader(session_id), after_seq=after_seq, display_only=True)))
+                self._messages.reader(session_id), after_seq=after_seq, display_only=True,
+                providers=self.message_display)))
             if self._reply_status is None:
                 await websocket.send_json({"type": "reply.status", "version": 2,
                     "session_id": session_id, "snapshot_id": None, "available": False, "items": []})

--- a/infra/mobile_realtime/channel.py
+++ b/infra/mobile_realtime/channel.py
@@ -77,7 +77,7 @@ from infra.mobile_realtime.runtime_inspection import (
     RuntimeInspectionService,
 )
 from infra.channels.contract import ChannelContext
-from infra.channels.message_view import message_rows, session_row
+from infra.channels.message_view import MessageDisplayProviders, message_rows, session_row
 from infra.mobile_realtime.message_view import message_chunks, message_json as _message_json
 from infra.mobile_realtime.attachments import (
     AttachmentChunk,
@@ -451,6 +451,7 @@ class MobileRealtimeChannel:
         self._mobile_ui_catalog_identity = ""
         self._mobile_ui_hot_connections: dict[str, int] = {}
         self._runtime_inspection: RuntimeInspectionService | None = None
+        self._message_display: MessageDisplayProviders | None = None
         self._model_catalog_reader: (
             Callable[[], Awaitable[ModelCatalogSnapshot]] | None
         ) = None
@@ -474,6 +475,19 @@ class MobileRealtimeChannel:
         if self._runtime_inspection is not None:
             raise RuntimeError("Runtime inspection service 已绑定")
         self._runtime_inspection = service
+
+    def bind_message_display(self, providers: MessageDisplayProviders) -> None:
+        """绑定一个 exact generation 的只读消息展示回调快照。"""
+        if not isinstance(providers, MessageDisplayProviders):
+            raise TypeError("消息展示 provider 类型无效")
+        if self._message_display is not None and self._message_display != providers:
+            raise RuntimeError("Mobile 消息展示 provider 已绑定")
+        self._message_display = providers
+
+    @property
+    def message_display(self) -> MessageDisplayProviders:
+        """返回当前展示请求使用的 provider；未绑定时显式显示 unavailable。"""
+        return self._message_display or MessageDisplayProviders()
 
     def bind_model_stats(self, reader: Callable[[str], Awaitable[ModelCallStats]]) -> None:
         if self._model_stats_reader is not None:
@@ -809,7 +823,11 @@ class MobileRealtimeChannel:
         page = reader.read_page(after_seq=message.seq - 1, through_seq=message.seq, limit=1)
         # 摘要明确选择表示；新展示清单和升级前的未完成下载都可重开。
         for display_only in (True, False):
-            rows = message_rows(page, display_only=display_only)
+            rows = message_rows(
+                page,
+                display_only=display_only,
+                providers=self.message_display,
+            )
             if not rows:
                 raise MobileCommandError("message_not_found", "消息不存在")
             content = _message_json(rows[0])
@@ -1952,7 +1970,11 @@ class MobileRealtimeChannel:
         except InvalidPage as error:
             raise MobileCommandError("invalid_pagination", str(error)) from error
         try:
-            page_payload: dict[str, object] = {"version": 2, "items": message_rows(page, display_only=display_only),
+            page_payload: dict[str, object] = {"version": 2, "items": message_rows(
+                page,
+                display_only=display_only,
+                providers=self.message_display,
+            ),
                 "after_seq": after_seq, "through_seq": page.through_seq, "has_more": page.has_more,
                 "next_after_seq": page.messages[-1].seq if page.messages else after_seq}
             if backward:

--- a/infra/mobile_realtime/channel.py
+++ b/infra/mobile_realtime/channel.py
@@ -77,7 +77,7 @@ from infra.mobile_realtime.runtime_inspection import (
     RuntimeInspectionService,
 )
 from infra.channels.contract import ChannelContext
-from infra.channels.message_view import MessageDisplayProviders, message_rows, session_row
+from infra.channels.message_view import MessageDisplayReader, read_message_rows, session_row
 from infra.mobile_realtime.message_view import message_chunks, message_json as _message_json
 from infra.mobile_realtime.attachments import (
     AttachmentChunk,
@@ -451,7 +451,7 @@ class MobileRealtimeChannel:
         self._mobile_ui_catalog_identity = ""
         self._mobile_ui_hot_connections: dict[str, int] = {}
         self._runtime_inspection: RuntimeInspectionService | None = None
-        self._message_display: MessageDisplayProviders | None = None
+        self._message_display: MessageDisplayReader | None = None
         self._model_catalog_reader: (
             Callable[[], Awaitable[ModelCatalogSnapshot]] | None
         ) = None
@@ -476,18 +476,16 @@ class MobileRealtimeChannel:
             raise RuntimeError("Runtime inspection service 已绑定")
         self._runtime_inspection = service
 
-    def bind_message_display(self, providers: MessageDisplayProviders) -> None:
-        """绑定一个 exact generation 的只读消息展示回调快照。"""
-        if not isinstance(providers, MessageDisplayProviders):
-            raise TypeError("消息展示 provider 类型无效")
+    def bind_message_display(self, providers: MessageDisplayReader) -> None:
+        """绑定逐页取得插件 lease 的只读投影入口。"""
         if self._message_display is not None and self._message_display != providers:
             raise RuntimeError("Mobile 消息展示 provider 已绑定")
         self._message_display = providers
 
     @property
-    def message_display(self) -> MessageDisplayProviders:
+    def message_display(self) -> MessageDisplayReader | None:
         """返回当前展示请求使用的 provider；未绑定时显式显示 unavailable。"""
-        return self._message_display or MessageDisplayProviders()
+        return self._message_display
 
     def bind_model_stats(self, reader: Callable[[str], Awaitable[ModelCallStats]]) -> None:
         if self._model_stats_reader is not None:
@@ -797,7 +795,7 @@ class MobileRealtimeChannel:
             raise MobileCommandError("plugin_overloaded", str(error)) from error
         raise MobileCommandError("unsupported_command", f"尚不支持命令: {frame.type}")
 
-    def prepare_message_content(self, frame: GenericCommand) -> dict[str, object]:
+    async def prepare_message_content(self, frame: GenericCommand) -> dict[str, object]:
         """校验 v2 完整 Message 下载请求及其不可变表示摘要。"""
         _expect_message_log_version(frame.payload)
         _expect_keys(frame.payload, {"message_log_version", "message_id", "byte_length", "sha256"})
@@ -805,14 +803,14 @@ class MobileRealtimeChannel:
         message_id = _expect_nonempty_string(frame.payload.get("message_id"), "message_id")
         byte_length = _expect_nonnegative_int(frame.payload.get("byte_length"), "byte_length")
         sha256 = _expect_sha256(frame.payload.get("sha256"), "sha256")
-        content = self.read_message_content(
+        content = await self.read_message_content(
             session_id=session_id, message_id=message_id,
             byte_length=byte_length, sha256=sha256,
         )
         return {"version": 2, "message_id": message_id, "byte_length": len(content),
                 "sha256": sha256, "encoding": "utf-8", "media_type": "application/json"}
 
-    def read_message_content(
+    async def read_message_content(
         self, *, session_id: str, message_id: str, byte_length: int, sha256: str,
     ) -> bytes:
         """读取与分页相同的完整展示 JSON；不暴露私有 binding 或模型续传数据。"""
@@ -823,10 +821,10 @@ class MobileRealtimeChannel:
         page = reader.read_page(after_seq=message.seq - 1, through_seq=message.seq, limit=1)
         # 摘要明确选择表示；新展示清单和升级前的未完成下载都可重开。
         for display_only in (True, False):
-            rows = message_rows(
+            rows = await read_message_rows(
                 page,
                 display_only=display_only,
-                providers=self.message_display,
+                reader=self.message_display,
             )
             if not rows:
                 raise MobileCommandError("message_not_found", "消息不存在")
@@ -1970,10 +1968,10 @@ class MobileRealtimeChannel:
         except InvalidPage as error:
             raise MobileCommandError("invalid_pagination", str(error)) from error
         try:
-            page_payload: dict[str, object] = {"version": 2, "items": message_rows(
+            page_payload: dict[str, object] = {"version": 2, "items": await read_message_rows(
                 page,
                 display_only=display_only,
-                providers=self.message_display,
+                reader=self.message_display,
             ),
                 "after_seq": after_seq, "through_seq": page.through_seq, "has_more": page.has_more,
                 "next_after_seq": page.messages[-1].seq if page.messages else after_seq}

--- a/infra/mobile_realtime/gateway.py
+++ b/infra/mobile_realtime/gateway.py
@@ -746,7 +746,7 @@ class MobileGatewayRuntime:
                     reader,
                     after_seq=after_seq,
                     display_only=display_only,
-                    providers=self.channel.message_display,
+                    reader_display=self.channel.message_display,
                 ),
                 "messages.appended",
             ))
@@ -1960,7 +1960,7 @@ class MobileGatewayRuntime:
         if connection is None or connection.websocket is not websocket:
             return
         try:
-            descriptor = self.channel.prepare_message_content(frame)
+            descriptor = await self.channel.prepare_message_content(frame)
             session_id = frame.session_id
             if session_id is None:
                 raise RuntimeError("message content prepare 缺少 session_id")
@@ -1995,7 +1995,7 @@ class MobileGatewayRuntime:
                 turn_id=None,
             )
 
-    def read_message_content_http(
+    async def read_message_content_http(
         self,
         *,
         ticket: str,
@@ -2021,7 +2021,7 @@ class MobileGatewayRuntime:
                 status_code=412,
             )
         try:
-            content = self.channel.read_message_content(
+            content = await self.channel.read_message_content(
                 session_id=verified.session_id,
                 message_id=verified.message_id,
                 byte_length=verified.byte_length,
@@ -2426,7 +2426,7 @@ def create_mobile_gateway_app(runtime: MobileGatewayRuntime) -> FastAPI:
 
         try:
             ticket = _message_content_http_bearer(request)
-            content, start, end, total, sha256 = runtime.read_message_content_http(
+            content, start, end, total, sha256 = await runtime.read_message_content_http(
                 ticket=ticket,
                 range_header=request.headers.get("range"),
                 if_range=request.headers.get("if-range"),

--- a/infra/mobile_realtime/gateway.py
+++ b/infra/mobile_realtime/gateway.py
@@ -741,7 +741,15 @@ class MobileGatewayRuntime:
                             device_id=device_id, connection_epoch=connection.connection_epoch)
 
         async with asyncio.TaskGroup() as tasks:
-            _ = tasks.create_task(send(follow_messages(reader, after_seq=after_seq, display_only=display_only), "messages.appended"))
+            _ = tasks.create_task(send(
+                follow_messages(
+                    reader,
+                    after_seq=after_seq,
+                    display_only=display_only,
+                    providers=self.channel.message_display,
+                ),
+                "messages.appended",
+            ))
             if self.channel.reply_status is None:
                 await self.publish_connection_control(control_type="session.message", device_id=device_id,
                     connection_epoch=connection.connection_epoch, payload={"type": "reply.status", "version": 2,

--- a/plugin_boundary.toml
+++ b/plugin_boundary.toml
@@ -185,3 +185,7 @@ note = "插件手册与 skill 文档仍在教学使用；代码中无此 Service
 [capabilities."reply.status.v2"]
 role = "seam"
 note = "客户端消费插件已投影的短命回复状态，不取得内部状态类"
+
+[capabilities."tools.display-name.v1"]
+role = "seam"
+note = "客户端只读历史 binding 名称；工具插件拥有描述解释，不允许打开或执行工具"

--- a/plugin_boundary_baseline.toml
+++ b/plugin_boundary_baseline.toml
@@ -24,8 +24,6 @@ R1 = [
     "agent/tools/filesystem.py|plugins.standard_tools",
     "agent/tools/filesystem.py|plugins.standard_tools.filesystem",
     "bootstrap/app.py|plugins.delivery.senders",
-    "infra/channels/message_view.py|plugins.models.projection",
-    "infra/channels/message_view.py|plugins.tools.api",
     "infra/mobile_realtime/runtime_inspection.py|plugins.scheduler.schedule",
     "infra/mobile_realtime/runtime_inspection.py|plugins.scheduler.store",
     "migrations/akasha_sparse_index_v8/migration.py|plugins.akasha.application.rebuild",

--- a/plugins/models/plugin.py
+++ b/plugins/models/plugin.py
@@ -13,7 +13,7 @@ from agent.plugin_composition import (
 from .litellm_catalog import LiteLlmCapabilityCatalog
 from .state import ModelsState
 from .store import ModelsStore
-from .projection import MODEL_CALLS, MODEL_CALL_HISTORY
+from .projection import MODEL_CALLS, MODEL_CALL_HISTORY, MODEL_DISPLAY, display_part
 from agent.plugin_composition.models import MODEL_CALL_STATS
 
 api_version = 3
@@ -36,7 +36,7 @@ dashboard_module = "dashboard.py"
 
 
 async def apply(ctx: Context, config: object) -> None:
-    """Publish five narrow views over one Root-local model state."""
+    """Publish narrow views over one Root-local model state."""
 
     _ = config
     store = ModelsStore(
@@ -65,4 +65,5 @@ async def apply(ctx: Context, config: object) -> None:
     _ = await ctx.provide(MODEL_CALLS, store.read_call)
     _ = await ctx.provide(MODEL_CALL_HISTORY, store.read_calls)
     _ = await ctx.provide(MODEL_CALL_STATS, store.read_call_stats)
+    _ = await ctx.provide(MODEL_DISPLAY, display_part)
     _ = await ctx.on(SNAPSHOT_SEALING, state.seal)

--- a/plugins/models/plugin.py
+++ b/plugins/models/plugin.py
@@ -13,7 +13,7 @@ from agent.plugin_composition import (
 from .litellm_catalog import LiteLlmCapabilityCatalog
 from .state import ModelsState
 from .store import ModelsStore
-from .projection import MODEL_CALLS, MODEL_CALL_HISTORY, MODEL_DISPLAY, display_part
+from .projection import MODEL_CALLS, MODEL_CALL_HISTORY, MODEL_DISPLAY, display_facts
 from agent.plugin_composition.models import MODEL_CALL_STATS
 
 api_version = 3
@@ -65,5 +65,5 @@ async def apply(ctx: Context, config: object) -> None:
     _ = await ctx.provide(MODEL_CALLS, store.read_call)
     _ = await ctx.provide(MODEL_CALL_HISTORY, store.read_calls)
     _ = await ctx.provide(MODEL_CALL_STATS, store.read_call_stats)
-    _ = await ctx.provide(MODEL_DISPLAY, display_part)
+    _ = await ctx.provide(MODEL_DISPLAY, display_facts)
     _ = await ctx.on(SNAPSHOT_SEALING, state.seal)

--- a/plugins/models/projection.py
+++ b/plugins/models/projection.py
@@ -29,10 +29,12 @@ from .store import ModelCallReader
 
 ContentRenderer = Callable[[ContentPart], Sequence[Mapping[str, Any]]]
 CallReader = Callable[[str], Mapping[str, Any]]
+DisplayRenderer = Callable[[ContentPart], Mapping[str, object] | None]
 MODEL_CALLS = ServiceKey[CallReader]("models.calls.v1")
 MODEL_CALL_HISTORY = ServiceKey[Callable[[str, int], tuple[Mapping[str, Any], ...]]](
     "models.call-history.v1"
 )
+MODEL_DISPLAY = ServiceKey[DisplayRenderer]("models.display.v1")
 
 
 def response_facts(
@@ -152,6 +154,13 @@ def display_facts(part: ContentPart) -> dict[str, object]:
     _ = check_facts(part)
     value = cast(Mapping[str, object], part.value)
     return {"call_record_id": value["call_record_id"], "thinking": value["thinking"]}
+
+
+def display_part(part: ContentPart) -> Mapping[str, object] | None:
+    """只处理模型 owner 的内容块；其他插件内容交给下一个 provider。"""
+    if part.kind != "model.facts":
+        return None
+    return display_facts(part)
 
 
 class MessageProjection:

--- a/plugins/models/projection.py
+++ b/plugins/models/projection.py
@@ -29,12 +29,12 @@ from .store import ModelCallReader
 
 ContentRenderer = Callable[[ContentPart], Sequence[Mapping[str, Any]]]
 CallReader = Callable[[str], Mapping[str, Any]]
-DisplayRenderer = Callable[[ContentPart], Mapping[str, object] | None]
+DisplayRenderer = Callable[[ContentPart], Mapping[str, object]]
 MODEL_CALLS = ServiceKey[CallReader]("models.calls.v1")
 MODEL_CALL_HISTORY = ServiceKey[Callable[[str, int], tuple[Mapping[str, Any], ...]]](
     "models.call-history.v1"
 )
-MODEL_DISPLAY = ServiceKey[DisplayRenderer]("models.display.v1")
+MODEL_DISPLAY = ServiceKey[DisplayRenderer]("message.display:model.facts")
 
 
 def response_facts(
@@ -154,13 +154,6 @@ def display_facts(part: ContentPart) -> dict[str, object]:
     _ = check_facts(part)
     value = cast(Mapping[str, object], part.value)
     return {"call_record_id": value["call_record_id"], "thinking": value["thinking"]}
-
-
-def display_part(part: ContentPart) -> Mapping[str, object] | None:
-    """只处理模型 owner 的内容块；其他插件内容交给下一个 provider。"""
-    if part.kind != "model.facts":
-        return None
-    return display_facts(part)
 
 
 class MessageProjection:

--- a/tests/test_control_page_routing.py
+++ b/tests/test_control_page_routing.py
@@ -23,12 +23,15 @@ async def test_only_message_read_uses_explicit_page_sender() -> None:
         "next_after_seq": -1,
         "has_more": False,
     }
+    async def read_messages(*_args):
+        return page
+
     # Router only consumes this narrow service surface in the page-routing fixture.
     service = cast(ControlService, SimpleNamespace(
         methods={},
         initialize=lambda _params: {"ok": True},
         status=lambda: {"ready": True},
-        read_messages=lambda *_args: page,
+        read_messages=read_messages,
     ))
 
     async def send(frame: dict[str, object]) -> None:

--- a/tests/test_message_view.py
+++ b/tests/test_message_view.py
@@ -2,14 +2,15 @@ from contextlib import closing
 from collections.abc import Mapping
 import json
 import sqlite3
+from pathlib import Path
 from typing import cast
 
 from fastapi.testclient import TestClient
 
 from bootstrap.chat_api import create_chat_app
-from infra.channels.message_view import message_rows
+from infra.channels.message_view import MessageDisplayProviders, message_rows
 from infra.channels.web_chat_channel import WebChatChannel
-from plugins.models.projection import check_facts
+from plugins.models.projection import check_facts, display_part
 from session.log import MessageLog, SessionAttributes
 from session.message import CallRef, ContentPart, ContentReferences, Control, Input, Output, ToolCall, ToolResult
 from tests.test_message_artifacts import storage
@@ -39,7 +40,16 @@ def test_view_keeps_independent_facts_and_hides_private_configuration(storage):
     append("result", ToolResult(CallRef("output", 1), "error", (ContentPart("text", "效果待确认"),)), CallRef("output", 1))
     append("quiet", Output((ContentPart("history.future", {"private": "content-secret"}),), "quiet"))
     before = snapshot(path)
-    rows = [_mapping(row) for row in message_rows(log.reader("s").read_tail())]
+    rows = [
+        _mapping(row)
+        for row in message_rows(
+            log.reader("s").read_tail(),
+            providers=MessageDisplayProviders(
+                tool_name=lambda binding_id: "original-name" if binding_id == "tool" else binding_id,
+                part_display=(display_part,),
+            ),
+        )
+    ]
     assert [row["id"] for row in rows] == ["input", "output", "pause", "result", "quiet"]
     body = [_mapping(row["body"]) for row in rows]
     assert [item["kind"] for item in body] == ["input", "output", "control", "tool_result", "output"]
@@ -53,6 +63,53 @@ def test_view_keeps_independent_facts_and_hides_private_configuration(storage):
     encoded = json.dumps(rows, ensure_ascii=False)
     assert "secret" not in encoded and "artifact.bin" not in encoded and "provider-call" not in encoded
     assert snapshot(path) == before
+
+
+def test_message_view_has_no_plugin_implementation_imports_and_degrades_without_providers(storage):
+    _, log, _ = storage
+    log.save_binding(
+        "missing-binding",
+        {"service": "tools.v1", "metadata": {"tool": {"name": "private-tool"}}},
+    )
+    checks = {"model.facts": check_facts}
+    writer = log.writer(
+        "s",
+        author="assistant",
+        source="conversation",
+        body_types=(Output,),
+        content=checks,
+        check_call=lambda call: None,
+    )
+    writer.append(
+        "output",
+        Output(
+            (
+                ContentPart(
+                    "model.facts",
+                    {
+                        "call_record_id": "call",
+                        "tool_ids": {},
+                        "thinking": "private",
+                        "continuation": {
+                            "binding_id": "provider",
+                            "payload": {"opaque": "secret"},
+                        },
+                    },
+                ),
+                ToolCall("missing-binding", {"private": "argument"}),
+            ),
+            "continue",
+        ),
+    )
+    source = Path(__file__).parents[1] / "infra/channels/message_view.py"
+    text = source.read_text(encoding="utf-8")
+    assert "plugins.models" not in text and "plugins.tools" not in text
+    parts = _mapping(_mapping(message_rows(log.reader("s").read_tail())[0])["body"])["parts"]
+    assert parts == [
+        {"kind": "model.facts", "display": "unavailable"},
+        {"kind": "tool_call", "binding_id": "missing-binding", "display": "unavailable"},
+    ]
+    assert "secret" not in json.dumps(parts, ensure_ascii=False)
 
 
 def test_migrated_history_stays_inside_original_message(migration, old_workspace):

--- a/tests/test_message_view.py
+++ b/tests/test_message_view.py
@@ -1,6 +1,7 @@
 from contextlib import closing
 from collections.abc import Mapping
 import json
+import pytest
 import sqlite3
 from pathlib import Path
 from typing import cast
@@ -10,7 +11,7 @@ from fastapi.testclient import TestClient
 from bootstrap.chat_api import create_chat_app
 from infra.channels.message_view import MessageDisplayProviders, message_rows
 from infra.channels.web_chat_channel import WebChatChannel
-from plugins.models.projection import check_facts, display_part
+from plugins.models.projection import check_facts, display_facts
 from session.log import MessageLog, SessionAttributes
 from session.message import CallRef, ContentPart, ContentReferences, Control, Input, Output, ToolCall, ToolResult
 from tests.test_message_artifacts import storage
@@ -46,7 +47,7 @@ def test_view_keeps_independent_facts_and_hides_private_configuration(storage):
             log.reader("s").read_tail(),
             providers=MessageDisplayProviders(
                 tool_name=lambda binding_id: "original-name" if binding_id == "tool" else binding_id,
-                part_display=(display_part,),
+                part_display={"model.facts": display_facts},
             ),
         )
     ]
@@ -160,3 +161,47 @@ def test_web_catalog_and_history_use_real_log_without_session_manager(tmp_path):
             with closing(sqlite3.connect(path)) as connection, connection:
                 connection.execute("UPDATE messages SET body=? WHERE id='3'", ('{"kind":"broken"}',))
             assert client.get(endpoint).status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_runtime_display_discovers_new_kind_and_releases_each_generation(storage):
+    """新内容只需插件贡献；同一 reader 在切代后不保留旧回调。"""
+    from agent.plugin_composition import CompositionRoot, ServiceKey
+    from agent.plugins.snapshot import RuntimeSnapshotCompiler, RuntimeSnapshotStore, get_current_runtime_snapshot
+    from bootstrap.message_display import RuntimeMessageDisplay
+
+    _, log, _ = storage
+    log.writer("custom", author="test", source="test", body_types=(Input,),
+        content={"example.fact": lambda _: ContentReferences()}).append(
+            "fact", Input((ContentPart("example.fact", {"private": "secret"}),)))
+    page = log.reader("custom").read_tail()
+    store = RuntimeSnapshotStore()
+    reader = RuntimeMessageDisplay(store)
+    roots = []
+    try:
+        for label in ("first", "replacement", None):
+            root = CompositionRoot("display-" + str(label))
+            roots.append(root)
+            if label is not None:
+                def display(part):
+                    assert part.kind == "example.fact"
+                    assert get_current_runtime_snapshot() is selected
+                    assert selected.lease_count == 1
+                    return {"label": label}
+                async def apply(ctx):
+                    await ctx.provide(ServiceKey("message.display:example.fact"), display)
+                await root.mount(apply, name="independent-display")
+            selected = RuntimeSnapshotCompiler().compile({}, composition_root=root, snapshot_revision=str(label))
+            if store.current is None:
+                store.install(selected)
+            else:
+                await store.commit(store.begin_publish(selected))
+            rows = await reader(page, display_only=True)
+            expected = {"kind": "example.fact", "display": "unavailable"} if label is None else {
+                "kind": "example.fact", "value": {"label": label}}
+            assert rows[0]["body"]["parts"] == [expected]
+            assert selected.lease_count == 0
+    finally:
+        await store.close()
+        for root in roots:
+            await root.dispose()

--- a/tests/test_mobile_message_log.py
+++ b/tests/test_mobile_message_log.py
@@ -21,7 +21,7 @@ from infra.mobile_realtime.inbox import DurableInboxManager
 from infra.mobile_realtime.key_protection import FileMasterKeyStore, KeysetManager
 from infra.mobile_realtime.pairing import PairingService
 from infra.mobile_realtime.storage import MobileRealtimeStorage
-from plugins.models.projection import check_facts, display_part
+from plugins.models.projection import check_facts, display_facts
 from session.log import MessageLog, SessionAttributes
 from session.message import CallRef, ContentPart, ContentReferences, Control, Input, Output, ToolCall, ToolResult
 from tests.mobile_realtime.test_channel import _Runtime, _generic_frame, _register_device
@@ -36,12 +36,12 @@ def mobile(tmp_path):
         runtime = _Runtime(storage)
         channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, runtime))
         channel.bind_messages(log.catalog())
-        channel.bind_message_display(
-            MessageDisplayProviders(
+        async def display(page, *, display_only):
+            return message_rows(page, display_only=display_only, providers=MessageDisplayProviders(
                 tool_name=lambda binding_id: binding_id,
-                part_display=(display_part,),
-            )
-        )
+                part_display={"model.facts": display_facts},
+            ))
+        channel.bind_message_display(display)
         yield log, runtime, channel, device
 
 
@@ -79,9 +79,9 @@ async def test_mobile_history_reads_full_message_prefix_and_directory_without_ol
     assert all(item['title'] == '新对话' for page in (first, second) for item in page['items'])
     await channel._get_history(device, command('history.get', session, page_size=2))
     page = runtime.events[-1]['payload']
-    assert page['items'] == message_rows(
+    assert page['items'] == await channel.message_display(
         log.reader(session).read_page(limit=2),
-        providers=channel.message_display,
+        display_only=False,
     )
     assert page['through_seq'] == 2 and page['next_after_seq'] == 1 and page['has_more']
     assert snapshot(tmp_path / 'sessions.db') == before
@@ -151,14 +151,14 @@ async def test_display_pages_omit_hidden_archives_and_keep_legacy_downloads(mobi
         {'kind': 'text', 'value': '当前正文'},
     ]
     assert len(json.dumps(compact).encode()) < 1024
-    legacy = channel.read_message_content(session_id=session, message_id='archive', byte_length=old['byte_length'], sha256=old['sha256'])
+    legacy = await channel.read_message_content(session_id=session, message_id='archive', byte_length=old['byte_length'], sha256=old['sha256'])
     assert len(legacy) > 400000 and json.loads(legacy)['body']['parts'][0]['archive']['private_archive']
     assert snapshot(tmp_path / 'sessions.db') == before
     append(log, session, 'large-visible', Input((ContentPart('text', 'x' * 80000),)))
     await channel._get_history(device, command('history.get', session, direction='backward', display_only=True, page_size=1))
     reference = runtime.events[-1]['payload']['items'][0]['message_ref']
     assert reference['display_only'] is True
-    visible = channel.read_message_content(session_id=session, message_id='large-visible', byte_length=reference['byte_length'], sha256=reference['sha256'])
+    visible = await channel.read_message_content(session_id=session, message_id='large-visible', byte_length=reference['byte_length'], sha256=reference['sha256'])
     assert json.loads(visible)['body']['parts'][0]['value'] == 'x' * 80000
     # 第一条权威记录保持原始归档，没有被展示适配器压缩。
     assert log.reader(session).get('archive').body.parts[0].value['private_archive'] == 'x' * 400000
@@ -223,24 +223,24 @@ async def test_mobile_large_messages_download_whole_json_and_page_budget_never_t
     assert len(json.dumps(page, ensure_ascii=False).encode()) < 240 * 1024
     expected = {
         row['id']: row
-        for row in message_rows(
+        for row in await channel.message_display(
             log.reader(session).read_page(limit=200),
-            providers=channel.message_display,
+            display_only=False,
         )
     }
     for row in page['items'][:4]:
         assert set(row) == {'id', 'session_id', 'seq', 'message_ref'}
         ref = row['message_ref']
         frame = command('message.content.prepare', session, message_id=row['id'], byte_length=ref['byte_length'], sha256=ref['sha256'])
-        descriptor = channel.prepare_message_content(frame)
+        descriptor = await channel.prepare_message_content(frame)
         assert descriptor['media_type'] == 'application/json' and descriptor['version'] == 2
-        content = channel.read_message_content(session_id=session, message_id=row['id'], byte_length=ref['byte_length'], sha256=ref['sha256'])
+        content = await channel.read_message_content(session_id=session, message_id=row['id'], byte_length=ref['byte_length'], sha256=ref['sha256'])
         assert json.loads(content) == expected[row['id']]
         assert 'secret' not in content.decode()
         with pytest.raises(MobileCommandError, match='manifest'):
-            channel.read_message_content(session_id=session, message_id=row['id'], byte_length=ref['byte_length'] + 1, sha256=ref['sha256'])
+            await channel.read_message_content(session_id=session, message_id=row['id'], byte_length=ref['byte_length'] + 1, sha256=ref['sha256'])
         with pytest.raises(MobileCommandError, match='不存在'):
-            channel.read_message_content(session_id=f'akashic:{uuid4()}', message_id=row['id'], byte_length=ref['byte_length'], sha256=ref['sha256'])
+            await channel.read_message_content(session_id=f'akashic:{uuid4()}', message_id=row['id'], byte_length=ref['byte_length'], sha256=ref['sha256'])
     seen = page['items'][:]
     while page['has_more']:
         await channel._get_history(device, command('history.get', session, page_size=200, after_seq=page['next_after_seq'], through_seq=page['through_seq']))

--- a/tests/test_mobile_message_log.py
+++ b/tests/test_mobile_message_log.py
@@ -10,7 +10,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from agent.config_models import MobileRealtimeConfig
-from infra.channels.message_view import message_rows
+from infra.channels.message_view import MessageDisplayProviders, message_rows
 from infra.mobile_realtime.auth import DeviceAuthenticator
 from infra.mobile_realtime.channel import MobileCommandError, MobileRealtimeChannel
 from fastapi import WebSocket
@@ -21,7 +21,7 @@ from infra.mobile_realtime.inbox import DurableInboxManager
 from infra.mobile_realtime.key_protection import FileMasterKeyStore, KeysetManager
 from infra.mobile_realtime.pairing import PairingService
 from infra.mobile_realtime.storage import MobileRealtimeStorage
-from plugins.models.projection import check_facts
+from plugins.models.projection import check_facts, display_part
 from session.log import MessageLog, SessionAttributes
 from session.message import CallRef, ContentPart, ContentReferences, Control, Input, Output, ToolCall, ToolResult
 from tests.mobile_realtime.test_channel import _Runtime, _generic_frame, _register_device
@@ -36,6 +36,12 @@ def mobile(tmp_path):
         runtime = _Runtime(storage)
         channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, runtime))
         channel.bind_messages(log.catalog())
+        channel.bind_message_display(
+            MessageDisplayProviders(
+                tool_name=lambda binding_id: binding_id,
+                part_display=(display_part,),
+            )
+        )
         yield log, runtime, channel, device
 
 
@@ -73,7 +79,10 @@ async def test_mobile_history_reads_full_message_prefix_and_directory_without_ol
     assert all(item['title'] == '新对话' for page in (first, second) for item in page['items'])
     await channel._get_history(device, command('history.get', session, page_size=2))
     page = runtime.events[-1]['payload']
-    assert page['items'] == message_rows(log.reader(session).read_page(limit=2))
+    assert page['items'] == message_rows(
+        log.reader(session).read_page(limit=2),
+        providers=channel.message_display,
+    )
     assert page['through_seq'] == 2 and page['next_after_seq'] == 1 and page['has_more']
     assert snapshot(tmp_path / 'sessions.db') == before
     append(log, session, 'later', Input((ContentPart('text', '新增'),)))
@@ -212,7 +221,13 @@ async def test_mobile_large_messages_download_whole_json_and_page_budget_never_t
     page = runtime.events[-1]['payload']
     assert page['has_more'] and len(page['items']) < 16
     assert len(json.dumps(page, ensure_ascii=False).encode()) < 240 * 1024
-    expected = {row['id']: row for row in message_rows(log.reader(session).read_page(limit=200))}
+    expected = {
+        row['id']: row
+        for row in message_rows(
+            log.reader(session).read_page(limit=200),
+            providers=channel.message_display,
+        )
+    }
     for row in page['items'][:4]:
         assert set(row) == {'id', 'session_id', 'seq', 'message_ref'}
         ref = row['message_ref']


### PR DESCRIPTION
消息展示不再 import models/tools 实现。内容插件通过 message.display:<kind> 提供自己可公开的字段；未知内容返回 unavailable。工具名称沿既有只读 binding 描述获取。Web、Mobile、控制端每页在一个 snapshot lease 内解析并调用，频道和长连接不缓存业务实现。

基于 #602 的 stacked PR。Message、回执及历史绑定不变；正文下载仍严格检查原摘要，提供者变化不放宽检查。恢复点为相邻 base 3f74cfa3。

验证：141 项相关展示/页面/频道回归通过，含新增 kind、替换、移除及每页 lease 释放；定向 Pyright 0 errors（106 warnings）；边界检查通过 R1=34、R2=239、R3=249。完整 Gate、CI、独立概念审查及全量外置验收留到实施完成后集中进行；draft 不代表可合并或架构已完成。