### PR TITLE
refactor: keep scheduler inspection with its plugin owner

### DIFF
--- a/bootstrap/chat_api.py
+++ b/bootstrap/chat_api.py
@@ -306,13 +306,16 @@ def create_chat_app(
             raise _runtime_http_error(error) from error
 
     @app.get("/api/chat/runtime/jobs")
-    def list_runtime_jobs() -> dict[str, object]:
-        return _require_runtime_inspection(runtime_inspection).list_jobs()
+    async def list_runtime_jobs() -> dict[str, object]:
+        try:
+            return await _require_runtime_inspection(runtime_inspection).list_jobs()
+        except RuntimeInspectionError as error:
+            raise _runtime_http_error(error) from error
 
     @app.get("/api/chat/runtime/jobs/{job_id}")
-    def read_runtime_job(job_id: str) -> dict[str, object]:
+    async def read_runtime_job(job_id: str) -> dict[str, object]:
         try:
-            return _require_runtime_inspection(runtime_inspection).get_job(job_id)
+            return await _require_runtime_inspection(runtime_inspection).get_job(job_id)
         except RuntimeInspectionError as error:
             raise _runtime_http_error(error) from error
 

--- a/docs/design/plugin-boundary-foundation.md
+++ b/docs/design/plugin-boundary-foundation.md
@@ -247,3 +247,12 @@ provider IDs 的持久语义不变，未知效果不变成可重试的成功。�
 最终 Output 的等待只读取来源与结束消息 ID，不依赖 turn_projection 类身份。
 注册表、发送记录、原 binding、lease 与恢复仍归原 owner；本层没有迁移正式数据。
 公开 Message 输入沿用已有 Core 值合同，不新建业务 schema 中心。
+
+
+### 9.7 调度检查由 scheduler 拥有
+
+调度列表、排序、启用过滤和详情文档由 `scheduler.inspection.v1` 的普通插件 provider
+生成。Core 不打开 schedules.json，不 import JobStore 或 ScheduledJob。真实 store
+与调度执行共用原 owner 的实例，不增加并行存储。每次 Web/Mobile 查询在一个 snapshot
+lease 内完成；缺 provider 明确返回 scheduler_unavailable，空列表只表示查询成功且无任务。
+本层只读取调度事实，不创建、改写、失效或减少计划。

--- a/infra/mobile_realtime/channel.py
+++ b/infra/mobile_realtime/channel.py
@@ -1389,14 +1389,14 @@ class MobileRealtimeChannel:
             _expect_keys(frame.payload, set())
             return CommandReply(
                 type="scheduler.job.list.ok",
-                payload=self._require_runtime_inspection().list_jobs(),
+                payload=await self._require_runtime_inspection().list_jobs(),
             )
         if frame.type == "scheduler.job.get":
             _expect_keys(frame.payload, {"job_id"})
             job_id = _expect_nonempty_string(frame.payload["job_id"], "job_id")
             return CommandReply(
                 type="scheduler.job.get.ok",
-                payload=self._require_runtime_inspection().get_job(job_id),
+                payload=await self._require_runtime_inspection().get_job(job_id),
             )
         if frame.type == "runtime.capability.list":
             _expect_keys(frame.payload, set())

--- a/infra/mobile_realtime/runtime_inspection.py
+++ b/infra/mobile_realtime/runtime_inspection.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping
+from collections.abc import AsyncIterator, Mapping
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol, cast
@@ -14,6 +15,7 @@ from agent.plugins.snapshot import (
     RuntimeSnapshot,
     RuntimeSnapshotLease,
     RuntimeSnapshotStore,
+    lease_runtime_snapshot,
 )
 from agent.skills import SkillRecord, SkillsLoader
 
@@ -123,37 +125,31 @@ class RuntimeInspectionService:
             ) from exc
         return {**self._document_summary(document), "markdown": content}
 
