### PR TITLE
feat: Dashboard 按请求租约读取声明能力

### DIFF
--- a/agent/plugin_composition/dashboard.py
+++ b/agent/plugin_composition/dashboard.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import MappingProxyType
+from typing import cast
 
-from agent.plugin_composition.model import CompositionError
+from agent.plugin_composition.model import CompositionError, ServiceKey
 
 
 @dataclass(frozen=True, slots=True)
@@ -28,6 +29,14 @@ class DashboardContext:
         default_factory=lambda: MappingProxyType({}),
         repr=False,
     )
+
+    _resolve: Callable[[ServiceKey[object]], object] | None = field(default=None, repr=False)
+
+    def require[T](self, key: ServiceKey[T]) -> T:
+        """在 async 路由的当前请求租约内取得声明能力，不暴露宿主 Root。"""
+        if self._resolve is None:
+            raise CompositionError("DASHBOARD_SCOPE_MISSING", "Dashboard 没有请求能力入口")
+        return cast(T, self._resolve(cast(ServiceKey[object], key)))
 
     def workspace_root(self, name: str) -> Path:
         """返回与当前 Dashboard generation 相同的声明式 workspace root。"""

--- a/agent/plugins/dashboard_host.py
+++ b/agent/plugins/dashboard_host.py
@@ -30,6 +30,7 @@ from starlette.routing import Match, WebSocketRoute
 from agent.plugin_composition import DashboardContext
 from agent.plugin_composition.diagnostics import plugin_entrypoint
 from agent.plugin_composition.model import (
+    CompositionError, ServiceKey,
     resolve_declared_workspace_file,
     resolve_declared_workspace_root,
 )
@@ -40,6 +41,7 @@ from agent.plugins.snapshot import (
     RuntimeSnapshot,
     RuntimeSnapshotStore,
     bind_runtime_snapshot,
+    get_current_runtime_snapshot,
     reset_runtime_snapshot,
 )
 
@@ -262,11 +264,30 @@ class PluginDashboardHost:
             enabled = getattr(module, "plugin_enabled", None)
             if enabled is not None and not callable(enabled):
                 raise RuntimeError("v3 dashboard plugin_enabled 必须是可调用对象")
