### PR TITLE
refactor: 统一摘要校验 owner 并保留记忆只读组合

### DIFF
--- a/docs/design/plugin-boundary-foundation.md
+++ b/docs/design/plugin-boundary-foundation.md
@@ -376,3 +376,14 @@ react 通过 Context 的公开 capture_runtime_scope 取得真实调用租约，
 snapshot 私有全局。已提交调用的取消、排空和 generation 归属保留原路径。
 restart 回归组合安装真正的 standard_tools 清理 owner，并明确授予其 skills 材料权；
 测试在 reply.execute 的注入点协调清理与发送，验证关闭完成前不能提交 restart。
+
+
+### 9.17 摘要范围的唯一 owner
+
+Context 提供已有摘要校验、连续来源范围和已结算前缀算法；Compaction 与 Markdown
+通过回调消费，删除局部边界中复制的算法。SummaryRecords 仍在原事务中校验来源，
+只追加摘要并推进原指针；权威消息正文没有写入或减少。
+
+Markdown 只读材料组合不要求安装 Compaction；真正遇到需要学习的摘要时必须取得
+原摘要读取能力，缺失明确失败，不跳过或伪造来源。Akasha 使用公开只读 embedding
+接口与实际 Message 编码，重建写入器的权限归属继续单独处理。