-    def list_jobs(self) -> dict[str, object]:
-        """返回当前 generation 的 scheduler 投影。"""
-        service = self._scheduler_inspection()
-        if service is None:
-            raise RuntimeInspectionError(
-                "scheduler_unavailable",
-                "调度检查服务尚未绑定",
-            )
-        return {"items": [dict(item) for item in service.list_jobs()]}
+    async def list_jobs(self) -> dict[str, object]:
+        """返回一个 generation 的 scheduler 投影并释放读取 lease。"""
+        async with self._scheduler_inspection() as service:
+            return {"items": [dict(item) for item in service.list_jobs()]}
 
-    def get_job(self, job_id: str) -> dict[str, object]:
+    async def get_job(self, job_id: str) -> dict[str, object]:
         """返回一个 scheduler 投影，不解释其中的业务字段。"""
-        service = self._scheduler_inspection()
-        if service is None:
-            raise RuntimeInspectionError(
-                "scheduler_unavailable",
-                "调度检查服务尚未绑定",
-            )
-        item = service.get_job(job_id)
-        if item is None:
-            raise RuntimeInspectionError("job_not_found", f"定时任务不存在: {job_id}")
-        return dict(item)
+        async with self._scheduler_inspection() as service:
+            item = service.get_job(job_id)
+            if item is None:
+                raise RuntimeInspectionError("job_not_found", f"定时任务不存在: {job_id}")
+            return dict(item)
 
-    def _scheduler_inspection(self) -> _SchedulerInspection | None:
-        """从当前 stable generation 的 Root 读取 provider。"""
+    @asynccontextmanager
+    async def _scheduler_inspection(self) -> AsyncIterator[_SchedulerInspection]:
+        """解析与调用持有同一代 lease，客户端不保留 provider。"""
         store = self._snapshot_store
-        snapshot = None if store is None else store.current
-        root = None if snapshot is None else snapshot.composition_root
-        if root is None:
-            return None
-        return root.context.get(_SCHEDULER_INSPECTION)
+        if store is None or store.current is None:
+            raise RuntimeInspectionError("scheduler_unavailable", "调度检查服务尚未绑定")
+        async with lease_runtime_snapshot(store) as snapshot:
+            root = snapshot.composition_root
+            service = None if root is None else root.context.get(_SCHEDULER_INSPECTION)
+            if service is None:
+                raise RuntimeInspectionError("scheduler_unavailable", "调度检查服务尚未绑定")
+            yield service
 
     async def list_capabilities(self) -> dict[str, object]:
         async with await self._acquire_snapshot() as snapshot:

--- a/infra/mobile_realtime/runtime_inspection.py
+++ b/infra/mobile_realtime/runtime_inspection.py
@@ -3,19 +3,18 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import cast
+from typing import Protocol, cast
 
-from agent.plugin_composition import TopologyFiberView
+from agent.plugin_composition import ServiceKey, TopologyFiberView
 from agent.plugins.composable import ComposablePlugin
 from agent.plugins.snapshot import (
     RuntimeSnapshot,
     RuntimeSnapshotLease,
     RuntimeSnapshotStore,
 )
-from plugins.scheduler.store import JobStore
-from plugins.scheduler.schedule import ScheduledJob
 from agent.skills import SkillRecord, SkillsLoader
 
 _MAX_DOCUMENT_BYTES = 192 * 1024
@@ -63,6 +62,23 @@ class RuntimeInspectionError(ValueError):
         self.code = code
 
 
+class _SchedulerInspection(Protocol):
+    """Core 运行时检查消费的 scheduler 只读投影。"""
+
+    def list_jobs(self) -> tuple[Mapping[str, object], ...]:
+        ...
+
+    def get_job(self, job_id: str) -> Mapping[str, object] | None:
+        ...
+
+
+# 只保留值级 seam，Core 不导入 scheduler 实现或数据模型。ServiceKey 按名称相等，
+# scheduler 插件从自己的 inspection 模块注册同名 key。
+_SCHEDULER_INSPECTION = ServiceKey[_SchedulerInspection](
+    "scheduler.inspection.v1"
+)
+
+
 class RuntimeInspectionService:
     """从运行时 owner 投影移动端可读的文档、任务与能力。"""
 
