### PR TITLE
并行工具调用：重叠执行、按模型顺序提交

### DIFF
--- a/docs/decisions/0064-parallel-tool-calls-commit-in-model-order.md
+++ b/docs/decisions/0064-parallel-tool-calls-commit-in-model-order.md
@@ -1,0 +1,50 @@
+# 0064 · 并行工具调用重叠执行、按模型顺序提交
+
+- 状态：accepted
+- 日期：2026-09-12
+- 关联条款：PRM-004、SES-003～SES-005、RUN-003、Tools 回执合同（[0059](0059-abandon-settles-tool-calls.md)、[0063](0063-execution-failures-have-terminal-results.md)）
+
+## 背景与决定
+
+模型可以在一次响应里返回多个独立工具调用，原 ReAct 循环逐个串行结算，浪费了 provider
+已经给出的并行度。决定让执行可重叠，但不改变任何持久语义：
+
+- 工具注册新增 `parallel: bool` 字段，默认 `False`。只有显式声明的调用允许与同批
+  parallel 调用重叠；旧归档描述缺少该字段时按 `False` 解释，行为与升级前一致。
+- ReAct 把连续 parallel 调用编成一组，走有界滚动池（`max_parallel_calls`）；
+  exclusive 调用是屏障，前面的组排空后才执行，其后的调用等它结算。
+- 组内每个调用仍走 `ToolExecution.execute_call` 的完整回执协议；唯一新增的是
+  `commit_after` 提交门——每个调用在 `finish` 前等前驱的结算事件，因此 ToolResult
+  与回执的落盘顺序永远是模型顺序，与完成先后无关。
+- 前驱无论成功或失败都在 `finally` 放行后继，一次失败不锁死整批；批级取消先放行
+  所有提交门再排空已开始调用，未开始的调用留给原有 pending/abandon 协议结算。
+
+## 理由与影响
+
+dispatch 并发、commit 保序与 Codex（`FuturesOrdered` + read/write 门）和
+deepseek-harness（prepare/dispatch/finalize 三段式 + 有界池）的主结构一致。
+`finish` 把结果消息与回执放在同一事务，这条不变量不拆；保序因此落在提交时机上，
+而不是先落盘再排序。
+
+`parallel` 是工具对自身并发安全的声明，不是调度策略：分类只读注册描述，调度只读
+分类结果，效果归属、幂等、授权与恢复完全留在 `ToolExecution`。fail-closed——binding
+失效、描述缺失或字段非 `True` 一律串行。
+
+并行不减少 provider 请求轮数；轮数只取决于模型在一个响应里放几个调用。本改动减少
+的是同一响应内多个独立调用的等待时间。已验证为无共享可变状态的只读工具（web
+fetch/search、tool_search、load_skill、list_schedules、recall_memory、read_file/
+list_dir）标记 `parallel=True`；其余一律保持 exclusive。
+
+## 持久化与恢复
+
+不新增表、不改 schema、不改写旧消息或旧回执。取消语义不变：`interrupted` 仍不表示
+外部效果已撤销；abandon 的"先提交终态再发取消"合同不受影响，晚到的组内提交按
+first-committed-wins 读取已存在终态。
+
+## 验收
+
+- 同批 parallel 调用的 `invoke` 可重叠；较快完成的结果不抢先落盘，ToolResult 顺序
+  等于模型顺序，provider 投影顺序不变。
+- exclusive 调用在前组完全结算前不启动；其后的 parallel 调用在它结算前不启动。
+- 池上限生效；任一并发度下日志与串行执行逐字节同构。
+- 组内失败停止补发、排空已开始调用；批级取消不死锁。

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -70,6 +70,7 @@
 | [0062](0062-tools-flow-through-provider-views.md) | accepted / implemented | 工具通过 provider view 流向消费者 | CTX-004、CTX-007、PLG-003、PLG-008、PLG-009、PLG-014、PLG-016、PLG-018 |
 
 | [0063](0063-execution-failures-have-terminal-results.md) | accepted | 执行失败明确收尾，恢复依据原回执 | Tools、Delivery、Wake、Mobile、Models |
+| [0064](0064-parallel-tool-calls-commit-in-model-order.md) | accepted | 并行工具调用重叠执行、按模型顺序提交 | PRM-004、SES-003～SES-005、RUN-003 |
 
 ## 新增规则
 

--- a/plugins/akasha/message_plugin.py
+++ b/plugins/akasha/message_plugin.py
@@ -331,6 +331,7 @@ async def apply(ctx: Context, config: Config) -> None:
             capture=capture_recall,
             idempotent=True,
             risk="read-only",
+            parallel=True,
         )
     )
     _ = await ctx.provide(AKASHA_TOOLS, catalog.view(*tool_refs))