--- a/plugin_boundary_baseline.toml
+++ b/plugin_boundary_baseline.toml
@@ -38,17 +38,9 @@ R1 = [
     "migrations/yoyo/20260909_01_close_empty_wake_responses.py|plugins.wake.request",
 ]
 R2 = [
-    "plugins/akasha/application/consumer.py|session.embedding_store",
-    "plugins/akasha/application/snapshot.py|session.embedding_store",
     "plugins/akasha/dashboard.py|agent.plugins.snapshot",
     "plugins/akasha/infrastructure/sparse_index/builder.py|agent.turn_effects",
-    "plugins/akasha/interest.py|session.embedding_store",
-    "plugins/akasha/learning.py|session.embedding_store",
-    "plugins/akasha/projection.py|session.embedding_store",
-    "plugins/akasha/projection.py|session.message_codec",
-    "plugins/akasha/recall_tool.py|session.embedding_store",
     "plugins/akasha/repair.py|session.embedding_store",
-    "plugins/akasha/runtime.py|session.embedding_store",
     "plugins/codex/driver.py|core.net.http",
     "plugins/codex/responses.py|core.net.http",
     "plugins/content/api.py|agent.turn_effects",

--- a/plugins/akasha/application/consumer.py
+++ b/plugins/akasha/application/consumer.py
@@ -10,8 +10,7 @@ from functools import partial
 from pathlib import Path
 
 from agent.plugin_composition.bindings import Bindings
-from agent.plugin_composition.messages import MessageCatalog
-from session.embedding_store import MessageEmbeddings
+from agent.plugin_composition.messages import MessageCatalog, MessageEmbeddings
 
 from ..domain.features import BurstAwareFeaturePool
 from ..domain.model import ContextState, EmbeddingSpaceMismatchError, MemoryConfig, Turn

--- a/plugins/akasha/application/snapshot.py
+++ b/plugins/akasha/application/snapshot.py
@@ -8,8 +8,7 @@ import sqlite3
 from tempfile import TemporaryDirectory
 
 from agent.plugin_composition.bindings import Bindings
-from session.embedding_store import MessageEmbeddings
-from agent.plugin_composition.messages import MessageCatalog
+from agent.plugin_composition.messages import MessageCatalog, MessageEmbeddings
 
 from ..domain.model import MemoryConfig
 from ..infrastructure.consumption import Consumption

--- a/plugins/akasha/interest.py
+++ b/plugins/akasha/interest.py
@@ -6,8 +6,7 @@ from datetime import datetime
 import numpy as np
 
 from agent.plugin_composition import ServiceKey
-from session.embedding_store import MessageEmbeddings
-from agent.plugin_composition.messages import MessageCatalog
+from agent.plugin_composition.messages import MessageCatalog, MessageEmbeddings
 from agent.plugin_contracts import Input, Output
 
 from .learning import Learning, LearningConfig

--- a/plugins/akasha/learning.py
+++ b/plugins/akasha/learning.py
@@ -8,8 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from agent.plugin_composition import ServiceKey
 from agent.plugin_composition.bindings import Bindings
-from session.embedding_store import MessageEmbeddings
-from agent.plugin_composition.messages import MessageCatalog
+from agent.plugin_composition.messages import MessageCatalog, MessageEmbeddings
 from agent.plugin_contracts import ContentPart, Input, Message, Output, ToolCall, ToolResult
 from ._boundaries import PostCommitReader, TOOLS, TurnProjection
 from .domain.model import Turn, TurnFeedback

--- a/plugins/akasha/projection.py
+++ b/plugins/akasha/projection.py
@@ -5,11 +5,10 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 import hashlib
 import json
+from typing import Protocol
+
 from agent.plugin_composition.messages import MessageCatalog
-from agent.plugin_contracts import Message, Output
-from agent.plugin_contracts import Input
-from session.message_codec import encode_body
-from session.embedding_store import EmbeddingRecords
+from agent.plugin_contracts import Input, Message, Output, encode_body
 import numpy as np
 
 from .domain.model import Turn, TurnFeedback
@@ -19,6 +18,10 @@ from ._boundaries import TurnProjection
 
 
 type CausalKey = tuple[datetime, str, int, str]
+
+
+class EmbeddingRecords(Protocol):
+    def read(self, message: Message, *, model: str, dimension: int) -> tuple[float, ...] | None: ...
 
 
 @dataclass(frozen=True, slots=True)

--- a/plugins/akasha/recall_tool.py
+++ b/plugins/akasha/recall_tool.py
@@ -13,8 +13,7 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_valida
 
 from agent.plugin_composition.bindings import Bindings
 from agent.plugin_composition.models import BoundEmbeddingModel
-from session.embedding_store import MessageEmbeddings
-from agent.plugin_composition.messages import MessageCatalog
+from agent.plugin_composition.messages import MessageCatalog, MessageEmbeddings
 from agent.plugin_contracts import ContentPart, ContentReferences, Message, Output, ToolCall, ToolResult
 from agent.plugin_contracts import json_value
 from ._boundaries import CallSource, Result, TOOLS

--- a/plugins/akasha/runtime.py
+++ b/plugins/akasha/runtime.py
@@ -154,9 +154,8 @@ async def prepare_materials(
             )
     references = {cast(str, ref["ref"]): ref for ref in _reference_rows(material)}
     # 同一消息有多次真实查询时，当前工具结果的精确出处供后续 Citation 使用。
-    references.update((ref.ref, {
-        "ref": ref.ref, "resolved_ref": ref.resolved_ref, "retrieval_ref": ref.retrieval_ref,
-    }) for ref in tool_references(snapshot, source, learning, bindings, records))
+    references.update((cast(str, ref["ref"]), ref)
+                      for ref in tool_references(snapshot, source, learning, bindings, records))
     result = dict(material)
     result["references"] = tuple(references.values())
     return result

--- a/plugins/akasha/runtime.py
+++ b/plugins/akasha/runtime.py
@@ -9,8 +9,7 @@ import json
 from typing import cast
 
 from agent.plugin_composition.bindings import Bindings
-from session.embedding_store import MessageEmbeddings
-from agent.plugin_composition.messages import MessageCatalog
+from agent.plugin_composition.messages import MessageCatalog, MessageEmbeddings
 from agent.plugin_contracts import Input, Message
 
 from .application.consumer import MessageConsumer, run_memory_job

--- a/plugins/compaction/_boundaries.py
+++ b/plugins/compaction/_boundaries.py
@@ -6,7 +6,7 @@ from typing import Protocol
 
 from agent.plugin_composition import Context, ServiceKey
 from agent.plugin_composition.models import ModelRequest
-from agent.plugin_contracts import CallRef, Control, Message, Output, ToolCall, ToolResult
+from agent.plugin_contracts import CallRef, Message
 
 
 MaterialData = Mapping[str, object]
@@ -29,6 +29,10 @@ class ContextModel(Protocol):
 
 
 class ContextBuilder(Protocol):
+    def settled_prefixes(self, messages: tuple[Message, ...]) -> tuple[int, ...]: ...
+
+    def summary_range(self, snapshot: tuple[Message, ...], source_message_ids: tuple[str, ...]) -> range: ...
+
     def build_attempt(
         self, snapshot: Sequence[Message], *, materials: MaterialData,
         model: ContextModel, tools: Sequence[Mapping[str, object]] = (),
@@ -113,39 +117,3 @@ MATERIALS = ServiceKey[MaterialRegistry]("context.materials.v3")
 TURN_PROJECTION = ServiceKey[TurnProjection]("turn.projection.v1")
 COMPACTION_SUMMARIES = ServiceKey[SummaryLookup]("compaction.summaries.v1")
 COMPACTION_READER = ServiceKey[CompactionReader]("compaction.reader.v1")
-
-
-def settled_prefixes(messages: tuple[Message, ...]) -> tuple[int, ...]:
-    """返回工具已结算或被明确放弃的前缀长度。"""
-    pending: dict[CallRef, Message] = {}
-    ends: list[int] = []
-    for index, message in enumerate(messages):
-        body = message.body
-        if isinstance(body, Output):
-            pending.update(
-                (CallRef(message.message_id, position), message)
-                for position, part in enumerate(body.parts)
-                if isinstance(part, ToolCall)
-            )
-        elif isinstance(body, ToolResult):
-            _ = pending.pop(body.call_ref, None)
-        elif isinstance(body, Control) and body.action == "abandon":
-            pending = {
-                ref: call for ref, call in pending.items()
-                if call.source != message.source or call.seq > body.through_seq
-            }
-        if not pending:
-            ends.append(index + 1)
-    return tuple(ends)
-
-
-def summary_range(snapshot: tuple[Message, ...], source_message_ids: tuple[str, ...]) -> range:
-    """按不可变消息身份定位摘要的连续覆盖区间。"""
-    identities = tuple(message.message_id for message in snapshot)
-    if not source_message_ids or source_message_ids[0] not in identities:
-        raise ValueError("摘要来源缺少实际消息")
-    start = identities.index(source_message_ids[0])
-    end = start + len(source_message_ids)
-    if identities[start:end] != source_message_ids:
-        raise ValueError("摘要来源不等于实际连续消息范围")
-    return range(start, end)

--- a/plugins/compaction/message_plugin.py
+++ b/plugins/compaction/message_plugin.py
@@ -16,7 +16,7 @@ from .records import StoredSummary, SummaryLookup, SummaryRecord, SummaryRecords
 from .message_summary import SummaryError, closed_groups, source_text, summarize, summary_groups, window_starts
 from ._boundaries import (
     COMPACTION_READER, COMPACTION_SUMMARIES, CONTEXT, MATERIALS, TURN_PROJECTION,
-    ContextModel, MaterialData, TurnProjection, summary_range,
+    ContextModel, MaterialData, TurnProjection,
 )
 
 api_version = 3
@@ -34,13 +34,16 @@ class Config(BaseModel):
 class _CompactionReader:
     """Markdown 只取得 compaction 的纯读取算法，不取得发布或模型权限。"""
 
+    def __init__(self, *, settled_prefixes: Callable[[tuple[Message, ...]], tuple[int, ...]]):
+        self._settled_prefixes = settled_prefixes
+
     def source_text(self, messages: Sequence[Message]) -> str:
         return source_text(messages)
 
     def window_starts(
         self, messages: tuple[Message, ...], projection: TurnProjection,
     ) -> tuple[int, ...]:
-        return window_starts(messages, projection)
+        return window_starts(messages, projection, settled_prefixes=self._settled_prefixes)
 
     def summary_groups(
         self, groups: tuple[tuple[Message, ...], ...], snapshot: tuple[Message, ...],
@@ -50,6 +53,8 @@ class _CompactionReader:
 
 async def apply(ctx: Context, config: Config) -> None:
     """注册只读材料和归档解析；apply 不打开 writer 或调用模型。"""
+    context = ctx.require(CONTEXT)
+
     def records() -> SummaryRecords:
         return SummaryRecords(ctx.require(OWNER_STATE).open(ctx))
 
@@ -76,7 +81,9 @@ async def apply(ctx: Context, config: Config) -> None:
     _ = await ctx.on(RUNTIME_STOPPING, stop)
     lookup = SummaryLookup(read, head)
     _ = await ctx.provide(COMPACTION_SUMMARIES, lookup)
-    _ = await ctx.provide(COMPACTION_READER, _CompactionReader())
+    _ = await ctx.provide(COMPACTION_READER, _CompactionReader(
+        settled_prefixes=context.settled_prefixes,
+    ))
 
     def material(record: StoredSummary) -> MaterialData:
         reference = ctx.require(BINDINGS).bind(COMPACTION_SUMMARIES, {
@@ -114,7 +121,9 @@ async def apply(ctx: Context, config: Config) -> None:
         if parent is None:
             origin: int | None = None
             # 首次窗口从最近完整单元累加；完整业务输入不得越过软水位或硬边界。
-            for index in reversed(window_starts(snapshot, turns)):
+            for index in reversed(window_starts(
+                snapshot, turns, settled_prefixes=context.settled_prefixes,
+            )):
                 candidate, error = ctx.require(CONTEXT).build_attempt(
                     snapshot, materials=materials, model=projection,
                     tools=request.tools, max_output_tokens=request.max_output_tokens,
@@ -129,9 +138,11 @@ async def apply(ctx: Context, config: Config) -> None:
                 raise SummaryError("当前完整工作与固定材料超过首次窗口容量")
             start = origin
         else:
-            covered = summary_range(snapshot, parent.source_message_ids)
+            covered = context.summary_range(snapshot, parent.source_message_ids)
             origin, start = covered.start, covered.stop
-        groups = closed_groups(snapshot, turns, after=start)
+        groups = closed_groups(
+            snapshot, turns, settled_prefixes=context.settled_prefixes, after=start,
+        )
         selected: tuple[tuple[Message, ...], ...] = ()
         # 原文保留量来自实际 Model 投影，包含尚未闭合的尾部与当前输入。
         for size in range(len(groups), 0, -1):
@@ -176,7 +187,9 @@ async def apply(ctx: Context, config: Config) -> None:
         record = record.model_copy(update={"tokens_after": after})
         # 3. binding 可以先固定，但读者只有在摘要事务成功后才取得此引用。
         reader = ctx.require(MESSAGE_CATALOG).reader(record.session_id)
-        _ = records().publish(record, reader, parent=parent)
+        _ = records().publish(
+            record, reader, parent=parent, summary_range=context.summary_range,
+        )
         return summary
 
     _ = await ctx.require(MATERIALS).register(ctx, name="compaction", prepare=prepare, reduce=reduce, priority=500)

--- a/plugins/compaction/message_summary.py
+++ b/plugins/compaction/message_summary.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import replace
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 
 from agent.plugin_composition.models import (
     BoundChatModel, ContextLengthError, ModelRequest, ModelTimeoutError,
@@ -12,7 +12,7 @@ from agent.plugin_composition.models import (
 )
 from agent.plugin_contracts import CallRef, ContentPart, Control, Message, Output, ToolCall, ToolResult
 from agent.plugin_contracts import body_to_dict
-from ._boundaries import TurnProjection, settled_prefixes
+from ._boundaries import TurnProjection
 
 logger = logging.getLogger(__name__)
 
@@ -73,15 +73,21 @@ def _protected_cuts(messages: tuple[Message, ...], projection: TurnProjection,
     return protected
 
 
-def window_starts(messages: tuple[Message, ...], projection: TurnProjection) -> tuple[int, ...]:
+def window_starts(
+    messages: tuple[Message, ...], projection: TurnProjection, *,
+    settled_prefixes: Callable[[tuple[Message, ...]], tuple[int, ...]],
+) -> tuple[int, ...]:
     """首次窗口只能从完整单元开始，当前未结束工作也作为整体保留。"""
     protected = _protected_cuts(messages, projection, keep_open=True)
     return tuple(index for index in (0, *settled_prefixes(messages))
                  if index < len(messages) and index not in protected)
 
 
-def closed_groups(messages: tuple[Message, ...], projection: TurnProjection,
-                  *, after: int = 0) -> tuple[tuple[Message, ...], ...]:
+def closed_groups(
+    messages: tuple[Message, ...], projection: TurnProjection, *,
+    settled_prefixes: Callable[[tuple[Message, ...]], tuple[int, ...]],
+    after: int = 0,
+) -> tuple[tuple[Message, ...], ...]:
     """完整 Turn 不拆开；open 工作只在已结算批次后提供压缩边界。"""
     groups: list[tuple[Message, ...]] = []
     ends = set(settled_prefixes(messages)) - _protected_cuts(messages, projection, keep_open=False)

--- a/plugins/compaction/records.py
+++ b/plugins/compaction/records.py
@@ -10,9 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from agent.plugin_composition import ServiceKey
 
 from agent.plugin_composition.messages import MessageConflict, MessageReader, OwnerStore, OwnerTransaction
-from agent.plugin_contracts import json_value
-from ._boundaries import summary_range
-
+from agent.plugin_contracts import Message, json_value
 Text = Annotated[str, Field(min_length=1)]
 Digest = Annotated[str, Field(pattern=r"^[0-9a-f]{64}$")]
 
@@ -241,6 +239,7 @@ class SummaryRecords:
 
     def publish(
         self, record: SummaryRecord, reader: MessageReader, *, parent: StoredSummary | None,
+        summary_range: Callable[[tuple[Message, ...], tuple[str, ...]], range],
     ) -> SummaryRecord:
         """原子检查 parent 与消息前缀，再只增摘要并推进本 Session 指针。"""
         self._state.check_access(reader)
@@ -266,7 +265,7 @@ class SummaryRecords:
                 raise ValueError("后续摘要不能撤回已有来源")
 
             # 2. 源消息与摘要在同一 authority 的事务中校验；读取模块无正文写权。
-            _ = summary_range(reader.snapshot(), record.source_message_ids)
+            _ = summary_range(tuple(reader.snapshot()), record.source_message_ids)
             _ = tx.save("summary:" + record.reference,
                         cast(Mapping[str, object], record.model_dump(mode="json")), expected_version=None)
             key = "head:" + record.session_id

--- a/plugins/context/plugin.py
+++ b/plugins/context/plugin.py
@@ -69,6 +69,7 @@ def _summary_cutoff(snapshot: tuple[Message, ...], summary: Summary | None) -> i
 class ContextBuilder:
     check_summary = staticmethod(check_summary)
     summary_range = staticmethod(summary_range)
+    settled_prefixes = staticmethod(settled_prefixes)
 
     @staticmethod
     def _reminder_content(materials: Materials) -> str | None:

--- a/plugins/markdown_memory/_boundaries.py
+++ b/plugins/markdown_memory/_boundaries.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Mapping, Sequence
-from typing import Protocol, cast
+from typing import Protocol
 
 from agent.plugin_composition import Context, ServiceKey
 from agent.plugin_contracts import ContentPart, ContentReferences, Message
@@ -59,6 +59,14 @@ class TurnProjection(Protocol):
     def project(self, messages: Sequence[Message], source: str) -> tuple[Turn, ...]: ...
 
 
+class ContextBuilder(Protocol):
+    def check_summary(self, part: ContentPart) -> ContentReferences: ...
+
+    def summary_range(
+        self, snapshot: tuple[Message, ...], source_message_ids: tuple[str, ...],
+    ) -> range: ...
+
+
 class ContentFacts(Protocol):
     def is_user_input(self, message: Message) -> bool: ...
 
@@ -66,30 +74,8 @@ class ContentFacts(Protocol):
 
 
 MATERIALS = ServiceKey[MaterialRegistry]("context.materials.v3")
+CONTEXT = ServiceKey[ContextBuilder]("context.v2")
 COMPACTION_SUMMARIES = ServiceKey[SummaryLookup]("compaction.summaries.v1")
 COMPACTION_READER = ServiceKey[CompactionReader]("compaction.reader.v1")
 CONTENT = ServiceKey[ContentFacts]("content.v2")
 TURN_PROJECTION = ServiceKey[TurnProjection]("turn.projection.v1")
-
-
-def check_summary(part: ContentPart) -> ContentReferences:
-    """校验已发布摘要的 binding 引用，不解析摘要正文。"""
-    value = part.value
-    if not isinstance(value, Mapping):
-        raise ValueError("context.summary 必须是对象")
-    data = dict(cast(Mapping[str, object], value))
-    if set(data) != {"reference"} or not isinstance(data["reference"], str) or not data["reference"]:
-        raise ValueError("context.summary 必须包含唯一的摘要 binding 引用")
-    return ContentReferences(binding_ids=(data["reference"],))
-
-
-def summary_range(snapshot: tuple[Message, ...], source_message_ids: tuple[str, ...]) -> range:
-    """按摘要 owner 发布的消息身份定位连续覆盖区间。"""
-    identities = tuple(message.message_id for message in snapshot)
-    if not source_message_ids or source_message_ids[0] not in identities:
-        raise ValueError("摘要来源缺少实际消息")
-    start = identities.index(source_message_ids[0])
-    end = start + len(source_message_ids)
-    if identities[start:end] != source_message_ids:
-        raise ValueError("摘要来源不等于实际连续消息范围")
-    return range(start, end)

--- a/plugins/markdown_memory/message_plugin.py
+++ b/plugins/markdown_memory/message_plugin.py
@@ -30,9 +30,9 @@ from infra.persistence.json_store import atomic_write_text
 from agent.plugin_composition.messages import MessageCatalog
 from agent.plugin_contracts import ContentPart, Input, Message, Output, ToolResult
 from ._boundaries import (
-    COMPACTION_READER, COMPACTION_SUMMARIES, CONTENT, MATERIALS,
-    CompactionReader, ContentFacts, StoredSummary, SummaryLookup, TURN_PROJECTION, TurnProjection,
-    check_summary, summary_range,
+    COMPACTION_READER, COMPACTION_SUMMARIES, CONTENT, CONTEXT, MATERIALS,
+    CompactionReader, ContentFacts, ContextBuilder, StoredSummary, SummaryLookup,
+    TURN_PROJECTION, TurnProjection,
 )
 
 if TYPE_CHECKING:
@@ -55,8 +55,8 @@ workspace_files = (
 )
 
 MaterialData = Mapping[str, object]
-inject = (CHAT_MODELS, MATERIALS, BINDINGS, MESSAGE_CATALOG, CONTENT, COMPACTION_SUMMARIES,
-          COMPACTION_READER, TURN_PROJECTION)
+inject = (CHAT_MODELS, MATERIALS, BINDINGS, MESSAGE_CATALOG, CONTENT, CONTEXT,
+          TURN_PROJECTION)
 
 
 _MEMORY_HEADINGS = (
@@ -627,6 +627,7 @@ async def _unapplied_groups(
     store: MarkdownProfileStore, sources: tuple[str, ...], projection: TurnProjection,
     *, compaction: CompactionReader,
     post_commit_effect: Callable[[Message], str | None],
+    summary_range: Callable[[tuple[Message, ...], tuple[str, ...]], range],
 ) -> tuple[tuple[Message, ...], ...] | None:
     """从最近已写入的祖先之后取完整组的原文，跳过未使用的摘要不会漏掉它覆盖的事实。"""
     start = 0
@@ -676,7 +677,8 @@ async def project(
     store: MarkdownProfileStore, models: ChatModels, lock_path: Path,
     sources: tuple[str, ...], projection: TurnProjection,
     content: ContentFacts,
-    compaction: CompactionReader,
+    context: ContextBuilder,
+    compaction: CompactionReader | None,
 ) -> None:
     """只处理已提交的模型 Output；两份文件沿原 before-image receipt 恢复。"""
     if reader.attributes.learning != "eligible" or message.source not in sources or not isinstance(message.body, Output):
@@ -686,7 +688,9 @@ async def project(
         return
     if len(refs) != 1:
         raise ValueError("一个 Output 只能声明实际使用的一份摘要")
-    reference = check_summary(refs[0]).binding_ids[0]
+    if compaction is None:
+        raise RuntimeError("Markdown 摘要投影需要 compaction.reader.v1")
+    reference = context.check_summary(refs[0]).binding_ids[0]
     user_input = content.is_user_input
     post_commit_effect = content.legacy_post_commit_effect
     # 1. 更新串行；两文件锁只保护已提交档案的读取和安装，不覆盖模型等待。
@@ -703,6 +707,7 @@ async def project(
             groups = await _unapplied_groups(
                 record, lookup, reader, store, sources, projection,
                 compaction=compaction, post_commit_effect=post_commit_effect,
+                summary_range=context.summary_range,
             )
             if not groups:
                 return
@@ -727,6 +732,7 @@ async def project(
 
 async def apply(ctx: Context, config: Config) -> None:
     """启动后才创建文件与跟随日志；归档 apply 不写入正式记忆。"""
+    context = ctx.require(CONTEXT)
     store: MarkdownProfileStore | None = None
     watcher: asyncio.Task[None] | None = None
     lock_path = ctx.workspace_file("memory/markdown-profile.lock")
@@ -777,11 +783,12 @@ async def apply(ctx: Context, config: Config) -> None:
                             )
                             for message in messages:
                                 try:
+                                    compaction = ctx.get(COMPACTION_READER)
                                     await project(message, reader=reader, bindings=ctx.require(BINDINGS),
                                                   store=store, models=ctx.require(CHAT_MODELS), lock_path=lock_path,
                                     sources=config.sources, projection=ctx.require(TURN_PROJECTION),
                                     content=ctx.require(CONTENT),
-                                    compaction=ctx.require(COMPACTION_READER))
+                                    context=context, compaction=compaction)
                                 except ModelError as error:
                                     if not error.retryable:
                                         raise

--- a/tests/test_akasha_message_plugin.py
+++ b/tests/test_akasha_message_plugin.py
@@ -111,14 +111,14 @@ async def test_actual_plugin_learns_provides_materials_and_runs_archived_recall_
                 inputs.append("q", Input((ContentPart("text", "remember the detail"),)))
                 async with ctx.require(MATERIALS).bind() as materials:
                     material = await materials.prepare(log.reader("s").snapshot(), "conversation")
-                assert [ref.ref for ref in material.references] == ["u", "a"]
+                assert [ref["ref"] for ref in material["references"]] == ["u", "a"]
                 # 普通兴趣服务只嵌入候选，复用真实已完成问答的固定向量。
                 before_interest = (tmp_path / "embedding-calls.txt").read_text()
                 interest = ctx.require(ServiceKey("akasha.semantic-interest.v1"))
                 assert await interest.score(["candidate interest", ""], cutoff=datetime.now(timezone.utc).isoformat()) == (0.999, 0.0)
                 assert (tmp_path / "embedding-calls.txt").read_text()[len(before_interest):] == "['candidate interest']\n"
                 read_recall = ctx.require(ServiceKey("akasha.recalls.v1"))
-                observed = read_recall(material.references[0].retrieval_ref)
+                observed = read_recall(material["references"][0]["retrieval_ref"])
                 assert observed.graph_version == 1
                 # 显式归档材料查询不争抢仍在运行的正式学习 writer。
                 from plugins.akasha.infrastructure.lease import WriterLease
@@ -132,7 +132,7 @@ async def test_actual_plugin_learns_provides_materials_and_runs_archived_recall_
                 async with host.open_binding(tuple(archive_refs)) as archived:
                     async with archived.require(MATERIALS).bind() as view:
                         copied = await view.prepare(log.reader("s").snapshot(), "conversation")
-                    assert [ref.ref for ref in copied.references] == ["u", "a"]
+                    assert [ref["ref"] for ref in copied["references"]] == ["u", "a"]
                 assert logical_state_sha256(graph) == before_graph
                 with pytest.raises(RuntimeError, match="already has a writer"):
                     WriterLease(graph)
@@ -200,7 +200,7 @@ async def test_prepared_recall_survives_config_change_and_source_removal(tmp_pat
                 inputs.append("q", Input((ContentPart("text", "recall it"),)))
                 async with ctx.require(MATERIALS).bind() as materials:
                     result = await materials.prepare(log.reader("s").snapshot(), "conversation")
-                assert [reference.ref for reference in result.references] == ["u", "a"]
+                    assert [reference["ref"] for reference in result["references"]] == ["u", "a"]
                 async with open_tool(bindings, identity) as tool:
                     prepared = await tool.prepare({"query": "original memory"})
 
@@ -340,7 +340,7 @@ async def test_mobile_inspector_bounds_long_messages_without_dropping_hit_member
                 inputs.append("query", Input((ContentPart("text", "recall it"),)))
                 async with ctx.require(MATERIALS).bind() as materials:
                     prepared = await materials.prepare(log.reader("s").snapshot(), "conversation")
-                identity = prepared.references[0].retrieval_ref
+                    identity = prepared["references"][0]["retrieval_ref"]
         provider = PluginMobileUiProvider(host)
         try:
             detail = await provider.query("akasha", revision, "inspector.detail", {"query_id": identity},

--- a/tests/test_akasha_message_plugin.py
+++ b/tests/test_akasha_message_plugin.py
@@ -157,14 +157,15 @@ async def test_actual_plugin_learns_provides_materials_and_runs_archived_recall_
                 assert recalled.source.call_ref == ref
                 assert recalled.graph_version == 1
                 before = (tmp_path / "embedding-calls.txt").read_text()
-                assert await execution.execute_call(reply) == result
+                replayed = await execution.execute_call(reply)
+                assert (replayed.outcome, replayed.parts) == (result.outcome, result.parts)
                 assert (tmp_path / "embedding-calls.txt").read_text() == before
                 assert len([message for message in log.reader("s").snapshot()
                             if isinstance(message.body, ToolResult)]) == 1
                 async with ctx.require(MATERIALS).bind() as materials:
                     after_tool = await materials.prepare(log.reader("s").snapshot(), "conversation")
-                assert [reference.ref for reference in after_tool.references] == ["u", "a"]
-                assert {reference.retrieval_ref for reference in after_tool.references} == {retrieval_ref}
+                assert [reference["ref"] for reference in after_tool["references"]] == ["u", "a"]
+                assert {reference["retrieval_ref"] for reference in after_tool["references"]} == {retrieval_ref}
                 # 同 owner 的另一条调用也不能借用先前 CallRef 的查询事实。
                 outputs.append("forged-request", Output((ToolCall(identity, {"query": "another query"}),), "continue"))
                 forged_ref = CallRef("forged-request", 0)

--- a/tests/test_message_compaction_records.py
+++ b/tests/test_message_compaction_records.py
@@ -6,6 +6,7 @@ import pytest
 
 from plugins.compaction.records import ImportedSummaryRecord, LegacySummarySource, SummaryLookup, SummaryRecord, SummaryRecords
 from plugins.content.plugin import check_text
+from plugins.context.plugin import ContextBuilder
 from session.log import MessageConflict, MessageLog, OwnerTransaction
 from session.message import ContentPart, Input
 
@@ -67,17 +68,17 @@ def test_summary_publication_is_create_only_and_stale_parent_cannot_win_after_re
         inputs(log)
         records = SummaryRecords(log.owner("compaction"))
         original = log.reader("s").snapshot()
-        first = records.publish(record("first"), log.reader("s"), parent=None)
-        second = records.publish(record("second", parent=first, ids=("u1", "u2")), log.reader("s"), parent=first)
-        assert records.publish(first, log.reader("s"), parent=None) == first
+        first = records.publish(record("first"), log.reader("s"), parent=None, summary_range=ContextBuilder.summary_range)
+        second = records.publish(record("second", parent=first, ids=("u1", "u2")), log.reader("s"), parent=first, summary_range=ContextBuilder.summary_range)
+        assert records.publish(first, log.reader("s"), parent=None, summary_range=ContextBuilder.summary_range) == first
         assert records.head("s") == second
         with pytest.raises(ValueError, match="漂移"):
-            records.publish(first.model_copy(update={"content": "overwritten"}), log.reader("s"), parent=None)
+            records.publish(first.model_copy(update={"content": "overwritten"}), log.reader("s"), parent=None, summary_range=ContextBuilder.summary_range)
         assert log.reader("s").snapshot() == original
     with closing(MessageLog(path)) as log:
         records = SummaryRecords(log.owner("compaction"))
         with pytest.raises(MessageConflict, match="parent"):
-            records.publish(record("loser", parent=first, ids=("u1", "u2")), log.reader("s"), parent=first)
+            records.publish(record("loser", parent=first, ids=("u1", "u2")), log.reader("s"), parent=first, summary_range=ContextBuilder.summary_range)
         assert records.read("loser") is None
         assert records.head("s") == second and records.read("first") == first
         assert log.reader("s").snapshot() == original
@@ -100,7 +101,7 @@ def test_imported_head_keeps_exact_legacy_row_and_accepts_native_child(tmp_path)
                             content={"text": check_text})
         writer.append("u3", Input((ContentPart("text", "third input"),)))
         native = records.publish(record("new-5", parent=head, ids=("u1", "u2", "u3")),
-                                 log.reader("s"), parent=head)
+                                 log.reader("s"), parent=head, summary_range=ContextBuilder.summary_range)
         assert native.generation == 5
         assert records.head("s") == native
 
@@ -120,9 +121,9 @@ def test_failed_head_update_rolls_back_new_summary_and_rejects_wrong_source(tmp_
     with closing(MessageLog(tmp_path / "sessions.db")) as log:
         inputs(log)
         records = SummaryRecords(log.owner("compaction"))
-        first = records.publish(record("first"), log.reader("s"), parent=None)
+        first = records.publish(record("first"), log.reader("s"), parent=None, summary_range=ContextBuilder.summary_range)
         with pytest.raises(ValueError, match="范围"):
-            records.publish(record("wrong", parent=first, ids=("u1", "missing")), log.reader("s"), parent=first)
+            records.publish(record("wrong", parent=first, ids=("u1", "missing")), log.reader("s"), parent=first, summary_range=ContextBuilder.summary_range)
         assert records.read("wrong") is None
         save = OwnerTransaction.save
         def fail_head(self, key, value, *, expected_version):
@@ -131,7 +132,7 @@ def test_failed_head_update_rolls_back_new_summary_and_rejects_wrong_source(tmp_
             return save(self, key, value, expected_version=expected_version)
         monkeypatch.setattr(OwnerTransaction, "save", fail_head)
         with pytest.raises(OSError, match="write failure"):
-            records.publish(record("next", parent=first, ids=("u1", "u2")), log.reader("s"), parent=first)
+            records.publish(record("next", parent=first, ids=("u1", "u2")), log.reader("s"), parent=first, summary_range=ContextBuilder.summary_range)
         assert records.head("s") == first
         assert records.read("next") is None
 
@@ -142,11 +143,11 @@ def test_summary_keeps_recent_start_and_only_extends_its_actual_range(tmp_path):
         writer = log.writer("s", author="user", source="conversation", body_types=(Input,), content={"text": check_text})
         writer.append("u3", Input((ContentPart("text", "third"),)))
         records = SummaryRecords(log.owner("compaction"))
-        first = records.publish(record("recent", ids=("u2",)), log.reader("s"), parent=None)
+        first = records.publish(record("recent", ids=("u2",)), log.reader("s"), parent=None, summary_range=ContextBuilder.summary_range)
         for ids in (("u1", "u2", "u3"), ("u2",)):
             with pytest.raises(ValueError, match="来源"):
-                records.publish(record("bad", parent=first, ids=ids), log.reader("s"), parent=first)
-        second = records.publish(record("extended", parent=first, ids=("u2", "u3")), log.reader("s"), parent=first)
+                records.publish(record("bad", parent=first, ids=ids), log.reader("s"), parent=first, summary_range=ContextBuilder.summary_range)
+        second = records.publish(record("extended", parent=first, ids=("u2", "u3")), log.reader("s"), parent=first, summary_range=ContextBuilder.summary_range)
         assert records.head("s") == second
         assert log.reader("s").get("u1").body.parts[0].value == "first original input"
 
@@ -202,7 +203,7 @@ async def apply(ctx, config):
             ctx = snapshot.composition_root.context
             async with ctx.require(MATERIALS).bind() as view:
                 prepared = await view.prepare(log.reader("s").snapshot(), "conversation")
-            reference = prepared.summary.reference
+                reference = prepared["summary"]["reference"]
             metadata = ctx.require(BINDINGS).describe(reference, COMPACTION_SUMMARIES)
             assert metadata == {"record_ref": "first", "session_id": "s"}
         writer = log.writer("s", author="assistant", source="conversation", body_types=(Output,),
@@ -212,7 +213,7 @@ async def apply(ctx, config):
         with pytest.raises(PermissionError):
             log.writer("s", author="user", source="conversation", body_types=(Input,),
                        content={"text": check_text}).append("forged", Input((used,)))
-        records.publish(record("second", parent=first, ids=("u1", "u2")), log.reader("s"), parent=first)
+        records.publish(record("second", parent=first, ids=("u1", "u2")), log.reader("s"), parent=first, summary_range=ContextBuilder.summary_range)
     finally:
         await host.terminate_all()
         log.close()

--- a/tests/test_message_compaction_summary.py
+++ b/tests/test_message_compaction_summary.py
@@ -8,6 +8,7 @@ from agent.plugin_composition.models import (
     LLMResponse, ModelCapabilities, ModelRequest, ModelRole, RateLimitError,
 )
 from plugins.compaction.message_summary import HEADINGS, SummaryError, closed_groups, summarize, summary_groups, window_starts
+from plugins.context.plugin import ContextBuilder
 from plugins.turn_projection.plugin import TurnProjection
 from plugins.models.state import _BoundChat
 from plugins.models.store import ModelsStore
@@ -52,8 +53,8 @@ def test_closed_prefix_never_splits_interleaved_sources_or_tool_batches():
         message(6, ToolResult(CallRef("1", 1), "success", ())),
         message(7, Input((ContentPart("text", "unanswered tail"),))),
     )
-    assert closed_groups(rows[:6], TurnProjection()) == ()
-    assert closed_groups(rows, TurnProjection()) == (rows[:7],)
+    assert closed_groups(rows[:6], TurnProjection(), settled_prefixes=ContextBuilder.settled_prefixes) == ()
+    assert closed_groups(rows, TurnProjection(), settled_prefixes=ContextBuilder.settled_prefixes) == (rows[:7],)
 
 
 def test_completed_turns_merge_overlapping_sources_but_open_batches_can_compact():
@@ -69,10 +70,10 @@ def test_completed_turns_merge_overlapping_sources_but_open_batches_can_compact(
         message(8, ToolResult(CallRef("7", 0), "success", ())),
     )
     projection = TurnProjection()
-    assert closed_groups(rows, projection) == (rows[:6], rows[6:])
-    assert window_starts(rows, projection) == (0, 6)
+    assert closed_groups(rows, projection, settled_prefixes=ContextBuilder.settled_prefixes) == (rows[:6], rows[6:])
+    assert window_starts(rows, projection, settled_prefixes=ContextBuilder.settled_prefixes) == (0, 6)
     # 先前摘要可能在当时的 open batch 后结束；本代只继续其实际剩余区间。
-    assert closed_groups(rows, projection, after=3) == (rows[3:6], rows[6:])
+    assert closed_groups(rows, projection, settled_prefixes=ContextBuilder.settled_prefixes, after=3) == (rows[3:6], rows[6:])
 
 
 @pytest.mark.parametrize("late_result", [False, True])
@@ -94,7 +95,7 @@ def test_abandon_closes_summary_prefix_without_inventing_a_tool_result(tmp_path,
         *((message(4, ToolResult(CallRef("1", 0), "success", (ContentPart("text", "late fact"),))),)
           if late_result else ()),
     )
-    assert closed_groups(rows, TurnProjection())[0] == rows[:3]
+    assert closed_groups(rows, TurnProjection(), settled_prefixes=ContextBuilder.settled_prefixes)[0] == rows[:3]
     projection = MessageProjection(provider, check_summary=_model_summary_check, source="conversation", read_call=store.read_call,
         render_content=lambda part: render_content(part, artifacts={}), tool_name=lambda binding: "old-tool",
         keep_input_ids=("3",))
@@ -128,7 +129,8 @@ async def test_summary_provider_excludes_late_abandoned_result_across_generation
         message(7, Output((ContentPart("text", "new answer"),), "complete")),
     )
     original = tuple(rows)
-    groups = closed_groups(rows, TurnProjection(), after=3 if prior_summary else 0)
+    groups = closed_groups(rows, TurnProjection(), settled_prefixes=ContextBuilder.settled_prefixes,
+                           after=3 if prior_summary else 0)
     _, calls = await summarize(summary_groups(groups, rows), previous=summary_text() if prior_summary else "",
                                model=provider, fallback=provider)
     assert "late excluded fact" not in str(requests)

--- a/tests/test_message_markdown_memory.py
+++ b/tests/test_message_markdown_memory.py
@@ -12,9 +12,12 @@ from agent.plugins.manager import PluginManager
 from agent.plugins.snapshot import lease_runtime_snapshot
 from bus.event_bus import EventBus
 from plugins.compaction.records import COMPACTION_SUMMARIES, SummaryRecord, SummaryRecords
+from plugins.content.api import is_user_input
 from plugins.content.plugin import check_text
 from plugins.context.api import check_summary
+from plugins.context.plugin import ContextBuilder
 from plugins.context.materials import MATERIALS
+from plugins.markdown_memory._boundaries import COMPACTION_READER, CONTENT, CONTEXT
 from plugins.turn_projection.plugin import TURN_PROJECTION
 from plugins.markdown_memory.store import MarkdownProfileStore
 from session.log import MessageLog, SessionAttributes
@@ -25,7 +28,7 @@ from session.message import ContentPart, Input, Output
 async def application(tmp_path, *, start=False, transient_failure=False, draft_failures=0):
     sources = tmp_path / "plugins"
     if not sources.exists():
-        for name in ("context", "compaction", "markdown_memory", "turn_projection"):
+        for name in ("content", "context", "compaction", "markdown_memory", "turn_projection"):
             shutil.copytree(Path(__file__).parents[1] / "plugins" / name, sources / name,
                             ignore=shutil.ignore_patterns("__pycache__"))
         for name in ("compaction", "markdown_memory"):
@@ -174,7 +177,7 @@ async def test_excluded_session_never_reaches_markdown_even_when_source_is_allow
             store = profile_store(tmp_path)
             await project(used, reader=log.reader("s"), bindings=ctx.require(BINDINGS), store=store,
                 models=ctx.require(CHAT_MODELS), lock_path=tmp_path / "workspace/memory/markdown-profile.lock",
-                sources=("conversation",), projection=ctx.require(TURN_PROJECTION))
+                sources=("conversation",), projection=ctx.require(TURN_PROJECTION), content=ctx.require(CONTENT), context=ctx.require(CONTEXT), compaction=ctx.require(COMPACTION_READER))
             assert not (tmp_path / "requests.jsonl").exists()
             assert not store.is_applied(summary.reference)
             assert log.reader("s").get("input").body.parts[0].value == "fact-one"
@@ -198,7 +201,7 @@ async def test_legacy_suppress_excludes_whole_turn_but_keeps_later_allowed_facts
             async def consume(message):
                 await project(message, reader=log.reader("s"), bindings=ctx.require(BINDINGS), store=store,
                     models=ctx.require(CHAT_MODELS), lock_path=tmp_path / "workspace/memory/markdown-profile.lock",
-                    sources=Config().sources, projection=ctx.require(TURN_PROJECTION))
+                    sources=Config().sources, projection=ctx.require(TURN_PROJECTION), content=ctx.require(CONTENT), context=ctx.require(CONTEXT), compaction=ctx.require(COMPACTION_READER))
             await consume(use)
             assert not (tmp_path / "requests.jsonl").exists()
             assert not store.is_applied(suppressed.reference)
@@ -239,7 +242,7 @@ async def test_markdown_does_not_reintroduce_abandoned_late_result_from_raw_rang
             store = profile_store(tmp_path)
             await project(used, reader=log.reader("s"), bindings=ctx.require(BINDINGS), store=store,
                 models=ctx.require(CHAT_MODELS), lock_path=tmp_path / "workspace/memory/markdown-profile.lock",
-                sources=("conversation",), projection=ctx.require(TURN_PROJECTION))
+                sources=("conversation",), projection=ctx.require(TURN_PROJECTION), content=ctx.require(CONTENT), context=ctx.require(CONTEXT), compaction=ctx.require(COMPACTION_READER))
             assert "fact-two" not in (tmp_path / "requests.jsonl").read_text()
             assert "fact-three" in store.read_memory()
             assert store.is_applied(child.reference)
@@ -268,7 +271,9 @@ def publish(log, reference, parent=None):
         source_message_ids=tuple(message.message_id for message in log.reader("s").snapshot()),
         content="actual summary", model_call_ids=("summary-model:" + reference,), trigger="soft_limit",
         context_window=32000, max_output_tokens=4096, keep_recent_tokens=20000, tokens_before=27000, tokens_after=18000)
-    return SummaryRecords(log.owner("plugin:compaction")).publish(record, log.reader("s"), parent=parent)
+    return SummaryRecords(log.owner("plugin:compaction")).publish(
+        record, log.reader("s"), parent=parent, summary_range=ContextBuilder.summary_range,
+    )
 
 
 async def record_use(
@@ -316,7 +321,7 @@ async def test_markdown_replays_output_after_restart_and_does_not_skip_unused_pa
         async with lease_runtime_snapshot(host.snapshot_store) as snapshot:
             async with snapshot.composition_root.context.require(MATERIALS).bind() as materials:
                 prepared = await materials.prepare(log.reader("s").snapshot(), "conversation")
-            assert "fact-two" in prepared.system_prompt
+                assert "fact-two" in prepared["system_prompt"]
         await record_use(log, host, used, "duplicate-use", "complete")
     async with application(tmp_path, start=True) as (log, host):
         await wait_applied(tmp_path, host, used.reference)
@@ -329,7 +334,7 @@ async def test_markdown_replays_output_after_restart_and_does_not_skip_unused_pa
             assert message is not None
             await project(message, reader=log.reader("s"), bindings=ctx.require(BINDINGS),
                           store=profile_store(tmp_path), models=ctx.require(CHAT_MODELS),
-                          lock_path=tmp_path / "workspace/memory/markdown-profile.lock", sources=("conversation",), projection=ctx.require(TURN_PROJECTION))
+                          lock_path=tmp_path / "workspace/memory/markdown-profile.lock", sources=("conversation",), projection=ctx.require(TURN_PROJECTION), content=ctx.require(CONTENT), context=ctx.require(CONTEXT), compaction=ctx.require(COMPACTION_READER))
         assert len((tmp_path / "requests.jsonl").read_text().splitlines()) == 1
 
 
@@ -360,7 +365,7 @@ async def test_restart_finishes_saved_draft_after_only_memory_file_was_applied(t
             with pytest.raises(OSError, match="second document failure"):
                 await project(used, reader=log.reader("s"), bindings=ctx.require(BINDINGS), store=store,
                     models=ctx.require(CHAT_MODELS), lock_path=tmp_path / "workspace/memory/markdown-profile.lock",
-                    sources=("conversation",), projection=ctx.require(TURN_PROJECTION))
+                    sources=("conversation",), projection=ctx.require(TURN_PROJECTION), content=ctx.require(CONTENT), context=ctx.require(CONTEXT), compaction=ctx.require(COMPACTION_READER))
         assert not store.is_applied(record.reference)
         assert "fact-one" in store.read_memory()
         assert store.read_self() == before_self
@@ -406,7 +411,7 @@ async def test_delayed_parent_output_cannot_reapply_older_facts_after_child(tmp_
             for message in (first, late):
                 await project(message, reader=log.reader("s"), bindings=ctx.require(BINDINGS), store=store,
                               models=ctx.require(CHAT_MODELS), lock_path=tmp_path / "workspace/memory/markdown-profile.lock",
-                              sources=("conversation",), projection=ctx.require(TURN_PROJECTION))
+                              sources=("conversation",), projection=ctx.require(TURN_PROJECTION), content=ctx.require(CONTENT), context=ctx.require(CONTEXT), compaction=ctx.require(COMPACTION_READER))
         assert store.latest_applied("s") == (child.reference, child.generation)
         assert store.is_applied(child.reference) and not store.is_applied(parent.reference)
         assert len((tmp_path / "requests.jsonl").read_text().splitlines()) == 1
@@ -432,7 +437,7 @@ async def test_restart_repairs_partial_sqlite_preparation_without_recomputing_mo
             ctx = snapshot.composition_root.context
             with pytest.raises(OSError, match="partial preparation"):
                 await project(used, reader=log.reader("s"), bindings=ctx.require(BINDINGS), store=store,
-                    models=ctx.require(CHAT_MODELS), lock_path=tmp_path / "workspace/memory/markdown-profile.lock", sources=("conversation",), projection=ctx.require(TURN_PROJECTION))
+                    models=ctx.require(CHAT_MODELS), lock_path=tmp_path / "workspace/memory/markdown-profile.lock", sources=("conversation",), projection=ctx.require(TURN_PROJECTION), content=ctx.require(CONTENT), context=ctx.require(CONTEXT), compaction=ctx.require(COMPACTION_READER))
         assert store.read_draft(record.reference) is not None
         assert not store.is_applied(record.reference)
     async with application(tmp_path, start=True) as (log, host):
@@ -442,7 +447,7 @@ async def test_restart_repairs_partial_sqlite_preparation_without_recomputing_mo
             message = log.reader("s").get("used")
             assert message is not None
             await project(message, reader=log.reader("s"), bindings=ctx.require(BINDINGS), store=store,
-                          models=ctx.require(CHAT_MODELS), lock_path=tmp_path / "workspace/memory/markdown-profile.lock", sources=("conversation",), projection=ctx.require(TURN_PROJECTION))
+                          models=ctx.require(CHAT_MODELS), lock_path=tmp_path / "workspace/memory/markdown-profile.lock", sources=("conversation",), projection=ctx.require(TURN_PROJECTION), content=ctx.require(CONTENT), context=ctx.require(CONTEXT), compaction=ctx.require(COMPACTION_READER))
         assert store.is_applied(record.reference)
         assert store.latest_applied("s") == (record.reference, record.generation)
         assert "fact-one" in store.read_memory()
@@ -517,7 +522,7 @@ async def test_profile_model_work_keeps_materials_readable_and_updates_serial(tm
                 ctx = snapshot.composition_root.context
                 await plugin.project(used, reader=log.reader("s"), bindings=ctx.require(BINDINGS), store=store,
                     models=ctx.require(CHAT_MODELS), lock_path=tmp_path / "workspace/memory/markdown-profile.lock",
-                    sources=("conversation",), projection=ctx.require(TURN_PROJECTION))
+                    sources=("conversation",), projection=ctx.require(TURN_PROJECTION), content=ctx.require(CONTENT), context=ctx.require(CONTEXT), compaction=ctx.require(COMPACTION_READER))
 
         monkeypatch.setattr(plugin, "prepare_profile_draft", paused_prepare)
         first = asyncio.create_task(update())
@@ -540,8 +545,8 @@ async def test_profile_model_work_keeps_materials_readable_and_updates_serial(tm
             async with lease_runtime_snapshot(host.snapshot_store) as snapshot:
                 async with snapshot.composition_root.context.require(MATERIALS).bind() as materials:
                     prepared = await asyncio.wait_for(materials.prepare((), "conversation"), 1)
-            assert before[1].strip() in prepared.system_prompt
-            assert "fact-one" not in prepared.system_prompt
+                assert before[1].strip() in prepared["system_prompt"]
+                assert "fact-one" not in prepared["system_prompt"]
             assert (store.read_memory(), store.read_self(), store.read_writes(None, 100)) == before
             if cancel_first:
                 first.cancel()
@@ -587,7 +592,7 @@ async def test_an_update_lock_alone_does_not_create_a_partial_profile_state(tmp_
         async with lease_runtime_snapshot(host.snapshot_store) as snapshot:
             async with snapshot.composition_root.context.require(MATERIALS).bind() as materials:
                 prepared = await materials.prepare((), "conversation")
-        assert "# Akashic 的自我认知" in prepared.system_prompt
+        assert "# Akashic 的自我认知" in prepared["system_prompt"]
         assert tuple(path.parent.iterdir()) == (path,)
 
 
@@ -609,7 +614,7 @@ async def test_default_markdown_uses_programmatic_admission_for_real_summary_pro
             store = profile_store(tmp_path)
             await project(used, reader=log.reader("s"), bindings=ctx.require(BINDINGS), store=store,
                 models=ctx.require(CHAT_MODELS), lock_path=tmp_path / "workspace/memory/markdown-profile.lock",
-                sources=Config().sources, projection=ctx.require(TURN_PROJECTION))
+                sources=Config().sources, projection=ctx.require(TURN_PROJECTION), content=ctx.require(CONTENT), context=ctx.require(CONTEXT), compaction=ctx.require(COMPACTION_READER))
             assert store.is_applied(summary.reference) is (learning == "eligible")
             assert (tmp_path / "requests.jsonl").exists() is (learning == "eligible")
         assert log.reader("s").get("input").body.parts[0].value == "fact-one"
@@ -632,7 +637,7 @@ def test_new_user_fact_cannot_use_an_assistant_or_background_claim(tmp_path, evi
         draft = {"memory_before": before, "memory": before + "- 用户喜欢红色\n", "self_before": "", "self": "",
                  "evidence": {"memory": {"- 用户喜欢红色": [evidence_id]}, "self": {}}}
         with pytest.raises(ValueError, match="用户事实|实际消息"):
-            check_evidence(draft, log.reader("s").snapshot())
+            check_evidence(draft, log.reader("s").snapshot(), is_user_input=is_user_input)
         assert len(log.reader("s").snapshot()) == 3
     finally:
         log.close()
@@ -647,7 +652,7 @@ def test_moving_an_operation_note_into_user_facts_requires_new_evidence():
              "memory": headings + "- 红色主题\n## 助手操作上下文\n",
              "self_before": "", "self": "", "evidence": {"memory": {}, "self": {}}}
     with pytest.raises(ValueError, match="实际消息"):
-        check_evidence(draft, ())
+        check_evidence(draft, (), is_user_input=is_user_input)
 
 
 @pytest.mark.asyncio
@@ -747,7 +752,7 @@ async def test_profile_input_omits_large_legacy_replay_but_preserves_user_eviden
             store = profile_store(tmp_path)
             await project(used, reader=log.reader("s"), bindings=ctx.require(BINDINGS), store=store,
                 models=ctx.require(CHAT_MODELS), lock_path=tmp_path / "workspace/memory/markdown-profile.lock",
-                sources=("legacy-unattributed",), projection=ctx.require(TURN_PROJECTION))
+                sources=("legacy-unattributed",), projection=ctx.require(TURN_PROJECTION), content=ctx.require(CONTENT), context=ctx.require(CONTEXT), compaction=ctx.require(COMPACTION_READER))
         prompts = (tmp_path / "requests.jsonl").read_text()
         request = json.loads(prompts.splitlines()[0])
         rows = json.loads(request.split("本次精确来源：\n", 1)[1])
@@ -767,6 +772,7 @@ async def test_profile_batches_keep_whole_turns_and_write_only_after_all_succeed
     import json
     from types import SimpleNamespace
     from plugins.markdown_memory.message_plugin import prepare_profile_draft
+    from plugins.compaction.message_plugin import _CompactionReader
     from plugins.compaction.message_summary import closed_groups
     from plugins.turn_projection.plugin import TurnProjection
     from agent.plugin_composition.models import ChatModels, LLMResponse, TransportError
@@ -779,7 +785,8 @@ async def test_profile_batches_keep_whole_turns_and_write_only_after_all_succeed
             writer.append(f"step-{index}", Output((ContentPart("text", "continue"),), "continue"))
             writer.append(f"answer-{index}", Output((ContentPart("text", "done"),), "complete"))
         original = log.reader("s").snapshot()
-        groups = closed_groups(original, TurnProjection())
+        groups = closed_groups(original, TurnProjection(), settled_prefixes=ContextBuilder.settled_prefixes)
+        compaction = _CompactionReader(settled_prefixes=ContextBuilder.settled_prefixes)
         store = profile_store(tmp_path)
         if large_profile:
             (tmp_path / "workspace/memory/MEMORY.md").write_text(
@@ -812,9 +819,15 @@ async def test_profile_batches_keep_whole_turns_and_write_only_after_all_succeed
         models = cast(ChatModels, SimpleNamespace(independent_execution=execution))
         if fail_second:
             with pytest.raises(TransportError, match="second batch"):
-                await prepare_profile_draft(groups, before[0], before[1], models)
+                await prepare_profile_draft(
+                    groups, before[0], before[1], models,
+                    compaction=compaction, is_user_input=is_user_input,
+                )
         else:
-            draft = await prepare_profile_draft(groups, before[0], before[1], models)
+            draft = await prepare_profile_draft(
+                groups, before[0], before[1], models,
+                compaction=compaction, is_user_input=is_user_input,
+            )
             assert draft["memory_before"] == before[0]
             assert isinstance(draft["memory"], str)
             assert "- fact-0" in draft["memory"] and "- fact-1" in draft["memory"]
@@ -853,7 +866,7 @@ async def test_profile_keeps_allowed_turn_inside_mixed_source_group(tmp_path):
             store = profile_store(tmp_path)
             await project(used, reader=log.reader("s"), bindings=ctx.require(BINDINGS), store=store,
                 models=ctx.require(CHAT_MODELS), lock_path=tmp_path / "workspace/memory/markdown-profile.lock",
-                sources=Config().sources, projection=ctx.require(TURN_PROJECTION))
+                sources=Config().sources, projection=ctx.require(TURN_PROJECTION), content=ctx.require(CONTENT), context=ctx.require(CONTEXT), compaction=ctx.require(COMPACTION_READER))
         prompt = (tmp_path / "requests.jsonl").read_text()
         assert "fact-one" not in prompt and "fact-two" not in prompt
         assert "fact-three" in store.read_memory() and store.is_applied(summary.reference)
@@ -917,9 +930,11 @@ def test_profile_additions_preserve_owner_files_and_enforce_evidence(tmp_path, c
         response = LLMResponse(json.dumps({"additions": additions}), finish_reason="length" if case == "truncated" else "stop")
         if case not in {"no_change", "new_fact", "empty_memory", "self"}:
             with pytest.raises(ValueError):
-                _check_profile_response(response, log.reader("s").snapshot(), memory, before_self)
+                _check_profile_response(response, log.reader("s").snapshot(), memory, before_self,
+                                         is_user_input=is_user_input)
         else:
-            draft = _check_profile_response(response, log.reader("s").snapshot(), memory, before_self)
+            draft = _check_profile_response(response, log.reader("s").snapshot(), memory, before_self,
+                                            is_user_input=is_user_input)
             assert draft["self_before"] == before_self
             assert draft["memory_before"] == memory
             if case == "no_change":
@@ -965,5 +980,6 @@ def test_profile_rejects_invalid_model_additions_before_building_a_durable_draft
     else:
         additions.append(entry)
     with pytest.raises(_InvalidDraft):
-        _check_profile_response(LLMResponse(json.dumps(payload)), (), before[0], before[1])
+        _check_profile_response(LLMResponse(json.dumps(payload)), (), before[0], before[1],
+                                   is_user_input=is_user_input)
     assert (store.read_memory(), store.read_self(), store.read_writes(None, 10)) == before


### PR DESCRIPTION
Context 提供原摘要范围和工具结算前缀算法，Compaction 与 Markdown 删除局部复制实现并通过回调消费。Markdown 的只读材料组合可不安装 Compaction，真正学习摘要时缺少读取能力明确失败。Akasha 的工具召回引用按 Mapping 继续传播，修复真实调用后准备材料时的属性访问错误。

基于 #614。摘要仍在原事务中核对真实消息，原 Message、摘要来源、学习资格和回执不变；不写正式 workspace。恢复点：3bef8c89，副手修改前已备份，源码可逐层 revert。

验证：记忆相关组合 74 项通过，修复后的完整 Akasha Message 链路 6 项通过（包含重放无重复向量调用、原归档恢复与材料出处）；定向类型检查 0 errors；边界 R1=32、R2=55、R3=0。

继续下一层实施；完整 Gate、CI、累计概念审查及全部外部组合验收尚未完成，不构成合并结论。