@@ -73,7 +89,6 @@ class RuntimeInspectionService:
         snapshot_store: RuntimeSnapshotStore | None,
     ) -> None:
         self._workspace = workspace.expanduser().resolve()
-        self._job_store = JobStore(self._workspace / "schedules.json")
         self._snapshot_store = snapshot_store
 
     def list_documents(self) -> dict[str, object]:
@@ -109,23 +124,36 @@ class RuntimeInspectionService:
         return {**self._document_summary(document), "markdown": content}
 
     def list_jobs(self) -> dict[str, object]:
-        jobs = sorted(
-            self._active_jobs(),
-            key=lambda job: (job.fire_at, job.id),
-        )
-        return {"items": [self._job_summary(job) for job in jobs]}
+        """返回当前 generation 的 scheduler 投影。"""
+        service = self._scheduler_inspection()
+        if service is None:
+            raise RuntimeInspectionError(
+                "scheduler_unavailable",
+                "调度检查服务尚未绑定",
+            )
+        return {"items": [dict(item) for item in service.list_jobs()]}
 
     def get_job(self, job_id: str) -> dict[str, object]:
-        job = next(
-            (candidate for candidate in self._active_jobs() if candidate.id == job_id),
-            None,
-        )
-        if job is None:
+        """返回一个 scheduler 投影，不解释其中的业务字段。"""
+        service = self._scheduler_inspection()
+        if service is None:
+            raise RuntimeInspectionError(
+                "scheduler_unavailable",
+                "调度检查服务尚未绑定",
+            )
+        item = service.get_job(job_id)
+        if item is None:
             raise RuntimeInspectionError("job_not_found", f"定时任务不存在: {job_id}")
-        return {**self._job_summary(job), "markdown": _job_markdown(job)}
+        return dict(item)
 
-    def _active_jobs(self) -> list[ScheduledJob]:
-        return [job for job in self._job_store.load() if job.enabled]
+    def _scheduler_inspection(self) -> _SchedulerInspection | None:
+        """从当前 stable generation 的 Root 读取 provider。"""
+        store = self._snapshot_store
+        snapshot = None if store is None else store.current
+        root = None if snapshot is None else snapshot.composition_root
+        if root is None:
+            return None
+        return root.context.get(_SCHEDULER_INSPECTION)
 
     async def list_capabilities(self) -> dict[str, object]:
         async with await self._acquire_snapshot() as snapshot:
@@ -170,19 +198,6 @@ class RuntimeInspectionService:
             "group": document.group,
             "description": document.description,
             "available": path.is_file(),
-        }
-
-    @staticmethod
-    def _job_summary(job: ScheduledJob) -> dict[str, object]:
-        return {
-            "id": job.id,
-            "name": job.name,
-            "trigger": job.trigger,
-            "tier": job.tier,
-            "fire_at": job.fire_at.isoformat(),
-            "timezone": job.timezone,
-            "enabled": job.enabled,
-            "run_count": job.run_count,
         }
 
 
@@ -428,30 +443,6 @@ def _find_mcp_item(
             if item["owner_id"] == owner_id and item["name"] == server_name
         ),
         None,
-    )
-
-
-def _job_markdown(job: ScheduledJob) -> str:
-    content = job.message if job.tier == "instant" else job.prompt
-    schedule = job.cron_expr or (
-        f"每 {job.interval_seconds} 秒"
-        if job.interval_seconds is not None
-        else job.fire_at.isoformat()
-    )
-    return "\n".join(
-        (
-            f"# {job.name or '未命名定时任务'}",
-            "",
-            f"- **状态：** {'启用' if job.enabled else '停用'}",
-            f"- **触发：** `{job.trigger}` / `{job.tier}`",
-            f"- **计划：** {schedule}",
-            f"- **时区：** `{job.timezone}`",
-            f"- **运行次数：** {job.run_count}",
-            "",
-            "## 内容",
-            "",
-            content or "",
-        )
     )
 
 

--- a/plugin_boundary.toml
+++ b/plugin_boundary.toml
@@ -189,3 +189,7 @@ note = "客户端消费插件已投影的短命回复状态，不取得内部状
 [capabilities."tools.display-name.v1"]
 role = "seam"
 note = "客户端只读历史 binding 名称；工具插件拥有描述解释，不允许打开或执行工具"
