### PR TITLE
test: 让迁移崩溃注入固定到被测模块身份

### DIFF
--- a/tests/test_turn_messages_migration.py
+++ b/tests/test_turn_messages_migration.py
@@ -7,6 +7,10 @@ from pathlib import Path
 import pytest
 
 from plugins.legacy_upgrade.legacy_upgrade_migrations.support.turn_messages import migrate_turn_messages
+from plugins.legacy_upgrade.legacy_upgrade_migrations.support.legacy_message_log import (
+    OwnerStore,
+    OwnerTransaction,
+)
 from plugins.content.api import legacy_post_commit_effect
 from plugins.content.plugin import check_text
 from plugins.sources.session import needs_reply
@@ -196,10 +200,7 @@ def test_archive_never_enters_default_model_content(tmp_path):
 
 @pytest.mark.parametrize('stage', ['before_receipt', 'after_commit'])
 def test_crash_keeps_transaction_atomic_and_retry_uses_same_message_identities(tmp_path, monkeypatch, stage):
-    from plugins.legacy_upgrade.legacy_upgrade_migrations.support.legacy_message_log import (
-        OwnerStore,
-        OwnerTransaction,
-    )
+    # 与被测迁移一起固定类身份；插件重载后的同名导入可能属于另一代模块。
     root = workspace(tmp_path)
     item = user(0)
     old = turn(root, 't1', [item])


### PR DESCRIPTION
## 问题与结果

全量运行中的插件重载会替换同名模块。Turn 迁移测试保留原 migrate_turn_messages 函数，却在测试体内重新导入 OwnerStore/OwnerTransaction，把故障注入挂到另一份类，导致两项 DID NOT RAISE。

本层在加载迁移函数时同时固定其故障注入类。事务回滚、提交后重试、原消息身份与备份完整性断言全部保留；迁移实现、历史 artifact 和数据语义不变。堆叠于 #643。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`none`
- `capability_owner`：`not_applicable`
- `consumer_scope`：Turn migration 的故障注入测试。
- `runtime_patch`：`none`；测试修改。
- `authoritative_state_owner`：原迁移与 Message owner 不变。
- `client_only_alternative`：不适用。
- `concept_gate`：`required`（累计重构统一审查）；本层不新增运行时概念。
- `protected_state`：正式 workspace 零写入。只允许隔离测试与 Git 交付，不 merge/deploy/正式迁移。

## 改动范围

仅 tests/test_turn_messages_migration.py 移动两项 import 并说明模块身份要求。head 8d000d42，父层 6b039170。无 schema/config 变化；revert 可回滚，原文件已备份。

## 验证

- 在独立进程先持有被测迁移，再移除并重新导入 legacy_message_log：旧版本 2 failed，修复后 2 passed；两个阶段仍分别检查真实提交前回滚和提交后重试。
- 完整 Turn migration 测试：29 passed。
- git diff --check 通过。
- 不新增需要单独类型检查的 API；最终累计类型检查、full Gate、CI 和独立概念审查仍待实施收口后执行，sourceDigest / planDigest 待生成。

## 正交性与概念完整性

新增概念 none。测试注入点与被测函数持有相同历史模块身份，不依赖当前同名 alias。独立 reviewer 计划 gpt-5.6-terra / xhigh；累计审查 head 和最终结论待定，保持 Draft。

## 工作手册

已核对 INDEX、WORKFLOW、持久化边界及既有迁移语义；没有长期行为变化，整体 NOW 在最终交付时更新。