+            dependencies = getattr(module, "inject", ())
+            if (not isinstance(dependencies, tuple)
+                    or any(not isinstance(key, ServiceKey) for key in dependencies)
+                    or len(set(dependencies)) != len(dependencies)):
+                raise ValueError("Dashboard inject 必须是不重复的 ServiceKey tuple")
+
+            def resolve(key: ServiceKey[object]) -> object:
+                """只在路由实际租约内解析声明能力，旧 Dashboard 不能借新 generation。"""
+                if key not in dependencies:
+                    raise CompositionError("SERVICE_UNDECLARED", f"Dashboard 未声明能力: {key.name}")
+                snapshot = get_current_runtime_snapshot()
+                if snapshot is None or snapshot.composition_root is None:
+                    raise CompositionError("DASHBOARD_SCOPE_MISSING", "Dashboard 能力需要实际请求租约")
+                current = snapshot.generations.get(generation.plugin_id)
+                if current is None or current.generation_id != generation.generation_id:
+                    raise CompositionError("DASHBOARD_GENERATION_MISMATCH", "Dashboard 不属于当前请求 generation")
+                return snapshot.composition_root.context.require(key)
+
             dashboard_context = DashboardContext(
                 plugin_id=generation.plugin_id,
                 plugin_dir=module_path.parent,
                 data_root=data_root,
                 validation=validation,
+                _resolve=resolve,
                 _workspace_roots=tuple(
                     (name, resolve_declared_workspace_root(workspace, name))
                     for name in workspace_roots

--- a/docs/design/plugin-boundary-foundation.md
+++ b/docs/design/plugin-boundary-foundation.md
@@ -387,3 +387,24 @@ Context 提供已有摘要校验、连续来源范围和已结算前缀算法；
 Markdown 只读材料组合不要求安装 Compaction；真正遇到需要学习的摘要时必须取得
 原摘要读取能力，缺失明确失败，不跳过或伪造来源。Akasha 使用公开只读 embedding
 接口与实际 Message 编码，重建写入器的权限归属继续单独处理。
+
+
+### 9.18 Dashboard 的请求能力入口
+
+Dashboard 模块通过自己的 inject 声明只读查询能力；async 路由使用 DashboardContext.require
+在实际请求租约中取得该能力。Core 不保存业务 key 清单。未声明、没有请求作用域或
+请求 generation 与页面不符均明确拒绝。页面不能取得宿主 Root、任意 SQL 或 writer。
+Akasha、Wake 与工作台使用这一入口；真实 HTTP、持久事实和编译页面内容共同验证。
+
+### 9.19 参考系统与有意的取舍
+
+| 参考 | 采用的机制 | Akashic 的取舍 |
+|---|---|---|
+| 本地 deepseek-harness 的 docs/architecture.md | Core 上安装普通能力插件，profile/bundle 明确组合，可撤销注册随卸载释放 | 分发与组合不能成为 Core 内另一份业务装配表；每个包仍走正式安装链 |
+| [JupyterLab 扩展](https://jupyterlab.readthedocs.io/en/stable/extension/extension_dev.html) | 提供/需要能力决定激活顺序，缺失必需能力明确失败，默认产品也由扩展组成 | 不要求提供者与消费者 import 同一业务 token 包；本地结构与有版本的名字组成 ABI，避免对象身份与包去重要求 |
+| [Backstage 扩展点](https://backstage.io/docs/backend-system/architecture/extension-points/) | 插件拥有自己的小扩展面，演进时使用新名称，失败归属具体 owner | 不建立 Core 业务接口目录；普通插件可声明局部输入，而不是共享所有业务 Protocol |
+| [VS Code 贡献点](https://code.visualstudio.com/api/references/contribution-points) | 包元数据声明 UI 与命令贡献，由宿主接纳 | 保留通用接纳与生命周期；业务展示和业务操作继续由外部插件拥有 |
+
+这些系统都需要协作合同。这里去中心化的是业务语义的所有权与发布路径，而不是消除
+可检验的协作语义。允许依赖公开能力，不允许通过 Python class 身份、兄弟源码或
+宿主私有对象偷渡实现依赖。真正的成功还必须由独立提供者替换和 checkout 缺席验收证明。

--- a/plugin_boundary_baseline.toml
+++ b/plugin_boundary_baseline.toml
@@ -38,7 +38,6 @@ R1 = [
     "migrations/yoyo/20260909_01_close_empty_wake_responses.py|plugins.wake.request",
 ]
 R2 = [
-    "plugins/akasha/dashboard.py|agent.plugins.snapshot",
     "plugins/akasha/infrastructure/sparse_index/builder.py|agent.turn_effects",
     "plugins/akasha/repair.py|session.embedding_store",
     "plugins/codex/driver.py|core.net.http",
@@ -90,8 +89,6 @@ R2 = [
     "plugins/standard_web/web.py|core.net.http",
     "plugins/telegram_sender/sender.py|infra.channels.telegram_utils",
     "plugins/telegram_sender/sender.py|session.artifacts",
-    "plugins/wake/dashboard.py|agent.plugins.snapshot",
-    "plugins/workbench_ui/dashboard.py|agent.plugins.snapshot",
     "plugins/workbench_ui/dashboard.py|infra.channels.message_view",
 ]
 R3 = [

--- a/plugins/akasha/dashboard.py
+++ b/plugins/akasha/dashboard.py
@@ -8,22 +8,17 @@ from fastapi import FastAPI, HTTPException, Query
 
 from agent.plugin_composition import DashboardContext
 from agent.plugin_composition.messages import MESSAGE_CATALOG
-from agent.plugins.snapshot import get_current_runtime_snapshot
 from agent.plugin_contracts import ContentPart, Message
 
 from .message_plugin import AKASHA_RECORDS_VIEW
 from .recalls import ContextSource, Hit, ProgramSource, Recall, RecallRecordsRead, ToolSource
 
 
-def _runtime_context():
-    snapshot = get_current_runtime_snapshot()
-    if snapshot is None or snapshot.composition_root is None:
-        raise RuntimeError("Akasha Dashboard 请求缺少实际 runtime snapshot")
-    return snapshot.composition_root.context
+inject = (AKASHA_RECORDS_VIEW, MESSAGE_CATALOG)
 
 
-def _records() -> RecallRecordsRead:
-    return _runtime_context().require(AKASHA_RECORDS_VIEW)()
+def _records(context: DashboardContext) -> RecallRecordsRead:
+    return context.require(AKASHA_RECORDS_VIEW)()
 
 
 def _message_text(message: Message) -> str:
@@ -61,10 +56,11 @@ def _message(
 def _hit_messages(
     recall: Recall,
     hit: Hit,
+    context: DashboardContext,
     *,
     full_text: bool,
 ) -> dict[str, object]:
-    reader = _runtime_context().require(MESSAGE_CATALOG).reader(hit.session_id)
+    reader = context.require(MESSAGE_CATALOG).reader(hit.session_id)
     messages: list[dict[str, object]] = []
     for message_id in hit.message_ids:
         message = reader.get(message_id)
@@ -98,9 +94,9 @@ def _source_fields(recall: Recall) -> tuple[str, str, int, dict[str, object]]:
     return source.query, "", -1, source_data
 
 
-def _row(identity: str, recall: Recall, *, full_text: bool) -> dict[str, object]:
+def _row(identity: str, recall: Recall, context: DashboardContext, *, full_text: bool) -> dict[str, object]:
     query_text, session_key, seq, source = _source_fields(recall)
-    hits = [_hit_messages(recall, hit, full_text=full_text) for hit in recall.hits]
+    hits = [_hit_messages(recall, hit, context, full_text=full_text) for hit in recall.hits]
     return {
         "query_id": identity,
         "session_key": session_key,
@@ -126,7 +122,7 @@ def register(app: FastAPI, context: DashboardContext) -> None:
 
     @app.get("/api/dashboard/akasha-inspector/overview")
     async def get_overview() -> dict[str, object]:
-        return {"available": True, "total": len(_records().list())}
+        return {"available": True, "total": len(_records(context).list())}
 
     @app.get("/api/dashboard/akasha-inspector/turns")
     async def list_turns(
@@ -136,17 +132,17 @@ def register(app: FastAPI, context: DashboardContext) -> None:
         page_size: int = Query(default=50, ge=1, le=200),
     ) -> dict[str, object]:
         # 1. 会话过滤只读召回出处，普通翻页不展开页外消息正文。
-        records = [(identity, recall) for identity, recall in _records().list()
+        records = [(identity, recall) for identity, recall in _records(context).list()
                    if not session_key or _source_fields(recall)[1] == session_key]
         query = q.strip().casefold()
         start = (page - 1) * page_size
         if query:
             # 文本搜索仍包含展示正文；只展开已经通过会话过滤的记录。
-            rows = [_row(identity, recall, full_text=False) for identity, recall in records]
+            rows = [_row(identity, recall, context, full_text=False) for identity, recall in records]
             rows = [row for row in rows if query in json.dumps(row, ensure_ascii=False).casefold()]
             items, total = rows[start:start + page_size], len(rows)
         else:
-            items = [_row(identity, recall, full_text=False)
+            items = [_row(identity, recall, context, full_text=False)
                      for identity, recall in records[start:start + page_size]]
             total = len(records)
         return {
@@ -158,7 +154,7 @@ def register(app: FastAPI, context: DashboardContext) -> None:
 
     @app.get("/api/dashboard/akasha-inspector/turns/{query_id:path}")
     async def get_turn(query_id: str) -> dict[str, object]:
-        recall = _records().read(query_id)
+        recall = _records(context).read(query_id)
         if recall is None:
             raise HTTPException(status_code=404, detail="Akasha 检索记录不存在")
-        return _row(query_id, recall, full_text=True)
+        return _row(query_id, recall, context, full_text=True)

--- a/plugins/wake/dashboard.py
+++ b/plugins/wake/dashboard.py
@@ -7,17 +7,16 @@ from collections.abc import Mapping
 from fastapi import FastAPI, HTTPException, Query
 
 from agent.plugin_composition import DashboardContext
-from agent.plugins.snapshot import get_current_runtime_snapshot
 
 from .message_plugin import WAKE_DASHBOARD
 from .runtime import DashboardView
 
 
-def _view() -> DashboardView:
-    snapshot = get_current_runtime_snapshot()
-    if snapshot is None or snapshot.composition_root is None:
-        raise RuntimeError("Wake Dashboard 请求缺少实际 runtime snapshot")
-    view = snapshot.composition_root.context.require(WAKE_DASHBOARD)()
+inject = (WAKE_DASHBOARD,)
+
+
+def _view(context: DashboardContext) -> DashboardView:
+    view = context.require(WAKE_DASHBOARD)()
     if view is None:
         raise RuntimeError("Wake runtime 尚未启动")
     return view
@@ -31,13 +30,13 @@ def register(app: FastAPI, context: DashboardContext) -> None:
         page: int = Query(default=1, ge=1),
         page_size: int = Query(default=25, ge=1, le=100),
     ) -> dict[str, object]:
-        view = _view()
+        view = _view(context)
         rows = view.list_attempts(page_size, offset=(page - 1) * page_size)
         return {"items": rows, "total": view.count_attempts(), "page": page, "page_size": page_size}
 
     @app.get("/api/dashboard/wake/attempts/{attempt_id}")
     async def get_attempt(attempt_id: str) -> Mapping[str, object]:
-        item = _view().get_attempt(attempt_id)
+        item = _view(context).get_attempt(attempt_id)
         if item is None:
             raise HTTPException(status_code=404, detail="Wake 定时检查不存在")
         return item
@@ -47,13 +46,13 @@ def register(app: FastAPI, context: DashboardContext) -> None:
         page: int = Query(default=1, ge=1),
         page_size: int = Query(default=25, ge=1, le=100),
     ) -> dict[str, object]:
-        view = _view()
+        view = _view(context)
         rows = view.list_runs(page_size, offset=(page - 1) * page_size)
         return {"items": rows, "total": view.count_runs(), "page": page, "page_size": page_size}
 
     @app.get("/api/dashboard/wake/runs/{run_id}")
     async def get_run(run_id: str) -> Mapping[str, object]:
-        item = _view().get_run(run_id)
+        item = _view(context).get_run(run_id)
         if item is None:
             raise HTTPException(status_code=404, detail="Wake 判断记录不存在")
         return item

--- a/plugins/workbench_ui/dashboard.py
+++ b/plugins/workbench_ui/dashboard.py
@@ -8,18 +8,12 @@ from fastapi import FastAPI, HTTPException, Query
 
 from agent.plugin_composition import DashboardContext
 from agent.plugin_composition.messages import MESSAGE_CATALOG
-from agent.plugins.snapshot import get_current_runtime_snapshot
 from infra.channels.message_view import session_row
 from agent.plugin_composition.messages import InvalidPage, MessageCatalog
 from agent.plugin_contracts import body_to_dict
 
 
-def _catalog() -> MessageCatalog:
-    snapshot = get_current_runtime_snapshot()
-    if snapshot is None or snapshot.composition_root is None:
-        raise RuntimeError("工作台请求缺少实际插件 snapshot")
-    return snapshot.composition_root.context.require(MESSAGE_CATALOG)
-
+inject = (MESSAGE_CATALOG,)
 
 def register(app: FastAPI, context: DashboardContext) -> None:
     """注册只读页面；请求 middleware 持有实际 generation，注册不打开运行数据。"""
@@ -30,7 +24,7 @@ def register(app: FastAPI, context: DashboardContext) -> None:
         limit: int = Query(default=50, ge=1, le=200),
     ) -> dict[str, object]:
         try:
-            page = _catalog().sessions(prefix=prefix, visibility=visibility, limit=limit,
+            page = context.require(MESSAGE_CATALOG).sessions(prefix=prefix, visibility=visibility, limit=limit,
                 after=None if cursor is None else (cursor[0], cursor[1]))
         except InvalidPage as error:
             raise HTTPException(status_code=400, detail=str(error)) from error
@@ -44,7 +38,7 @@ def register(app: FastAPI, context: DashboardContext) -> None:
         limit: int = Query(default=50, ge=1, le=200),
     ) -> dict[str, object]:
         try:
-            page = _catalog().reader(session_id).read_tail(
+            page = context.require(MESSAGE_CATALOG).reader(session_id).read_tail(
                 before_seq=before_seq, through_seq=through_seq, limit=limit,
             )
         except KeyError as error:

--- a/tests/test_message_plugin_dashboards.py
+++ b/tests/test_message_plugin_dashboards.py
@@ -219,7 +219,7 @@ async def test_wake_dashboard_matches_target_delivery_and_compiled_module(tmp_pa
             detail="dashboard fixture",
             completed_at=now,
         )
-        direct_receipt = ctx.require(DELIVERY_READ).status(original.notification_id, original.sink.name)
+        direct_receipt = ctx.require(DELIVERY_READ).status(original.notification_id, original.sink["name"])
         assert direct_receipt is not None
         target_message = log.reader(original.target.session_id).get(original.notification_id)
         assert target_message is not None

--- a/tests/test_plugin_hot_reload.py
+++ b/tests/test_plugin_hot_reload.py
@@ -18,6 +18,7 @@ from fastapi.testclient import TestClient
 from starlette.convertors import CONVERTOR_TYPES, StringConvertor
 from starlette.websockets import WebSocketDisconnect
 
+from agent.plugin_composition import CompositionError
 from agent.plugins.artifacts import ArtifactPointer, read_pointer, write_pointers
 from agent.plugins.dashboard_host import (
     DashboardBinding,
@@ -32,6 +33,7 @@ from agent.plugins.snapshot import (
     RuntimeSnapshot,
     RuntimeSnapshotCompiler,
     RuntimeSnapshotStore,
+    lease_runtime_snapshot,
 )
 from agent.plugins.watcher import PluginWatcher
 from agent.skills import SkillsLoader
@@ -1327,10 +1329,20 @@ async def test_dashboard_routes_follow_snapshot_generation(
     )
 
     def write_dashboard(version: str) -> None:
+        (plugin_dir / "plugin.py").write_text(_v3_source(
+            "snapshot_dashboard",
+            exports="from agent.plugin_composition import ServiceKey\ndashboard_module = 'dashboard.py'\nweb_module = 'web_module.js'\n",
+            body=f"    await ctx.provide(ServiceKey('fixture.dashboard-value'), '{version}')\n",
+        ))
         (plugin_dir / "dashboard.py").write_text(
+            "from agent.plugin_composition import ServiceKey\n"
+            "VALUE = ServiceKey('fixture.dashboard-value')\n"
+            "inject = (VALUE,)\n"
             "def register(app, context):\n"
+            "    @app.get('/api/dashboard/undeclared')\n"
+            "    async def undeclared(): return context.require(ServiceKey('core.message-writers'))\n"
             "    @app.get('/api/dashboard/snapshot-version')\n"
-            f"    def version(): return {{'version': '{version}'}}\n"
+            "    async def version(): return {'version': context.require(VALUE)}\n"
             "    class Closeable:\n"
             "        def close(self):\n"
             f"            (context.data_root / 'dashboard-{version}-closed').write_text('closed')\n"
@@ -1407,8 +1419,16 @@ async def test_dashboard_routes_follow_snapshot_generation(
         "/api/dashboard/snapshot-version",
         headers=new_headers,
     ).json() == {"version": "release-b"}
+    with pytest.raises(CompositionError, match="未声明能力"):
+        client.get("/api/dashboard/undeclared", headers=new_headers)
     old_binding = old_snapshot.dashboard_bindings[0]
-    assert TestClient(old_binding.app).get("/api/dashboard/snapshot-version").json() == {"version": "release-a"}  # type: ignore[attr-defined]
+    with pytest.raises(CompositionError, match="实际请求租约"):
+        TestClient(old_binding.app).get("/api/dashboard/snapshot-version")
+    import httpx
+    async with lease_runtime_snapshot(manager.snapshot_store):
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=old_binding.app), base_url="http://fixture") as old_client:
+            with pytest.raises(CompositionError, match="当前请求 generation"):
+                await old_client.get("/api/dashboard/snapshot-version")
     await manager.snapshot_store.retry_drains()
     assert (old_generation.data_dir / "dashboard-release-a-closed").exists()
     assert old_generation.scope.closed


### PR DESCRIPTION
Akasha、Wake 和工作台 Dashboard 通过本模块的 inject 声明只读能力，在 async 路由中使用 DashboardContext.require。宿主检查声明、真实请求租约及页面 generation；插件不再读取 Core 私有 snapshot 或 Root。

基于 #615。保留原查询与 HTTP 数据形状，页面不获得 SQL 或消息写入器。设计文档补齐 deepseek-harness、JupyterLab、Backstage 和 VS Code 的一手参考与有意取舍。

验证：17 项真实 Dashboard/API/编译页面回归通过；generation 切换回归验证实际 provider、未声明访问、无租约访问与旧页面跨代访问拒绝；定向类型检查 0 errors。静态边界 R1=32、R2=52、R3=0。

恢复点 b8944e49，改动前副本位于任务 dashboard-capabilities 备份，无正式 workspace 写入。完整 Gate、CI 与累计评审依用户要求留在全部实施后；继续下一层，不等待检查完成。