--- a/plugins/conversation/program.py
+++ b/plugins/conversation/program.py
@@ -55,6 +55,7 @@ async def run_reply(
     authorize: Authorize,
     max_output_tokens: int,
     max_steps: int,
+    max_parallel_calls: int = 4,
     tool_view: ToolView | None = None,
     tool_names: Sequence[str] | None = None,
     exclude_materials: frozenset[str] = frozenset(),
@@ -167,6 +168,7 @@ async def run_reply(
                 materials=build_materials, content=view, tools=menu,
                 max_output_tokens=max_output_tokens, max_steps=max_steps,
                 reduce=reduce, preview=preview, terminal_tools=terminal_tools,
+                max_parallel_calls=max_parallel_calls,
             )
         finally:
             output.expire()

--- a/plugins/react/plugin.py
+++ b/plugins/react/plugin.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 from uuid import uuid4
 
 from agent.plugin_composition import Context, RuntimeScope, ServiceKey
-from agent.plugins.snapshot import get_current_runtime_lease
+from agent.plugins.snapshot import RuntimeSnapshotLease, get_current_runtime_lease
 from agent.plugin_composition.models import (
     BoundChatModel,
     ContextLengthError,
@@ -112,16 +112,24 @@ def _terminal_result(messages: Sequence[Message], source: str, tools: ToolMenu,
     return any(seq > boundary and ref in succeeded for ref, seq in calls.items())
 
 
-async def _settle(tools: ToolMenu, call: CallRef) -> None:
+async def _settle(
+    tools: ToolMenu,
+    call: CallRef,
+    *,
+    commit_after: asyncio.Event | None = None,
+    lease: RuntimeSnapshotLease | None = None,
+) -> None:
     """普通取消等待原调用；明确放弃由 Tools 提交终态并释放等待者。"""
-    lease = get_current_runtime_lease()
+    # 子任务不是 lease 的 owner task；由调度方在原任务解析后显式传入。
+    if lease is None:
+        lease = get_current_runtime_lease()
     scope = None if lease is None else RuntimeScope(lease.fork())
 
     async def execute():
         if scope is None:
-            return await tools.execute(call)
+            return await tools.execute(call, commit_after=commit_after)
         async with scope:
-            return await tools.execute(call)
+            return await tools.execute(call, commit_after=commit_after)
 
     operation = execute()
     try:
@@ -148,6 +156,81 @@ async def _settle(tools: ToolMenu, call: CallRef) -> None:
     finally:
         if scope is not None:
             await scope.close()
+
+
+def _parallel(reader: MessageReader, tools: ToolMenu, call: CallRef) -> bool:
+    """只按工具注册时的 parallel 声明分类；失效引用一律串行，真实错误留给结算路径。"""
+    message = reader.get(call.message_id)
+    body = None if message is None else message.body
+    if not isinstance(body, Output) or call.part_index >= len(body.parts):
+        return False
+    part = body.parts[call.part_index]
+    return isinstance(part, ToolCall) and tools.parallel(part.binding_id)
+
+
+async def _settle_group(
+    tools: ToolMenu,
+    calls: Sequence[CallRef],
+    limit: int,
+    lease: RuntimeSnapshotLease | None,
+) -> None:
+    """同组调用重叠执行但按模型顺序提交结果；失败停止补发，取消排空已开始调用。"""
+    settled = [asyncio.Event() for _ in calls]
+
+    async def run(index: int, call: CallRef) -> None:
+        try:
+            await _settle(
+                tools, call, commit_after=settled[index - 1] if index else None, lease=lease
+            )
+        finally:
+            # 前驱无论成功失败都放行后继提交，不能让一次失败锁住整批。
+            settled[index].set()
+
+    tasks: list[asyncio.Task[None]] = []
+    in_flight: set[asyncio.Task[None]] = set()
+    try:
+        for index, call in enumerate(calls):
+            while len(in_flight) >= limit:
+                done, in_flight = await asyncio.wait(
+                    in_flight, return_when=asyncio.FIRST_COMPLETED
+                )
+                for finished in done:
+                    if finished.cancelled():
+                        raise asyncio.CancelledError
+                    failure = finished.exception()
+                    if failure is not None:
+                        raise failure
+            task = asyncio.create_task(run(index, call))
+            tasks.append(task)
+            in_flight.add(task)
+        for task in tasks:
+            await task
+    finally:
+        # 2. 放行所有提交门再排空；从未开始的任务也绝不阻塞后继提交。
+        for event in settled:
+            event.set()
+        for task in tasks:
+            _ = task.cancel()
+        _ = await asyncio.gather(*tasks, return_exceptions=True)
+
+
+async def _settle_pending(
+    reader: MessageReader, tools: ToolMenu, source: str, limit: int
+) -> None:
+    """结算未闭段调用：exclusive 调用是屏障，连续 parallel 调用走有界滚动池。"""
+    calls = _pending_calls(reader.snapshot(), source)
+    lease = get_current_runtime_lease()
+    index = 0
+    while index < len(calls):
+        if not _parallel(reader, tools, calls[index]):
+            await _settle(tools, calls[index], lease=lease)
+            index += 1
+            continue
+        end = index + 1
+        while end < len(calls) and _parallel(reader, tools, calls[end]):
+            end += 1
+        await _settle_group(tools, calls[index:end], limit, lease)
+        index = end
 
 
 @asynccontextmanager
@@ -221,16 +304,18 @@ async def react(
     reduce: SummaryReducer | None = None,
     preview: Preview | None = None,
     terminal_tools: frozenset[str] = frozenset(),
+    max_parallel_calls: int = 1,
 ) -> Message:
     """先结算已提交调用，再读日志推理并逐条提交；没有 Turn、Attempt 或历史副本。"""
     if type(max_steps) is not int or max_steps < 0:
         raise ValueError("模型请求上限必须是非负整数")
+    if type(max_parallel_calls) is not int or max_parallel_calls < 1:
+        raise ValueError("并行工具上限必须是正整数")
     if reader.session_id != writer.session_id:
         raise ValueError("ReAct reader 与 writer 必须属于同一 Session")
     while True:
-        # 1. 串行策略停止补发并排空已开始调用；换算法无需改 Tool effect owner。
-        for call in _pending_calls(reader.snapshot(), writer.source):
-            await _settle(tools, call)
+        # 1. 结算策略停止补发并排空已开始调用；换算法无需改 Tool effect owner。
+        await _settle_pending(reader, tools, writer.source, max_parallel_calls)
         snapshot = reader.snapshot()
         if terminal_tools and _terminal_result(snapshot, writer.source, tools, terminal_tools):
             return writer.append(uuid4().hex, Output((), "quiet"),

--- a/plugins/scheduler/message_plugin.py
+++ b/plugins/scheduler/message_plugin.py
@@ -92,6 +92,7 @@ async def apply(ctx: Context, config: Config) -> None:
         open=open_list,
         idempotent=True,
         risk="read-only",
+        parallel=True,
     )
 
     async def program(task: Task, reader: MessageReader) -> Message:

--- a/plugins/standard_tools/files.py
+++ b/plugins/standard_tools/files.py
@@ -133,4 +133,5 @@ async def register_file(
         risk=(
             "read-only" if backend_type in (ReadFileTool, ListDirTool) else "read-write"
         ),
+        parallel=backend_type in (ReadFileTool, ListDirTool),
     )

--- a/plugins/standard_tools/skills.py
+++ b/plugins/standard_tools/skills.py
@@ -153,5 +153,5 @@ async def register_skills(ctx: Context) -> ToolRef:
     return await ctx.require(TOOLS).register(
         ctx, name="load_skill", description="按技能名称读取完整指令和固定资源目录；先读取再执行，相对资源以返回的 base_directory 为根。未知、不可用或空技能返回错误。",
         parameters=SkillQuery.model_json_schema(), open=open_tool, capture=capture,
-        risk="read-only", idempotent=True,
+        risk="read-only", idempotent=True, parallel=True,
     )

--- a/plugins/standard_web/web.py
+++ b/plugins/standard_web/web.py
@@ -63,6 +63,6 @@ async def register_web(ctx: Context) -> tuple[ToolRef, ...]:
         refs.append(await ctx.require(TOOLS).register(
             ctx, name=backend.name, description=backend.description,
             parameters=normalize_tool_parameters(backend.parameters), open=open_tool,
-            risk="read-only",
+            risk="read-only", parallel=True,
         ))
     return tuple(refs)

--- a/plugins/tool_search/plugin.py
+++ b/plugins/tool_search/plugin.py
@@ -244,6 +244,7 @@ async def apply(ctx: Context, config: object) -> None:
         public=False,
         idempotent=True,
         risk="read-only",
+        parallel=True,
     )
     view = catalog.view(search_ref)
     _ = await ctx.provide(TOOL_SEARCH_TOOLS, view)

--- a/plugins/tools/execution.py
+++ b/plugins/tools/execution.py
@@ -54,12 +54,14 @@ class ToolExecution:
             raise ValueError("工具调用必须有稳定 key")
         return await self._execute("program:" + key, binding_id, arguments, None)
 
-    async def execute_call(self, reply: MessageReply) -> Result:
+    async def execute_call(
+        self, reply: MessageReply, *, commit_after: asyncio.Event | None = None
+    ) -> Result:
         """同一已提交调用只有一个效果身份，与等待者及结果展示位置无关。"""
         self._state.check_access(reply.reader, reply.writer)
         call = reply.request()
         key = durable_call_key(reply.call_ref)
-        return await self._execute(key, call.binding_id, call.arguments, reply)
+        return await self._execute(key, call.binding_id, call.arguments, reply, commit_after)
 
     async def deny_call(self, reply: MessageReply, reason: str) -> Result:
         """结算不再获准启动的调用；已有执行先排空，崩溃后的 start 不能伪称未发生。"""
@@ -99,6 +101,7 @@ class ToolExecution:
         binding_id: str,
         arguments: Mapping[str, object],
         reply: MessageReply | None,
+        commit_after: asyncio.Event | None = None,
     ) -> Result:
         if not isinstance(binding_id, str) or not binding_id:
             raise ValueError("工具调用必须固定 binding")
@@ -108,7 +111,7 @@ class ToolExecution:
         fingerprint = _fingerprint(binding_id, arguments, reply)
 
         async def run(task: Task) -> Result:
-            return await self._run(task, key, binding_id, arguments, fingerprint, reply)
+            return await self._run(task, key, binding_id, arguments, fingerprint, reply, commit_after)
 
         # 1. 不同插件 scope 共用获授的 Task key，热更不能把活调用当成崩溃。
         def admit(slot: TaskSlot) -> tuple[Task, bool]:
@@ -183,8 +186,15 @@ class ToolExecution:
         arguments: Mapping[str, object],
         fingerprint: str,
         reply: MessageReply | None,
+        commit_after: asyncio.Event | None = None,
     ) -> Result:
         """恢复先查回执；最终授权后先落盘 start，再进入真实工具。"""