+
+[capabilities."scheduler.inspection.v1"]
+role = "seam"
+note = "scheduler 拥有任务字段和展示；宿主只消费插件只读投影"

--- a/plugin_boundary_baseline.toml
+++ b/plugin_boundary_baseline.toml
@@ -24,8 +24,6 @@ R1 = [
     "agent/tools/filesystem.py|plugins.standard_tools",
     "agent/tools/filesystem.py|plugins.standard_tools.filesystem",
     "bootstrap/app.py|plugins.delivery.senders",
-    "infra/mobile_realtime/runtime_inspection.py|plugins.scheduler.schedule",
-    "infra/mobile_realtime/runtime_inspection.py|plugins.scheduler.store",
     "migrations/akasha_sparse_index_v8/migration.py|plugins.akasha.application.rebuild",
     "migrations/akasha_sparse_index_v8/migration.py|plugins.akasha.config",
     "migrations/akasha_sparse_index_v8/migration.py|plugins.akasha.infrastructure.loader",

--- a/plugins/scheduler/dashboard.py
+++ b/plugins/scheduler/dashboard.py
@@ -1,0 +1,49 @@
+"""提供 scheduler 自己拥有的只读展示值。"""
+
+from __future__ import annotations
+
+from .schedule import ScheduledJob
+
+
+def job_summary(job: ScheduledJob) -> dict[str, object]:
+    """投影运行时检查使用的稳定摘要。"""
+    return {
+        "id": job.id,
+        "name": job.name,
+        "trigger": job.trigger,
+        "tier": job.tier,
+        "fire_at": job.fire_at.isoformat(),
+        "timezone": job.timezone,
+        "enabled": job.enabled,
+        "run_count": job.run_count,
+    }
+
+
+def job_markdown(job: ScheduledJob) -> str:
+    """渲染 scheduler 字段，Core 无需理解任务 schema。"""
+    content = job.message if job.tier == "instant" else job.prompt
+    schedule = job.cron_expr or (
+        f"每 {job.interval_seconds} 秒"
+        if job.interval_seconds is not None
+        else job.fire_at.isoformat()
+    )
+    return "\n".join(
+        (
+            f"# {job.name or '未命名定时任务'}",
+            "",
+            f"- **状态：** {'启用' if job.enabled else '停用'}",
+            f"- **触发：** `{job.trigger}` / `{job.tier}`",
+            f"- **计划：** {schedule}",
+            f"- **时区：** `{job.timezone}`",
+            f"- **运行次数：** {job.run_count}",
+            "",
+            "## 内容",
+            "",
+            content or "",
+        )
+    )
+
+
+def job_detail(job: ScheduledJob) -> dict[str, object]:
+    """在任务摘要中加入 scheduler 自己拥有的详情文档。"""
+    return {**job_summary(job), "markdown": job_markdown(job)}

--- a/plugins/scheduler/inspection.py
+++ b/plugins/scheduler/inspection.py
@@ -3,30 +3,11 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Protocol, runtime_checkable
 
 from agent.plugin_composition import ServiceKey
 
 from .dashboard import job_detail, job_summary
 from .store import JobStore
-
-
-@runtime_checkable
-class SchedulerInspection(Protocol):
-    """Core 运行时检查消费的 scheduler 投影。"""
-
-    def list_jobs(self) -> tuple[Mapping[str, object], ...]:
-        """按 scheduler 展示顺序返回启用任务。"""
-        ...
-
-    def get_job(self, job_id: str) -> Mapping[str, object] | None:
-        """返回一个启用任务；缺失或停用时返回 None。"""
-        ...
-
-
-SCHEDULER_INSPECTION = ServiceKey[SchedulerInspection](
-    "scheduler.inspection.v1"
-)
 
 
 class SchedulerInspectionProvider:
@@ -49,3 +30,6 @@ class SchedulerInspectionProvider:
             if job.id == job_id and job.enabled:
                 return job_detail(job)
         return None
+
+
+SCHEDULER_INSPECTION = ServiceKey[SchedulerInspectionProvider]("scheduler.inspection.v1")

--- a/plugins/scheduler/inspection.py
+++ b/plugins/scheduler/inspection.py
@@ -1,0 +1,51 @@
+"""scheduler 自己拥有的只读检查能力。"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Protocol, runtime_checkable
+
+from agent.plugin_composition import ServiceKey
+
+from .dashboard import job_detail, job_summary
+from .store import JobStore
+
+
+@runtime_checkable
+class SchedulerInspection(Protocol):
+    """Core 运行时检查消费的 scheduler 投影。"""
+
+    def list_jobs(self) -> tuple[Mapping[str, object], ...]:
+        """按 scheduler 展示顺序返回启用任务。"""
+        ...
+
+    def get_job(self, job_id: str) -> Mapping[str, object] | None:
+        """返回一个启用任务；缺失或停用时返回 None。"""
+        ...
+
+
+SCHEDULER_INSPECTION = ServiceKey[SchedulerInspection](
+    "scheduler.inspection.v1"
+)
+
+
+class SchedulerInspectionProvider:
+    """只读并投影 scheduler 状态，不修改权威持久化。"""
+
+    def __init__(self, store: JobStore) -> None:
+        self._store = store
+
+    def list_jobs(self) -> tuple[Mapping[str, object], ...]:
+        """从 owner store 读取启用任务并确定性排序。"""
+        return tuple(
+            job_summary(job)
+            for job in sorted(self._store.load(), key=lambda item: (item.fire_at, item.id))
+            if job.enabled
+        )
+
+    def get_job(self, job_id: str) -> Mapping[str, object] | None:
+        """读取一个启用任务，不改变 scheduler 状态。"""
+        for job in self._store.load():
+            if job.id == job_id and job.enabled:
+                return job_detail(job)
+        return None

--- a/plugins/scheduler/message_plugin.py
+++ b/plugins/scheduler/message_plugin.py
@@ -26,6 +26,7 @@ from session.message import CallRef, Message
 
 from .runtime import SchedulerRuntime
 from .store import JobStore
+from .inspection import SCHEDULER_INSPECTION, SchedulerInspectionProvider
 from .tools import CancelInput, ListSchedules, ScheduleInput, ScheduleTool
 
 api_version = 3
@@ -79,6 +80,7 @@ class Config(BaseModel):
 async def apply(ctx: Context, config: Config) -> None:
     """注册工具不启动调度；旧 binding 直接重读同一文件，不依赖当前 runtime 指针。"""
     store = JobStore(ctx.workspace_file("schedules.json"))
+    _ = await ctx.provide(SCHEDULER_INSPECTION, SchedulerInspectionProvider(store))
     watcher: asyncio.Task[None] | None = None
     tool_view = ToolView(())
     catalog = ctx.require(TOOLS)

--- a/tests/test_scheduler_inspection.py
+++ b/tests/test_scheduler_inspection.py
@@ -1,0 +1,130 @@
+"""验证 scheduler 检查保持在插件边界内。"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from infra.mobile_realtime.runtime_inspection import (
+    RuntimeInspectionError,
+    RuntimeInspectionService,
+)
+from plugins.scheduler.inspection import SchedulerInspectionProvider
+from plugins.scheduler.schedule import ScheduledJob
+from plugins.scheduler.store import JobStore
+
+
+def _job(
+    job_id: str,
+    fire_at: datetime,
+    *,
+    enabled: bool = True,
+    message: str = "检查状态",
+) -> ScheduledJob:
+    return ScheduledJob(
+        trigger="every",
+        tier="instant",
+        fire_at=fire_at,
+        channel="web",
+        chat_id="chat-1",
+        interval_seconds=60,
+        message=message,
+        enabled=enabled,
+        name=job_id,
+        id=job_id,
+    )
+
+
+def test_scheduler_provider_projects_only_enabled_jobs(tmp_path: Path) -> None:
+    first = _job("first", datetime(2026, 9, 12, 1, 0, tzinfo=UTC))
+    second = _job("second", first.fire_at + timedelta(minutes=1))
+    disabled = _job("disabled", first.fire_at - timedelta(minutes=1), enabled=False)
+    store = JobStore(tmp_path / "schedules.json")
+    store.save({job.id: job for job in (second, disabled, first)})
+
+    provider = SchedulerInspectionProvider(store)
+
+    assert [item["id"] for item in provider.list_jobs()] == ["first", "second"]
+    assert provider.get_job("disabled") is None
+    detail = provider.get_job("first")
+    assert detail is not None
+    assert {key: value for key, value in detail.items() if key != "markdown"} == {
+        "id": "first",
+        "name": "first",
+        "trigger": "every",
+        "tier": "instant",
+        "fire_at": "2026-09-12T01:00:00+00:00",
+        "timezone": "UTC",
+        "enabled": True,
+        "run_count": 0,
+    }
+    assert detail["markdown"] == (
+        "# first\n\n"
+        "- **状态：** 启用\n"
+        "- **触发：** `every` / `instant`\n"
+        "- **计划：** 每 60 秒\n"
+        "- **时区：** `UTC`\n"
+        "- **运行次数：** 0\n\n"
+        "## 内容\n\n"
+        "检查状态"
+    )
+
+
+class _Provider:
+    def list_jobs(self) -> tuple[Mapping[str, object], ...]:
+        return (
+            {"id": "external", "display": "来自 scheduler"},
+        )
+
+    def get_job(self, job_id: str) -> Mapping[str, object] | None:
+        return {"id": job_id, "display": "来自 scheduler"}
+
+
+def test_core_passes_through_scheduler_projection_without_reading_workspace(
+    tmp_path: Path,
+) -> None:
+    provider = _Provider()
+    context = SimpleNamespace(
+        get=lambda key: provider
+        if key.name == "scheduler.inspection.v1"
+        else None
+    )
+    snapshot_store = SimpleNamespace(
+        current=SimpleNamespace(composition_root=SimpleNamespace(context=context))
+    )
+    service = RuntimeInspectionService(
+        workspace=tmp_path,
+        snapshot_store=snapshot_store,
+    )
+
+    assert service.list_jobs() == {
+        "items": [{"id": "external", "display": "来自 scheduler"}]
+    }
+    assert service.get_job("external") == {
+        "id": "external",
+        "display": "来自 scheduler",
+    }
+    assert not (tmp_path / "schedules.json").exists()
+
+
+def test_core_reports_scheduler_unavailable_without_provider(tmp_path: Path) -> None:
+    service = RuntimeInspectionService(workspace=tmp_path, snapshot_store=None)
+
+    with pytest.raises(RuntimeInspectionError, match="调度检查服务尚未绑定") as error:
+        service.list_jobs()
+
+    assert error.value.code == "scheduler_unavailable"
+
+
+def test_core_runtime_inspection_has_no_scheduler_implementation_import() -> None:
+    source = (Path(__file__).parents[1] / "infra/mobile_realtime/runtime_inspection.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "plugins.scheduler" not in source
+    assert "JobStore" not in source
+    assert "ScheduledJob" not in source

--- a/tests/test_scheduler_inspection.py
+++ b/tests/test_scheduler_inspection.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Mapping
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 
@@ -84,38 +83,42 @@ class _Provider:
         return {"id": job_id, "display": "来自 scheduler"}
 
 
-def test_core_passes_through_scheduler_projection_without_reading_workspace(
-    tmp_path: Path,
-) -> None:
+@pytest.mark.asyncio
+async def test_core_passes_through_scheduler_projection_without_reading_workspace(tmp_path: Path) -> None:
+    from agent.plugin_composition import CompositionRoot, ServiceKey
+    from agent.plugins.snapshot import RuntimeSnapshotCompiler, RuntimeSnapshotStore, get_current_runtime_snapshot
+
+    root = CompositionRoot("scheduler-inspection")
     provider = _Provider()
-    context = SimpleNamespace(
-        get=lambda key: provider
-        if key.name == "scheduler.inspection.v1"
-        else None
-    )
-    snapshot_store = SimpleNamespace(
-        current=SimpleNamespace(composition_root=SimpleNamespace(context=context))
-    )
-    service = RuntimeInspectionService(
-        workspace=tmp_path,
-        snapshot_store=snapshot_store,
-    )
+    async def apply(ctx):
+        await ctx.provide(ServiceKey("scheduler.inspection.v1"), provider)
+    await root.mount(apply, name="external-scheduler")
+    store = RuntimeSnapshotStore()
+    snapshot = RuntimeSnapshotCompiler().compile({}, composition_root=root)
+    store.install(snapshot)
+    service = RuntimeInspectionService(workspace=tmp_path, snapshot_store=store)
+    original = provider.list_jobs
+    def list_jobs():
+        assert get_current_runtime_snapshot() is snapshot
+        assert snapshot.lease_count == 1
+        return original()
+    provider.list_jobs = list_jobs
+    try:
+        assert await service.list_jobs() == {"items": [{"id": "external", "display": "来自 scheduler"}]}
+        assert await service.get_job("external") == {"id": "external", "display": "来自 scheduler"}
+        assert snapshot.lease_count == 0
+        assert not (tmp_path / "schedules.json").exists()
+    finally:
+        await store.close()
+        await root.dispose()
 
-    assert service.list_jobs() == {
-        "items": [{"id": "external", "display": "来自 scheduler"}]
-    }
-    assert service.get_job("external") == {
-        "id": "external",
-        "display": "来自 scheduler",
-    }
-    assert not (tmp_path / "schedules.json").exists()
 
-
-def test_core_reports_scheduler_unavailable_without_provider(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_core_reports_scheduler_unavailable_without_provider(tmp_path: Path) -> None:
     service = RuntimeInspectionService(workspace=tmp_path, snapshot_store=None)
 
     with pytest.raises(RuntimeInspectionError, match="调度检查服务尚未绑定") as error:
-        service.list_jobs()
+        await service.list_jobs()
 
     assert error.value.code == "scheduler_unavailable"
 

--- a/tests/test_scheduler_messages.py
+++ b/tests/test_scheduler_messages.py
@@ -350,8 +350,11 @@ async def test_sender_failure_closes_fire_in_same_runtime(tmp_path, raises):
     """已落盘的发送失败立即结束调度，不等待服务重启。"""
     install(tmp_path)
     sender = tmp_path / "plugins/test_sender/plugin.py"
-    failure = 'raise TimeoutError("sender connection lost")' if raises else 'return Receipt(status="failed", error="sender connection lost")'
-    sender.write_text(sender.read_text().replace('return Receipt(status="delivered", provider_ids=("original-A",))', failure))
+    failure = 'raise TimeoutError("sender connection lost")' if raises else 'return SendResult(status="failed", error="sender connection lost")'
+    original = 'return SendResult(status="delivered", provider_ids=("original-A",))'
+    source = sender.read_text()
+    assert original in source, "fixture sender 的故障注入入口必须存在"
+    sender.write_text(source.replace(original, failure))
     async with application(tmp_path, replying=False, start=False) as (log, host):
         store = JobStore(tmp_path / "workspace/schedules.json")
         job = ScheduledJob(trigger="after", tier="instant", fire_at=datetime.now(UTC) - timedelta(seconds=1),


### PR DESCRIPTION
Web/Mobile 的调度查询通过 scheduler.inspection.v1 消费只读投影；JobStore、排序、启用过滤和 Markdown 都由 scheduler 提供。Core 不再 import scheduler 实现或读取 schedules.json；解析与查询在同一代 lease 内完成，缺 provider 明确失败。

基于 #604 的 stacked PR，恢复点 935dfe24。调度执行共用原 store，正式数据及减少协议不变。同时修复 sender 测试 fixture 改名后故障注入不再命中的问题，保留发送失败断言。

验证：93 项相关调度/展示/频道测试通过（91 项首次通过，故障注入修正后 2 项通过）；定向 Pyright 0 errors（12 warnings）；边界检查通过 R1=32、R2=224、R3=239。完整 Gate、CI、独立概念审查在全栈实施后集中处理；draft 不代表可合并。