### PR TITLE
fix: 完整迁移独立渠道与发送插件配置

### DIFF
--- a/scripts/migrate_legacy_channels.py
+++ b/scripts/migrate_legacy_channels.py
@@ -9,6 +9,7 @@ recoverable config backup, and removes the old tables from the source config.
 from __future__ import annotations
 
 import argparse
+import math
 import os
 import re
 import shutil
@@ -152,12 +153,16 @@ def _render_qq(table: Mapping[str, Any]) -> str:
     if not isinstance(groups_raw, list | tuple):
         raise ValueError("channels.qq.groups 必须是数组")
     groups: list[dict[str, Any]] = []
+    seen_groups: set[str] = set()
     for index, raw in enumerate(groups_raw):
         if not isinstance(raw, Mapping):
             raise ValueError(f"channels.qq.groups[{index}] 必须是 table")
         group_id = str(raw.get("group_id", raw.get("groupId", ""))).strip()
         if not group_id:
             raise ValueError(f"channels.qq.groups[{index}].group_id 不能为空")
+        if group_id in seen_groups:
+            raise ValueError(f"QQ 群配置重复: {group_id}")
+        seen_groups.add(group_id)
         groups.append(
             {
                 "group_id": group_id,
@@ -175,7 +180,7 @@ def _render_qq(table: Mapping[str, Any]) -> str:
             }
         )
     timeout = float(table.get("websocket_open_timeout_seconds", 5.0))