+        # 同批并行调用只重叠执行；结果提交仍按模型顺序逐个放行。
+        async def commit(record: OwnerRecord | None, result: Result) -> Result:
+            if commit_after is not None:
+                _ = await commit_after.wait()
+            return finish(self._state, key, record, result, reply)
+
         record = self._record(key, fingerprint)
         if record is not None:
             if record.value["phase"] == "done":
@@ -212,8 +222,8 @@ class ToolExecution:
                     try:
                         final = freeze_json(await tool.prepare(arguments, source))
                     except InvalidArguments as error:
-                        return finish(self._state,
-                            key, record, Result("error", (ContentPart("text", str(error)),)), reply,
+                        return await commit(
+                            record, Result("error", (ContentPart("text", str(error)),)),
                         )
                     if not isinstance(final, Mapping):
                         raise TypeError("工具 prepare 必须返回参数对象")
@@ -234,15 +244,13 @@ class ToolExecution:
                 if started:
                     found = await tool.query(key)
                     if found is not None:
-                        return finish(self._state, key, record, found, reply)
+                        return await commit(record, found)
                     if not tool.idempotent:
-                        return finish(self._state,
-                            key,
+                        return await commit(
                             record,
                             Result(
                                 "error", (ContentPart("text", "原工具调用中断且没有可查询结果；先检查当前状态，不要直接重复执行原操作。"),)
                             ),
-                            reply,
                         )
                 # 4. 只为即将发生的调用授权；撤权不能抹掉可查询的历史结果。
                 try:
@@ -250,14 +258,12 @@ class ToolExecution:
                     if reply is not None:
                         reply.check_start()
                 except Denied as error:
-                    return finish(self._state,
-                        key,
+                    return await commit(
                         record,
                         Result(
                             "interrupted" if started else "denied",
                             (ContentPart("text", str(error)),),
                         ),
-                        reply,
                     )
                 if not task.active:
                     raise asyncio.CancelledError
@@ -273,31 +279,27 @@ class ToolExecution:
                 except BaseException as failure:
                     # start intent 已耐久；内部异常或取消都不能证明远端没有效果。
                     try:
-                        _ = finish(self._state,
-                            key,
+                        _ = await commit(
                             record,
                             Result(
                                 "interrupted" if isinstance(failure, asyncio.CancelledError) else "error",
                                 (ContentPart("text", "工具调用取消，已执行的效果不会撤销。" if isinstance(failure, asyncio.CancelledError) else f"工具执行失败: {type(failure).__name__}；已执行的效果不会撤销。"),),
                             ),
-                            reply,
                         )
                     except Exception as record_failure:
                         raise failure from record_failure
                     raise
-                return finish(self._state, key, record, result, reply)
+                return await commit(record, result)
         except asyncio.CancelledError as failure:
             # 恢复期间取消也终结原 started intent，不能稍后借重试重新发起效果。
             try:
                 current = self._state.read(key)
                 if current is not None and current.value["phase"] == "started":
-                    _ = finish(self._state,
-                        key,
+                    _ = await commit(
                         current,
                         Result(
                             "interrupted", (ContentPart("text", "原工具调用在恢复时取消；已执行的效果不会撤销。"),)
                         ),
-                        reply,
                     )
             except Exception as record_failure:
                 raise failure from record_failure

--- a/plugins/tools/menu.py
+++ b/plugins/tools/menu.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable, Mapping
 from typing import Any, Protocol, cast
 
@@ -154,13 +155,24 @@ class ToolMenu:
         )
         return cast(str, description["name"])
 
+    def parallel(self, binding_id: str) -> bool:
+        """只有注册时显式声明 parallel=True 的调用才允许重叠；失效 binding 一律按串行处理。"""
+        try:
+            description = cast(
+                Mapping[str, object],
+                self._bindings.describe(binding_id, TOOLS)["tool"],
+            )
+        except Exception:
+            return False
+        return description.get("parallel") is True
+
     def check_call(self, call: ToolCall) -> None:
         if call.binding_id not in self._bound.values():
             raise PermissionError("工具请求不属于本次获授 view")
 
-    async def execute(self, call: CallRef) -> Result:
+    async def execute(self, call: CallRef, *, commit_after: asyncio.Event | None = None) -> Result:
         reply = self._reply(call)
         try:
-            return await self._execution.execute_call(reply)
+            return await self._execution.execute_call(reply, commit_after=commit_after)
         finally:
             reply.writer.expire()

--- a/plugins/tools/plugin.py
+++ b/plugins/tools/plugin.py
@@ -131,6 +131,16 @@ class _ToolView:
         self._active = False
 
 
+def _same_description(current: Mapping[str, object], archived: object) -> bool:
+    """归档描述与当前注册逐字段一致；旧归档缺少 parallel 字段时按 False 解释。"""
+    if not isinstance(archived, Mapping):
+        return False
+    candidate = cast(Mapping[str, object], archived)
+    if "parallel" not in candidate:
+        candidate = {**candidate, "parallel": False}
+    return current == candidate
+
+
 class ToolCatalog:
     """普通注册表拥有工具描述、目标与参数准备；不管理消息或循环。"""
 
@@ -174,6 +184,7 @@ class ToolCatalog:
         public: bool = True,
         idempotent: bool = False,
         risk: Literal["read-only", "read-write", "external-side-effect"] = "read-write",
+        parallel: bool = False,
         search_hint: str | None = None,
     ) -> ToolRef:
         """目标自行校验参数 schema；注册表固定发现描述与真实资源入口。"""
@@ -189,7 +200,7 @@ class ToolCatalog:
             raise ValueError("工具风险声明无效")
         if search_hint is not None and not isinstance(search_hint, str):
             raise TypeError("工具搜索提示必须是字符串或 None")
-        if any(type(value) is not bool for value in (idempotent, public)):
+        if any(type(value) is not bool for value in (idempotent, public, parallel)):
             raise TypeError("工具执行和发现选项必须是 bool")
         if capture is not None and not callable(capture):
             raise TypeError("工具 capture 必须是同步回调")
@@ -204,6 +215,7 @@ class ToolCatalog:
                     "parameters": parameters,
                     "idempotent": idempotent,
                     "risk": risk,
+                    "parallel": parallel,
                     "search_hint": search_hint,
                 }
             ),
@@ -380,7 +392,7 @@ class ToolCatalog:
             raise ValueError("工具 binding 描述无效")
         name = description.get("name")
         registration = self._tools.get(name) if isinstance(name, str) else None
-        if registration is None or registration.ref.description != description:
+        if registration is None or not _same_description(registration.ref.description, description):
             raise ValueError("工具 binding 与归档注册不一致")
         preparation = registration.preparation
         authorization = registration.authorization
@@ -420,7 +432,7 @@ class ToolCatalog:
             raise ValueError("工具 binding 缺少工具名")
         registration = self._tools[name]
         preparation = registration.preparation
-        if registration.ref.description != description or metadata["prepare"] != (
+        if not _same_description(registration.ref.description, description) or metadata["prepare"] != (
             None if preparation is None else preparation.name
         ):
             raise ValueError("归档工具描述或参数准备与 binding 不一致")
@@ -462,7 +474,7 @@ class ToolCatalog:
         registration = self._tools.get(cast(str, description["name"]))
         authorization = (
             None
-            if registration is None or registration.ref.description != description
+            if registration is None or not _same_description(registration.ref.description, description)
             else registration.authorization
         )
         if authorization is None or metadata["authorize"] != authorization.name:

--- a/tests/test_message_react.py
+++ b/tests/test_message_react.py
@@ -34,7 +34,8 @@ from session.message import (
 
 @asynccontextmanager
 async def runtime(tmp_path, complete, invoke, *, max_steps=4, authorize_hook=None,
-                  reducer=None, material_source=None, estimate=None, preview_state=None, terminal_tools=frozenset()):
+                  reducer=None, material_source=None, estimate=None, preview_state=None,
+                  terminal_tools=frozenset(), parallel=frozenset(), max_parallel_calls=4):
     log = MessageLog(tmp_path / "sessions.db")
     store = ModelsStore(tmp_path / "models.db", tmp_path / "backups")
     store.initialize()
@@ -56,6 +57,7 @@ async def runtime(tmp_path, complete, invoke, *, max_steps=4, authorize_hook=Non
         max_tool_schemas = None
     model = _BoundChat(descriptor, Driver(), store)
     log.save_binding("tool", {"target": "test-file-effect"})
+    log.save_binding("other", {"target": "test-file-effect"})
     def writer(body, call_ref=None):
         return log.writer(
             "s", author="test", source="conversation", body_types=(body,),
@@ -72,7 +74,7 @@ async def runtime(tmp_path, complete, invoke, *, max_steps=4, authorize_hook=Non
             return None
     @asynccontextmanager
     async def open_tool(binding):
-        assert binding == "tool"
+        assert binding in {"tool", "other"}
         yield Target()
     async def authorize(binding, arguments):
         if authorize_hook is not None:
@@ -87,24 +89,31 @@ async def runtime(tmp_path, complete, invoke, *, max_steps=4, authorize_hook=Non
         def schemas(self) -> tuple[Mapping[str, Any], ...]:
             return ({"type": "function", "function": {
                 "name": "example", "parameters": {"type": "object"},
-            }},)
+            }}, {"type": "function", "function": {
+                "name": "other", "parameters": {"type": "object"},
+            }})
 
         def decode(self, call: ModelToolCall):
             if call.name == "tool_call":
                 assert call.arguments["name"] == "example"
                 return "tool", call.arguments["arguments"]
+            if call.name == "other":
+                return "other", call.arguments
             _, arguments = NativePresentation({"example": {}}).decode(call)
             return "tool", arguments
 
         def name(self, binding: str) -> str:
-            assert binding == "tool"
-            return "example"
+            assert binding in {"tool", "other"}
+            return {"tool": "example", "other": "other"}[binding]
 
-        async def execute(self, ref: CallRef) -> Result:
+        def parallel(self, binding: str) -> bool:
+            return binding in parallel
+
+        async def execute(self, ref: CallRef, *, commit_after: asyncio.Event | None = None) -> Result:
             return await execution.execute_call(MessageReply(
                 "result:" + ref.message_id + ":" + str(ref.part_index), ref,
                 log.reader("s"), writer(ToolResult, ref), self.check_start,
-            ))
+            ), commit_after=commit_after)
 
         def check_start(self) -> None:
             if not self.task.active:
@@ -132,7 +141,8 @@ async def runtime(tmp_path, complete, invoke, *, max_steps=4, authorize_hook=Non
         with preview_state.open(task, reader.session_id, source) if preview_state is not None else nullcontext(None) as preview:
             return await react(reader, output, model=model, context=ContextBuilder(),
                                projection=projection, materials=materials, content=Content(), tools=Menu(task),
-                               max_output_tokens=100, max_steps=max_steps, reduce=reducer, preview=preview, terminal_tools=terminal_tools)
+                               max_output_tokens=100, max_steps=max_steps, reduce=reducer, preview=preview,
+                               terminal_tools=terminal_tools, max_parallel_calls=max_parallel_calls)
     conversation = Conversation(reader=log.reader("s"), inputs=writer(Input), controls=writer(Control),
                                 tasks=tasks)
     async def interrupted_reply(reader, source, ref):
@@ -694,3 +704,128 @@ async def test_mixed_valid_and_rejected_calls_replay_after_restart(tmp_path):
         assert (await (await conversation.start(run)).join()).body.finish == "complete"
         assert log.reader("s").snapshot()[:len(before)] == before
     assert len(effects) == 1 and len(requests) == 2
+
+
+@pytest.mark.asyncio
+async def test_parallel_calls_overlap_but_results_commit_in_model_order(tmp_path):
+    """执行可重叠，但 ToolResult 落盘顺序仍是模型顺序；provider 也只看到模型顺序。"""
+    entered: list[int] = []
+    finished: list[int] = []
+    tail_done = asyncio.Event()
+    release_first = asyncio.Event()
+    requests = []
+
+    async def complete(request):
+        requests.append(request)
+        if len(requests) == 1:
+            return LLMResponse(None, [ModelToolCall("a", "example", {"call": 0}),
+                                      ModelToolCall("b", "example", {"call": 1}),
+                                      ModelToolCall("c", "example", {"call": 2})])
+        rows = [row for row in request.messages if row["role"] == "tool"]
+        assert [row["tool_call_id"] for row in rows] == ["a", "b", "c"]
+        return LLMResponse("done")
+
+    async def invoke(key, arguments):
+        index = cast(int, arguments["call"])
+        entered.append(index)
+        if index == 0:
+            await release_first.wait()
+        finished.append(index)
+        if len(finished) >= 2 and 0 not in finished:
+            tail_done.set()
+        return Result("success", (ContentPart("text", str(index)),))
+
+    async with runtime(tmp_path, complete, invoke,
+                       parallel=frozenset({"tool"})) as (conversation, log, _, run):
+        await conversation.accept("u1", Input(()))
+        task = await conversation.start(run)
+        await asyncio.wait_for(tail_done.wait(), 5)
+        # 1. 后续调用已完成效果，但结果消息仍等首个调用提交，乱序不影响日志顺序。
+        assert not any(isinstance(m.body, ToolResult) for m in log.reader("s").snapshot())
+        release_first.set()
+        await asyncio.wait_for(task.join(), 5)
+        results = [m.body for m in log.reader("s").snapshot() if isinstance(m.body, ToolResult)]
+        assert [r.call_ref.part_index for r in results] == [0, 1, 2]
+        assert sorted(entered) == sorted(finished) == [0, 1, 2]
+        assert len(requests) == 2
+
+
+@pytest.mark.asyncio
+async def test_exclusive_call_separates_parallel_groups(tmp_path):
+    """exclusive 调用是屏障：等前组排空才执行，其后的并行调用等它结算。"""
+    order: list[tuple[str, int]] = []
+    blocked_started = asyncio.Event()
+    gate = asyncio.Event()
+
+    async def complete(request):
+        if not any(row["role"] == "tool" for row in request.messages):
+            return LLMResponse(None, [ModelToolCall("p0", "example", {"call": 0}),
+                                      ModelToolCall("p1", "example", {"call": 1}),
+                                      ModelToolCall("x", "other", {"call": 2}),
+                                      ModelToolCall("p3", "example", {"call": 3})])
+        return LLMResponse("done")
+
+    async def invoke(key, arguments):
+        index = cast(int, arguments["call"])
+        order.append(("start", index))
+        if index == 1:
+            blocked_started.set()
+            await gate.wait()
+        order.append(("end", index))
+        return Result("success", ())
+
+    async with runtime(tmp_path, complete, invoke,
+                       parallel=frozenset({"tool"})) as (conversation, log, _, run):
+        await conversation.accept("u1", Input(()))
+        task = await conversation.start(run)
+        await asyncio.wait_for(blocked_started.wait(), 5)
+        for _ in range(5):
+            await asyncio.sleep(0)
+        # 2. 前组未排空时 exclusive 与其后调用都未开始。
+        assert ("start", 2) not in order and ("start", 3) not in order
+        gate.set()
+        await asyncio.wait_for(task.join(), 5)
+        assert order.index(("start", 2)) > order.index(("end", 1))
+        assert order.index(("start", 3)) > order.index(("end", 2))
+
+
+@pytest.mark.asyncio
+async def test_parallel_group_respects_dispatch_limit(tmp_path):
+    """有界池只放开 limit 个执行；排空槽位前不补发新调用。"""
+    in_flight = 0
+    peak = 0
+    entered: list[int] = []
+    two_entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def complete(request):
+        if not any(row["role"] == "tool" for row in request.messages):
+            return LLMResponse(None, [ModelToolCall("c" + str(i), "example", {"call": i})
+                                      for i in range(4)])
+        return LLMResponse("done")
+
+    async def invoke(key, arguments):
+        nonlocal in_flight, peak
+        index = cast(int, arguments["call"])
+        entered.append(index)
+        in_flight += 1
+        peak = max(peak, in_flight)
+        if in_flight == 2:
+            two_entered.set()
+        await release.wait()
+        in_flight -= 1
+        return Result("success", ())
+
+    async with runtime(tmp_path, complete, invoke, parallel=frozenset({"tool"}),
+                       max_parallel_calls=2) as (conversation, log, _, run):
+        await conversation.accept("u1", Input(()))
+        task = await conversation.start(run)
+        await asyncio.wait_for(two_entered.wait(), 5)
+        for _ in range(5):
+            await asyncio.sleep(0)
+        assert in_flight == 2 and sorted(entered) == [0, 1]
+        release.set()
+        await asyncio.wait_for(task.join(), 5)
+        assert peak == 2 and sorted(entered) == [0, 1, 2, 3]
+        results = [m.body for m in log.reader("s").snapshot() if isinstance(m.body, ToolResult)]
+        assert [r.call_ref.part_index for r in results] == [0, 1, 2, 3]

--- a/tests/test_scheduler_tools.py
+++ b/tests/test_scheduler_tools.py
@@ -29,7 +29,7 @@ async def test_cancel_self_commits_then_lets_original_fire_drain_its_tool(tmp_pa
         def __init__(self) -> None:
             pass
 
-        async def execute(self, call: CallRef) -> Result:
+        async def execute(self, call: CallRef, *, commit_after=None) -> Result:
             result = await target.invoke("cancel-self", prepared)
             results.append(result)
             return result

--- a/tests/test_tool_bindings.py
+++ b/tests/test_tool_bindings.py
@@ -404,3 +404,17 @@ async def test_binding_authorize_checks_final_arguments_and_old_binding_keeps_ol
     finally:
         await host.terminate_all()
         log.close()
+
+
+def test_archived_tool_description_without_parallel_stays_exclusive():
+    """旧归档描述缺少 parallel 字段时按 exclusive 解释，升级后 binding 不失效。"""
+    from plugins.tools.plugin import _same_description
+
+    current = {"name": "example", "parallel": False, "risk": "read-write"}
+    assert _same_description(current, {"name": "example", "risk": "read-write"})
+    assert _same_description(current, {**current})
+    assert not _same_description(
+        current, {"name": "example", "risk": "read-write", "parallel": True}
+    )
+    assert not _same_description(current, {"name": "example"})
+    assert not _same_description(current, "not-a-mapping")


### PR DESCRIPTION
## 问题与结果

- 解决的问题：模型一次响应中的多个工具调用此前只能串行 `_settle`，长耗时只读调用（web_fetch、tool_search、read_file 等）互相排队，单轮 wall-clock 被最慢调用之和放大。
- 用户可见结果：同一模型响应里连续的 `parallel=True` 工具调用重叠执行（有界滚动池，`run_reply` 默认上限 4），exclusive 调用作为屏障；`ToolResult` 与回执仍严格按模型顺序落盘，provider 侧与回放语义与串行执行完全一致。
- 本 PR 不处理：模型把独立调用合并进一个响应的提示词引导（减少 provider 请求轮数的另一半）；按参数动态判定并发安全（参考 dsh `isConcurrencySafe(arguments)`，当前用显式 `parallel` 声明，粒度更粗但 fail-closed）；provider wire 协议、`max_steps` 语义、ToolResult 线格式均不变。

## Change intent

- `change_type`：`feature`
- `semantic_delta`：`compatible`（持久化日志与串行执行同构；旧归档 binding 缺少 `parallel` 字段按 `False` 归一，不失效）
- `capability_owner`：`plugin`（tools 注册表 / react 调度器）
- `consumer_scope`：所有经 `run_reply` → `react` 的工具调用消费方，共享 `max_parallel_calls=4` 上限；直接调 `react` 的调用方默认仍为 1（保守串行）
- `runtime_patch`：`required`
- `runtime_patch_reason`：`asyncio.create_task` 派生的子任务不是 runtime lease 的 owner task，`get_current_runtime_lease()` 返回 `None` 会导致 `writers.bind` 报"授权需要实际 runtime scope"；修复为 `_settle_pending` 解析一次 lease 并显式 fork 传入每个子任务的 `RuntimeScope`
- `authoritative_state_owner`：`ToolExecution` 仍是每个调用的唯一效果 owner（receipt 协议、幂等、授权、abandon 不变）
- `client_only_alternative`：不适用；并发调度必须在 effect owner 所在的 react 循环内做
- `concept_gate`：`required`
- `concept_gate_reason`：改变运行时控制流（工具调用从串行变为受控重叠），需确认不引入新概念——不新增 Turn/Attempt，调度只是 react 循环内的结算策略
- 关联不变量：`finish` 中"ToolResult 消息 + 回执 done 同事务提交"不拆分；`sessions.db/messages` 只追加；已开始调用的取消排空语义不变
- `protected_state`：消息日志、工具回执、binding 归档
- 允许的副作用：`parallel=True` 工具的真实读取效果可互相重叠（HTTP 请求、文件读、内存快照查询）
- 禁止的副作用：exclusive 工具之间、以及与在飞 parallel 组之间的任何重叠；ToolResult 物理 seq 乱序

## 改动范围

- 主要文件：`plugins/react/plugin.py`（`_settle_pending`/`_settle_group` 调度、lease 透传）、`plugins/tools/execution.py`（`commit_after` 提交门，6 个 `finish` 提交点统一门控）、`plugins/tools/plugin.py`（`register(parallel=)` + `_same_description` 归档归一）、`plugins/tools/menu.py`（`parallel()` 分类 + 透传）、`plugins/conversation/program.py`（`max_parallel_calls` 参数）、8 个只读工具标注 `parallel=True`、决策 `docs/decisions/0064`
- 配置或迁移影响：无；旧归档描述自动按 `parallel=False` 解释
- 已知 schema lineage 与最终 schema identity：不变（`parallel` 只进内存工具描述，不进持久 schema）
- 协议 source、runtime、provider 与 scenario 的不可变 revision：不变
- 回滚方式：revert 本提交即恢复串行结算；`parallel` 字段对旧代码只是描述里多余键，无持久污染

## 验证

- [x] 相关 targeted tests 已通过：`test_message_react.py` 46 passed（含 3 个新增确定性并发测试：重叠+保序、exclusive 屏障、上限=2 峰值校验）；`test_tool_bindings.py` 36 passed（含归档无 `parallel` 字段兼容用例）；工具执行/绑定/调度相关批次 41+43 passed
- [x] Python 类型检查或前端 typecheck/lint 已通过；不适用项已说明：pyright 0 errors（仓库既有 warning 数量不变，未新增）
- [x] `python docker/debug/gate.py run --base origin/main` 已运行：GATE PASSED（report `docker/debug/reports/change-gate/20260912-220232-1a95615d`；首跑暴露 lease owner-task 问题，修复后重跑通过）
- `sourceDigest`：`f12ecb5cf1b814602d005672d9faed657714cb2f2de76ae716af05a80cffc56c`
- `planDigest`：`4f5a5f559abc5609904faf7a2b227cca0d7eb382e92d6373984ce47afe162390`
- 真实设备证据（设备/API、debug application ID、源码/APK 身份；不适用时说明）：不适用，纯运行时调度变更，无移动端/设备面
- 未运行项与原因：`tests/` 全量已跑，28 failed / 1842 passed；同一失败集合在 `origin/main` 基线 worktree 上原样复现（socket 协议版本、真实服务依赖、builtin 集成等既有/环境性失败），与本改动无关

## 正交性与概念完整性

- 是否属于架构性 PR 或大改动：`yes`（改变运行时控制流，361 行 diff，无新概念）
- 独立 reviewer / model / reasoning：参考实现比对完成——Codex `FuturesOrdered` + `tool_supports_parallel` 读/写门、deepseek-harness `executionMode` + `runGroup` 有界池 + 连续前缀提交；本实现取两者公共内核（dispatch 重叠 / commit 保序 / exclusive 屏障 / fail-closed 分类）
- 审查 head：`c6f4985a`
- 新增概念及其唯一 owner；没有时写 `none`：`parallel` 注册元数据，owner 为 `ToolCatalog.register`；`commit_after` 提交门只是 `ToolExecution` 内部参数，非新概念
- 无关设计轴的变化传播；没有时写 `none`：none（不动 risk 语义、不动授权、不动 abandon、不动 projection）
- 最短正常/失败/热更新链路：正常—同批 parallel 调用重叠执行、按模型顺序逐个 commit；失败—任一任务异常停止补发，前驱 `settled` 事件在 `finally` 放行后继，绝不死锁；热更新—不同插件 scope 共用 Task key 的既有 admit 逻辑不变
- legacy/source-specific 残留扫描：归档描述比较三处（`_bind_saved`/`open`/`authorize`）统一走 `_same_description` 归一
- must-fix 及处置证据：Gate 首跑失败（runtime lease 在子任务中缺失）已修复并复跑通过
- 最终结论：`pass`

## 工作手册

- [x] 已核对 `projectneed.md`、相关决策和 `NOW.md`。
- [x] 长期语义变化已先获得确认，或本次没有长期语义变化。
- [x] 跨仓库或客户端改动已按 MOB-001 核对能力 owner；不适用时已标明。
- [x] 已完成事项已从 `NOW.md` 删除；当前没有对应事项时标记不适用。

Generated with [Devin](https://devin.ai)