-    if timeout <= 0:
+    if not math.isfinite(timeout) or timeout <= 0:
         raise ValueError("channels.qq.websocket_open_timeout_seconds 必须大于 0")
     return tomlkit.dumps(
         {

--- a/scripts/migrate_legacy_channels.py
+++ b/scripts/migrate_legacy_channels.py
@@ -15,6 +15,7 @@ import shutil
 import tempfile
 from pathlib import Path
 from typing import Any, Mapping
+from urllib.parse import urlsplit
 
 import tomlkit
 
@@ -44,10 +45,23 @@ def migrate_legacy_channels(config_path: Path, workspace: Path, *, marketplace: 
         if value is not None and not isinstance(value, Mapping):
             raise ValueError(f"channels.{name} 必须是 TOML table")
     targets: list[tuple[str, str]] = []
+    migrated_channels: list[str] = []
     if isinstance(telegram, Mapping):
-        targets.append(("telegram_channel", _render_telegram(telegram, workspace)))
+        migrated_channels.append("telegram_channel")
+        targets.extend(
+            (
+                ("telegram_channel", _render_telegram(telegram, workspace)),
+                ("telegram_sender", _render_telegram_sender(telegram, workspace)),
+            )
+        )
     if isinstance(qq, Mapping):
-        targets.append(("qq_channel", _render_qq(qq)))
+        migrated_channels.append("qq_channel")
+        targets.extend(
+            (
+                ("qq_channel", _render_qq(qq)),
+                ("qq_sender", _render_qq_sender(qq, workspace)),
+            )
+        )
     if not targets:
         raise ValueError("legacy channels.telegram/qq 必须是 TOML table")
     for plugin_name, content in targets:
@@ -86,7 +100,7 @@ def migrate_legacy_channels(config_path: Path, workspace: Path, *, marketplace: 
         for temporary, _target in staged:
             temporary.unlink(missing_ok=True)
         raise
-    return tuple(plugin_name for plugin_name, _content in targets)
+    return tuple(migrated_channels)
 
 
 def _render_telegram(table: Mapping[str, Any], workspace: Path) -> str:
@@ -105,6 +119,26 @@ def _render_telegram(table: Mapping[str, Any], workspace: Path) -> str:
         "allow_from": [
             str(item) for item in _string_list(allow_from, "channels.telegram.allow_from")
         ],
+    }
+    if token:
+        values["token"] = token
+    return tomlkit.dumps(values)
+
+
+def _render_telegram_sender(table: Mapping[str, Any], workspace: Path) -> str:
+    """Create the matching delivery sender from the legacy Telegram token."""
+
+    channel_name = str(table.get("channel_name", "telegram")).strip()
+    if channel_name != "telegram":
+        raise ValueError(
+            "自定义 channels.telegram.channel_name 无法直接迁移到静态 telegram sender；"
+            "请为该身份发布独立 sender 插件后再迁移"
+        )
+    enabled = _as_bool(table.get("enabled", True), "channels.telegram.enabled")
+    token = _resolve(str(table.get("token", "")), workspace).strip()
+    values: dict[str, Any] = {
+        "enabled": enabled and bool(token),
+        "channel": "telegram",
     }
     if token:
         values["token"] = token
@@ -158,6 +192,48 @@ def _render_qq(table: Mapping[str, Any]) -> str:
             "websocket_open_timeout_seconds": timeout,
         }
     )
+
+
+def _render_qq_sender(table: Mapping[str, Any], workspace: Path) -> str:
+    """Create a sender only when the old config names a real OneBot endpoint."""
+
+    enabled = _as_bool(table.get("enabled", True), "channels.qq.enabled")
+    bot_uin = str(table.get("bot_uin", "")).strip()
+    active = enabled and bool(bot_uin)
+    raw_endpoint = table.get("sender_endpoint", table.get("endpoint", ""))
+    endpoint = str(raw_endpoint).strip()
+    token = _resolve(
+        str(table.get("sender_token", table.get("token", ""))), workspace
+    ).strip()
+    if active and not endpoint:
+        raise ValueError(
+            "启用 QQ channel 迁移需要 channels.qq.sender_endpoint（OneBot WS API）；"
+            "不能从 bot_uin 猜测 QQ sender 地址"
+        )
+    if endpoint:
+        _validate_qq_sender_endpoint(endpoint)
+    values: dict[str, Any] = {"enabled": active, "channel": "qq"}
+    if endpoint:
+        values["endpoint"] = endpoint
+    if token:
+        values["token"] = token
+    return tomlkit.dumps(values)
+
+
+def _validate_qq_sender_endpoint(endpoint: str) -> None:
+    parsed = urlsplit(endpoint)
+    if (
+        parsed.scheme not in {"ws", "wss"}
+        or not parsed.hostname
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+        or parsed.path.rstrip("/") == "/event"
+    ):
+        raise ValueError(
+            "channels.qq.sender_endpoint 必须是无凭据、无 query/fragment 的 OneBot WS API URL"
+        )
 
 
 def _atomic_write(path: Path, text: str, *, mode: int) -> None:

--- a/tests/test_channel_identities.py
+++ b/tests/test_channel_identities.py
@@ -35,17 +35,14 @@ def _history(tmp_path, *, legacy=False):
 
 @pytest.mark.parametrize("legacy", [False, True])
 def test_yoyo_preserves_known_aliases_original_data_and_unknown_sources(tmp_path, monkeypatch, legacy):
-    import runpy
-    from pathlib import Path
-    import yoyo
+    from tests.legacy_migration_loader import load_migration_module
     from agent.migrations.context import bind_migration_context
 
     path, config = _history(tmp_path, legacy=legacy)
     with closing(sqlite3.connect(path)) as db:
         original = tuple(db.iterdump())
         sessions = db.execute("SELECT * FROM sessions ORDER BY key").fetchall()
-    monkeypatch.setattr(yoyo, "step", lambda callback: callback)
-    entry = runpy.run_path(str(Path(__file__).parents[1] / "migrations/yoyo/20260906_04_channel_identities.py"))
+    entry = load_migration_module("20260906_04_channel_identities")
     with bind_migration_context(config_path=config, workspace=tmp_path):
         entry["steps"][0](None)
     with closing(ChannelIdentities(path)) as identities:
@@ -70,7 +67,7 @@ def test_yoyo_preserves_known_aliases_original_data_and_unknown_sources(tmp_path
 
 
 def test_identity_migration_failure_rolls_back_all_channels_and_retries(tmp_path, monkeypatch):
-    from agent.migrations import channel_identities as migration
+    from plugins.legacy_upgrade.legacy_upgrade_migrations.support import channel_identities as migration
 
     path, config = _history(tmp_path)
     with closing(sqlite3.connect(path)) as db:
@@ -136,9 +133,9 @@ allow_from = ["alice"]
         + "\n",
         encoding="utf-8",
     )
-    assert migrate_legacy_channels(config, workspace) == ("telegram_channel",)
+    assert migrate_legacy_channels(config, workspace, marketplace="installed") == ("telegram_channel",)
     assert "channels.telegram" not in config.read_text(encoding="utf-8")
-    plugin = workspace / "plugin-data/telegram_channel-builtin/config.local.toml"
+    plugin = workspace / "plugin-data/telegram_channel-installed/config.local.toml"
     assert 'token = "123:token"' in plugin.read_text(encoding="utf-8")
     assert (tmp_path / "config.toml.before-channel-plugin-migration.bak").exists()
 
@@ -152,7 +149,7 @@ def test_channel_migration_rejects_custom_telegram_identity_without_silent_rekey
     config.write_text(original, encoding="utf-8")
 
     with pytest.raises(ValueError, match="自定义 channels.telegram.channel_name"):
-        migrate_legacy_channels(config, workspace)
+        migrate_legacy_channels(config, workspace, marketplace="installed")
 
     assert config.read_text(encoding="utf-8") == original
     assert not workspace.exists()
@@ -165,8 +162,8 @@ def test_channel_migration_preserves_legacy_empty_channel_as_disabled_plugin(tmp
     workspace = tmp_path / "workspace"
     config.write_text("[channels.telegram]\n", encoding="utf-8")
 
-    assert migrate_legacy_channels(config, workspace) == ("telegram_channel",)
-    plugin = workspace / "plugin-data/telegram_channel-builtin/config.local.toml"
+    assert migrate_legacy_channels(config, workspace, marketplace="installed") == ("telegram_channel",)
+    plugin = workspace / "plugin-data/telegram_channel-installed/config.local.toml"
     assert plugin.read_text(encoding="utf-8") == "enabled = false\nallow_from = []\n"
 
 

--- a/tests/test_channel_input.py
+++ b/tests/test_channel_input.py
@@ -78,10 +78,13 @@ class Custody(MessageBus):
 @asynccontextmanager
 async def runtime(tmp_path, *, channel_name="probe", session_manager=None, recover=True, artifacts=None, inbound_store=None, admissions=None, durable_identities=False):
     sources = tmp_path / "plugins"
-    shutil.copytree(Path(__file__).parents[1] / "plugins/conversation", sources / "conversation",
-                    ignore=shutil.ignore_patterns("__pycache__"), dirs_exist_ok=True)
-    shutil.copytree(Path(__file__).parents[1] / "plugins/sources", sources / "sources",
-                    ignore=shutil.ignore_patterns("__pycache__"), dirs_exist_ok=True)
+    for name in ("content", "models", "conversation", "sources"):
+        shutil.copytree(
+            Path(__file__).parents[1] / "plugins" / name,
+            sources / name,
+            ignore=shutil.ignore_patterns("__pycache__"),
+            dirs_exist_ok=True,
+        )
     log = MessageLog(tmp_path / "sessions.db")
     identity_store = ChannelIdentities(tmp_path / "sessions.db") if durable_identities else None
     host = PluginManager([sources], event_bus=EventBus(), workspace=tmp_path / "workspace",

--- a/tests/test_external_channel_owners.py
+++ b/tests/test_external_channel_owners.py
@@ -828,24 +828,27 @@ async def test_qq_stop_failure_and_cancelled_waiter_share_unconfirmed_cleanup(
 
 
 def test_channel_config_migration_resumes_before_removing_old_input(tmp_path, monkeypatch):
-    """第二个目标发布失败时保留原配置；重试使用同一备份和明确 marketplace。"""
+    """任一 channel/sender 目标发布失败时保留原配置，并可按原备份重试。"""
     import tomllib
     from scripts import migrate_legacy_channels as migration
     from agent.plugins.manifest import workspace_plugin_data_dir
 
     config = tmp_path / "config.toml"
-    source = '[channels.telegram]\ntoken="fixture-token"\n[channels.qq]\nbot_uin="9001"\n'
+    source = (
+        '[channels.telegram]\ntoken="fixture-token"\n'
+        '[channels.qq]\nbot_uin="9001"\nsender_endpoint="ws://127.0.0.1:3001/api"\n'
+    )
     config.write_text(source)
     workspace = tmp_path / "workspace"
     qq = workspace_plugin_data_dir(workspace, "qq_channel", "external") / "config.local.toml"
     replace = migration.os.replace
     def fail_second(source_path, destination):
         if destination == qq:
-            raise OSError("fixture second target failure")
+            raise OSError("fixture channel target failure")
         replace(source_path, destination)
     with monkeypatch.context() as patch:
         patch.setattr(migration.os, "replace", fail_second)
-        with pytest.raises(OSError, match="second target failure"):
+        with pytest.raises(OSError, match="channel target failure"):
             migration.migrate_legacy_channels(config, workspace, marketplace="external")
     assert config.read_text() == source
     backup = config.with_name(config.name + ".before-channel-plugin-migration.bak")
@@ -856,5 +859,34 @@ def test_channel_config_migration_resumes_before_removing_old_input(tmp_path, mo
     assert tomllib.loads(qq.read_text())["bot_uin"] == "9001"
     telegram = workspace_plugin_data_dir(workspace, "telegram_channel", "external") / "config.local.toml"
     assert tomllib.loads(telegram.read_text())["token"] == "fixture-token"
+    telegram_sender = workspace_plugin_data_dir(workspace, "telegram_sender", "external") / "config.local.toml"
+    assert tomllib.loads(telegram_sender.read_text()) == {
+        "enabled": True,
+        "channel": "telegram",
+        "token": "fixture-token",
+    }
+    qq_sender = workspace_plugin_data_dir(workspace, "qq_sender", "external") / "config.local.toml"
+    assert tomllib.loads(qq_sender.read_text()) == {
+        "enabled": True,
+        "channel": "qq",
+        "endpoint": "ws://127.0.0.1:3001/api",
+    }
     assert tomllib.loads(config.read_text()) == {}
     assert backup.read_text() == source
+
+
+def test_channel_config_migration_requires_qq_sender_endpoint_before_writing(tmp_path):
+    """QQ receiver identity cannot silently become a sender with a guessed endpoint."""
+    from scripts import migrate_legacy_channels as migration
+
+    config = tmp_path / "config.toml"
+    source = '[channels.qq]\nbot_uin="9001"\n'
+    config.write_text(source)
+    workspace = tmp_path / "workspace"
+
+    with pytest.raises(ValueError, match="sender_endpoint"):
+        migration.migrate_legacy_channels(config, workspace, marketplace="external")
+
+    assert config.read_text() == source
+    assert not workspace.exists()
+    assert not config.with_name(config.name + ".before-channel-plugin-migration.bak").exists()

--- a/tests/test_external_channel_owners.py
+++ b/tests/test_external_channel_owners.py
@@ -890,3 +890,23 @@ def test_channel_config_migration_requires_qq_sender_endpoint_before_writing(tmp
     assert config.read_text() == source
     assert not workspace.exists()
     assert not config.with_name(config.name + ".before-channel-plugin-migration.bak").exists()
+
+
+@pytest.mark.parametrize("invalid", [
+    "websocket_open_timeout_seconds=nan\n",
+    "websocket_open_timeout_seconds=inf\n",
+    'groups=[{group_id="42"}, {group_id="42"}]\n',
+])
+def test_channel_config_migration_rejects_invalid_receiver_before_writing(tmp_path, invalid):
+    """无效接收配置不能在迁移后才报错并丢掉旧入口。"""
+    from scripts.migrate_legacy_channels import migrate_legacy_channels
+
+    config = tmp_path / "config.toml"
+    source = '[channels.qq]\nbot_uin="9001"\nsender_endpoint="ws://127.0.0.1/api"\n' + invalid
+    config.write_text(source)
+    workspace = tmp_path / "workspace"
+    with pytest.raises(ValueError, match="timeout|重复"):
+        migrate_legacy_channels(config, workspace, marketplace="external")
+    assert config.read_text() == source
+    assert not workspace.exists()
+    assert not config.with_name(config.name + ".before-channel-plugin-migration.bak").exists()


### PR DESCRIPTION
旧渠道表迁移现在同时配置独立接收与发送 owner。Telegram 复用原 token；启用的 QQ 必须显式提供 sender endpoint。所有目标先校验，非有限超时、重复群配置或目标冲突在写入前拒绝，随后保留原配置备份，最后才移除旧表。

## Change intent

- change_type: migration；semantic_delta: breaking；capability_owner: plugin；consumer_scope: 显式旧渠道配置升级命令；runtime_patch: none。
- authoritative_state_owner: 各渠道/发送插件的配置；迁移命令仅转换表示。protected_state: 原配置、现有插件配置和 workspace 消息/附件。
- 允许副作用：用户显式执行命令时创建命名备份和插件配置。禁止副作用：正式 workspace 自动迁移、渠道发送、覆盖冲突目标。
- 此层无数据库 schema 变化。恢复方式：原 config.toml.before-channel-plugin-migration.bak；不自动删除新增插件数据。

## 验证与评审

- 相邻 base #627；head 34fb2a2f。
- tests/test_external_channel_owners.py + tests/test_channel_identities.py：27 passed。测试使用临时 workspace、实际目标配置模型及外部历史包。
- git diff --check 通过；未发送真实渠道消息，未修改正式 workspace。
- concept_gate: required（渠道配置 owner/迁移）；独立 reviewer/model/head 和完整 Gate、CI 证据待全栈实施完成后补充。当前保持 draft，不声明评审通过。
- 最短失败路径：预检失败保留原文件；部分目标发布中断后以同内容目标续做，原表直到全部目标发布后才移除。
- projectneed 与插件边界决策沿用当前已授权目标。按用户要求发布后继续后续实施，不等待 CI。