### PR TITLE
修复本地插件类型边界与 Wake 跨 generation 配置

### DIFF
--- a/plugins/computer/dashboard.py
+++ b/plugins/computer/dashboard.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI, HTTPException, Response, WebSocket, WebSocketDiscon
 from starlette.websockets import WebSocketState
 from websockets.asyncio.client import connect
 from websockets.exceptions import ConnectionClosed, InvalidHandshake
+from websockets.typing import Subprotocol
 
 from agent.plugin_composition import DashboardContext
 
@@ -56,7 +57,7 @@ def register(app: FastAPI, context: DashboardContext) -> httpx.Client:
             for item in socket.headers.get("sec-websocket-protocol", "").split(",")
             if item.strip()
         }
-        protocols = ["binary"] if "binary" in requested else None
+        protocols = [Subprotocol("binary")] if "binary" in requested else None
         try:
             upstream_context = connect(
                 display,

--- a/plugins/computer/mcp_server.py
+++ b/plugins/computer/mcp_server.py
@@ -88,7 +88,7 @@ def prune_screenshots(screenshot_dir: Path, *, keep: Path) -> None:
         path.unlink()
 
 
-def screenshot_result(raw: bytes, media_type: str) -> dict[str, object]:
+def screenshot_result(raw: bytes, media_type: str) -> dict[str, list[dict[str, str]]]:
     """Return a file reference that both text and multimodal agents can consume."""
 
     path = save_screenshot(raw, media_type)

--- a/plugins/message_push/boundary.py
+++ b/plugins/message_push/boundary.py
@@ -23,8 +23,11 @@ class CallSource(Protocol):
     @property
     def effect_key(self) -> str: ...
 
-    call_ref: CallRef
-    messages: tuple[Message, ...]
+    @property
+    def call_ref(self) -> CallRef: ...
+
+    @property
+    def messages(self) -> tuple[Message, ...]: ...
 
 
 ToolOutcome = Literal["success", "denied", "error", "interrupted"]

--- a/plugins/reply/follow.py
+++ b/plugins/reply/follow.py
@@ -22,7 +22,8 @@ class SourceSession(Protocol):
 class Source(Protocol):
     @property
     def name(self) -> str: ...
-    def open(self, session_id: str) -> SourceSession: ...
+    @property
+    def open(self) -> Callable[[str], SourceSession]: ...
 
 
 class Sources(Protocol):

--- a/plugins/wake/runtime.py
+++ b/plugins/wake/runtime.py
@@ -28,7 +28,7 @@ from ._boundary import (
     ToolView,
     WAKE_TOOLS_VIEW,
 )
-from .api import Config, DRIFT_WAKE, EVENTMAIL_WAKE
+from .api import Config, DeliveryTarget, DRIFT_WAKE, EVENTMAIL_WAKE
 from .legacy_rules import read_archived_rules
 from .messages import recent_context
 from .request import Request, TOOLS as WAKE_TOOLS, WAKE_PROGRAM
@@ -143,7 +143,7 @@ class Runtime:
     """Timer 与来源变化只提供检查机会；原请求提交后由 Source 恢复真实执行。"""
 
     def __init__(self, ctx: Context, config: Config, *, now: Callable[[], datetime] = lambda: datetime.now(UTC)):
-        self.ctx, self.config, self.now = ctx, config, now
+        self.ctx, self.config, self.now = ctx, self._current_config(config), now
         self.state = WakeState(ctx.data_root / "wake.sqlite3")
         # Runtime owns creation and schema validation. Dashboard readers only
         # open this already-initialized file read-only.
@@ -151,6 +151,14 @@ class Runtime:
         self.source = Source(ctx, self.state, now=now)
         self.duties = Duties(ctx.require(EVENTMAIL_WAKE), ctx.require(DRIFT_WAKE), self.state, ctx.require(SEMANTIC_INTEREST))
         self.changed = asyncio.Event()
+
+    @staticmethod
+    def _current_config(config: Config) -> Config:
+        """把跨 generation 的配置值重建为当前 Wake 模块的类型。"""
+        target = config.delivery
+        if type(config) is Config and (target is None or type(target) is DeliveryTarget):
+            return config
+        return Config.model_validate(config.model_dump(mode="python"))
 
     def dashboard_view(self) -> DashboardView:
         """Build a dashboard view from narrow read-only callbacks."""

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -11,7 +11,6 @@
     "core",
     "infra",
     "memory2",
-    "prompts",
     "session"
   ],
   "exclude": [

--- a/tests/legacy_migration_loader.py
+++ b/tests/legacy_migration_loader.py
@@ -8,10 +8,12 @@ from pathlib import Path
 import shutil
 import sys
 from types import ModuleType
+from typing import cast
 
 import yoyo
 
 from agent.migrations.bundles import (
+    MigrationBundle,
     _read_migrations,
     migration_import_paths,
 )
@@ -30,8 +32,9 @@ class _TestBundle:
     migration_root: Path
 
 
-def _bundle(root: Path) -> _TestBundle:
-    return _TestBundle(package_name=_PACKAGE_NAME, migration_root=root)
+def _bundle(root: Path) -> MigrationBundle:
+    # 私有导入 helper 只读取这两个字段；完整 manifest 校验由安装测试覆盖。
+    return cast(MigrationBundle, _TestBundle(package_name=_PACKAGE_NAME, migration_root=root))
 
 
 def _clear_package() -> None:

--- a/tests/mobile_realtime/test_channel.py
+++ b/tests/mobile_realtime/test_channel.py
@@ -1125,7 +1125,7 @@ async def test_lazy_mcp_catalog_error_does_not_abort_next_command(tmp_path: Path
     from agent.plugins.snapshot import RuntimeSnapshot
     from infra.mobile_realtime.runtime_inspection import _mcp_items
 
-    snapshot = RuntimeSnapshot("lazy-mcp", {}, None)
+    snapshot = RuntimeSnapshot("lazy-mcp", {}, ())
     snapshot.mcp_server_registry = cast(Any, SimpleNamespace(
         descriptors=(SimpleNamespace(owner="computer", name="computer"),),
     ))

--- a/tests/test_agent_restart_tool.py
+++ b/tests/test_agent_restart_tool.py
@@ -408,6 +408,7 @@ async def test_restart_tool_binds_invoke_to_prepared_durable_call() -> None:
     assert isinstance(rejected, str) and "只能包含 reason" in rejected
     assert tool._prepared is None
     prepared = await tool.prepare({"reason": " reload "}, source)
+    assert isinstance(prepared, Mapping)
     pending = tool._prepared
     assert pending is not None
     assert prepared == {"reason": "reload"}

--- a/tests/test_akasha_consumption_migration.py
+++ b/tests/test_akasha_consumption_migration.py
@@ -9,7 +9,7 @@ from yoyo import get_backend
 from plugins.legacy_upgrade.legacy_upgrade_migrations.support.akasha_consumption import cutover_akasha
 from agent.migrations.context import bind_migration_context
 from plugins.akasha.application.rebuild import rebuild_memory
-from plugins.akasha.domain.model import MemoryConfig
+from plugins.legacy_upgrade.legacy_upgrade_migrations.support.akasha.domain.model import MemoryConfig
 from plugins.akasha.infrastructure.persistence import load_consumption, logical_state_sha256, sha256_file
 from plugins.akasha.infrastructure.sparse_index import BuildConfig, build_sparse_index
 from session.embedding_store import MessageEmbeddingStore

--- a/tests/test_akasha_message_plugin.py
+++ b/tests/test_akasha_message_plugin.py
@@ -4,7 +4,7 @@ from contextlib import asynccontextmanager
 from collections.abc import Callable, Mapping
 from pathlib import Path
 import shutil
-from typing import Literal
+from typing import Literal, cast
 
 import pytest
 
@@ -20,6 +20,19 @@ from plugins.akasha.message_plugin import AKASHA_TOOLS
 from agent.plugin_composition.bindings import BINDINGS
 from session.log import MessageLog
 from session.message import CallRef, ContentPart, ContentReferences, Input, Output, ToolCall, ToolResult
+
+
+def _reference_rows(material: Mapping[str, object]) -> tuple[Mapping[str, object], ...]:
+    """把材料中的引用值窄化为测试需要的行结构。"""
+    references = material["references"]
+    if not isinstance(references, (list, tuple)):
+        raise AssertionError("材料引用必须是列表")
+    rows: list[Mapping[str, object]] = []
+    for reference in references:
+        if not isinstance(reference, Mapping):
+            raise AssertionError("材料引用行必须是对象")
+        rows.append(cast(Mapping[str, object], reference))
+    return tuple(rows)
 
 
 @asynccontextmanager
@@ -111,14 +124,17 @@ async def test_actual_plugin_learns_provides_materials_and_runs_archived_recall_
                 inputs.append("q", Input((ContentPart("text", "remember the detail"),)))
                 async with ctx.require(MATERIALS).bind() as materials:
                     material = await materials.prepare(log.reader("s").snapshot(), "conversation")
-                assert [ref["ref"] for ref in material["references"]] == ["u", "a"]
+                material_references = _reference_rows(material)
+                assert [ref["ref"] for ref in material_references] == ["u", "a"]
                 # 普通兴趣服务只嵌入候选，复用真实已完成问答的固定向量。
                 before_interest = (tmp_path / "embedding-calls.txt").read_text()
                 interest = ctx.require(ServiceKey("akasha.semantic-interest.v1"))
                 assert await interest.score(["candidate interest", ""], cutoff=datetime.now(timezone.utc).isoformat()) == (0.999, 0.0)
                 assert (tmp_path / "embedding-calls.txt").read_text()[len(before_interest):] == "['candidate interest']\n"
                 read_recall = ctx.require(ServiceKey("akasha.recalls.v1"))
-                observed = read_recall(material["references"][0]["retrieval_ref"])
+                retrieval_ref = material_references[0]["retrieval_ref"]
+                assert isinstance(retrieval_ref, str)
+                observed = read_recall(retrieval_ref)
                 assert observed.graph_version == 1
                 # 显式归档材料查询不争抢仍在运行的正式学习 writer。
                 from plugins.akasha.infrastructure.lease import WriterLease
@@ -132,7 +148,8 @@ async def test_actual_plugin_learns_provides_materials_and_runs_archived_recall_
                 async with host.open_binding(tuple(archive_refs)) as archived:
                     async with archived.require(MATERIALS).bind() as view:
                         copied = await view.prepare(log.reader("s").snapshot(), "conversation")
-                    assert [ref["ref"] for ref in copied["references"]] == ["u", "a"]
+                    copied_references = _reference_rows(copied)
+                    assert [ref["ref"] for ref in copied_references] == ["u", "a"]
                 assert logical_state_sha256(graph) == before_graph
                 with pytest.raises(RuntimeError, match="already has a writer"):
                     WriterLease(graph)
@@ -164,8 +181,9 @@ async def test_actual_plugin_learns_provides_materials_and_runs_archived_recall_
                             if isinstance(message.body, ToolResult)]) == 1
                 async with ctx.require(MATERIALS).bind() as materials:
                     after_tool = await materials.prepare(log.reader("s").snapshot(), "conversation")
-                assert [reference["ref"] for reference in after_tool["references"]] == ["u", "a"]
-                assert {reference["retrieval_ref"] for reference in after_tool["references"]} == {retrieval_ref}
+                after_tool_references = _reference_rows(after_tool)
+                assert [reference["ref"] for reference in after_tool_references] == ["u", "a"]
+                assert {reference["retrieval_ref"] for reference in after_tool_references} == {retrieval_ref}
                 # 同 owner 的另一条调用也不能借用先前 CallRef 的查询事实。
                 outputs.append("forged-request", Output((ToolCall(identity, {"query": "another query"}),), "continue"))
                 forged_ref = CallRef("forged-request", 0)
@@ -201,9 +219,10 @@ async def test_prepared_recall_survives_config_change_and_source_removal(tmp_pat
                 inputs.append("q", Input((ContentPart("text", "recall it"),)))
                 async with ctx.require(MATERIALS).bind() as materials:
                     result = await materials.prepare(log.reader("s").snapshot(), "conversation")
-                    assert [reference["ref"] for reference in result["references"]] == ["u", "a"]
+                    assert [reference["ref"] for reference in _reference_rows(result)] == ["u", "a"]
                 async with open_tool(bindings, identity) as tool:
                     prepared = await tool.prepare({"query": "original memory"})
+                    assert isinstance(prepared, Mapping)
 
     # 重启前改变可变配置并移除源码；归档闭包仍须使用原配置、原图与原预算。
     config_path.write_text('db_path = "other.db"\ninject_max_chars = 1\n')
@@ -341,7 +360,9 @@ async def test_mobile_inspector_bounds_long_messages_without_dropping_hit_member
                 inputs.append("query", Input((ContentPart("text", "recall it"),)))
                 async with ctx.require(MATERIALS).bind() as materials:
                     prepared = await materials.prepare(log.reader("s").snapshot(), "conversation")
-                    identity = prepared["references"][0]["retrieval_ref"]
+                    references = _reference_rows(prepared)
+                    identity = references[0]["retrieval_ref"]
+                    assert isinstance(identity, str)
         provider = PluginMobileUiProvider(host)
         try:
             detail = await provider.query("akasha", revision, "inspector.detail", {"query_id": identity},

--- a/tests/test_akasha_recall_tool.py
+++ b/tests/test_akasha_recall_tool.py
@@ -1,5 +1,5 @@
 import pytest
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from contextlib import asynccontextmanager
 
 from agent.plugin_composition.models import EmbeddingResult, EmbeddingSpaceDescriptor
@@ -45,6 +45,7 @@ async def test_recall_tool_recovers_original_query_after_graph_advances_without_
         assert await runtime.consume() == 1
         recall = target(tmp_path, runtime)
         arguments = await recall.prepare({"query": "original memory"})
+        assert isinstance(arguments, Mapping)
         result = await recall.invoke("request", arguments)
         observed = records.read("tool:request")
         assert observed.source.kind == "program"
@@ -84,6 +85,7 @@ async def test_prepared_recall_keeps_learning_model_and_budget_when_defaults_cha
         assert await runtime.consume() == 1
         original = target(tmp_path, runtime, max_chars=100)
         prepared = await original.prepare({"query": "recall"})
+        assert isinstance(prepared, Mapping)
         changed = target(tmp_path, runtime, binding="unavailable-new-rule", model_id="new-default", max_chars=1)
         result = await changed.invoke("prepared", prepared)
         record = records.read("tool:prepared")
@@ -101,6 +103,7 @@ async def test_bad_embedding_never_publishes_query_or_changes_learning(tmp_path,
             return values
         recall = target(tmp_path, runtime, embed=invalid)
         prepared = await recall.prepare({"query": "test"})
+        assert isinstance(prepared, Mapping)
         with pytest.raises(ValueError, match="embedding"):
             await recall.invoke("invalid", prepared)
         assert records.read("tool:invalid") is None

--- a/tests/test_channel_identities.py
+++ b/tests/test_channel_identities.py
@@ -43,8 +43,12 @@ def test_yoyo_preserves_known_aliases_original_data_and_unknown_sources(tmp_path
         original = tuple(db.iterdump())
         sessions = db.execute("SELECT * FROM sessions ORDER BY key").fetchall()
     entry = load_migration_module("20260906_04_channel_identities")
+    steps = entry["steps"]
+    assert isinstance(steps, list)
+    migrate = steps[0]
+    assert callable(migrate)
     with bind_migration_context(config_path=config, workspace=tmp_path):
-        entry["steps"][0](None)
+        migrate(None)
     with closing(ChannelIdentities(path)) as identities:
         assert identities.load("telegram_work") == {"alice": "z"}
         assert identities.resolve("feishu", "ou_123") == "room"
@@ -60,7 +64,7 @@ def test_yoyo_preserves_known_aliases_original_data_and_unknown_sources(tmp_path
         assert db.execute("SELECT * FROM sessions ORDER BY key").fetchall() == sessions
         committed = tuple(db.iterdump())
     with bind_migration_context(config_path=config, workspace=tmp_path):
-        entry["steps"][0](None)
+        migrate(None)
     with closing(sqlite3.connect(path)) as db:
         assert tuple(db.iterdump()) == committed
     assert len(tuple((tmp_path / "backups/channel-identities").glob("*/manifest.json"))) == 1

--- a/tests/test_channel_input.py
+++ b/tests/test_channel_input.py
@@ -372,7 +372,9 @@ async def test_mobile_restart_replays_input_once_and_only_finishes_transport(
                                  (5, "message_embeddings"), (6, "message_artifacts")]:
                 from tests.legacy_migration_loader import load_migration_module
                 module = load_migration_module(f"20260905_{number:02d}_{name}")
-                module[f"migrate_{name}"](None)
+                migrate = module[f"migrate_{name}"]
+                assert callable(migrate)
+                migrate(None)
 
     # 2. 分别模拟正文提交前与提交后进程结束，重开都不能重复正文。
     if committed:
@@ -601,7 +603,9 @@ async def test_channel_input_imported_artifact_is_pinned_and_read_lease_closed(t
                                  (5, "message_embeddings"), (6, "message_artifacts")]:
                 from tests.legacy_migration_loader import load_migration_module
                 module = load_migration_module(f"20260905_{number:02d}_{name}")
-                module[f"migrate_{name}"](None)
+                migrate = module[f"migrate_{name}"]
+                assert callable(migrate)
+                migrate(None)
         opened = []
         acquire = artifacts.acquire
         async def track(ref):

--- a/tests/test_context_materials.py
+++ b/tests/test_context_materials.py
@@ -160,7 +160,9 @@ async def test_program_excludes_retrieval_without_running_it_or_losing_persona()
         # 显式排除不改变全局注册；普通回复仍能取得原有检索。
         async with service.bind() as view:
             result = await view.prepare((), "conversation")
-        assert result["reminders"][0]["text"] == "retrieved private context"
+        reminders = result["reminders"]
+        assert isinstance(reminders, tuple)
+        assert reminders[0]["text"] == "retrieved private context"
 
 
 @pytest.mark.asyncio
@@ -265,8 +267,10 @@ async def test_reminder_order_uses_owner_and_name_and_keeps_each_request_snapsho
             before = await view.prepare((), "conversation")
             current = "new"
             after = await view.prepare((), "conversation")
-        assert [item["text"] for item in before["reminders"]] == ["early", "evil-a", "old", "trusted-z"]
-        assert [item["text"] for item in after["reminders"]] == ["early", "evil-a", "new", "trusted-z"]
+        before_reminders, after_reminders = before["reminders"], after["reminders"]
+        assert isinstance(before_reminders, tuple) and isinstance(after_reminders, tuple)
+        assert [item["text"] for item in before_reminders] == ["early", "evil-a", "old", "trusted-z"]
+        assert [item["text"] for item in after_reminders] == ["early", "evil-a", "new", "trusted-z"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_core_messages.py
+++ b/tests/test_core_messages.py
@@ -323,9 +323,11 @@ async def test_saved_embedding_enables_same_root_and_space_change_preserves_grap
                 sent = len(calls)
                 async with ctx.require(MATERIALS).bind() as materials:
                     result = await materials.prepare(core.message_log.reader("fixture").snapshot(), "conversation")
+                reminders = result["reminders"]
+                assert isinstance(reminders, tuple)
                 status = next(
                     part["text"]
-                    for part in result["reminders"]
+                    for part in reminders
                     if part["name"] == "status"
                 )
                 assert "召回不可用" in status and "重建" in status
@@ -341,7 +343,9 @@ async def test_saved_embedding_enables_same_root_and_space_change_preserves_grap
                 })
                 async with ctx.require(MATERIALS).bind() as materials:
                     result = await materials.prepare(core.message_log.reader("fixture").snapshot(), "conversation")
-                assert not any(part["name"] == "status" for part in result["reminders"])
+                reminders = result["reminders"]
+                assert isinstance(reminders, tuple)
+                assert not any(part["name"] == "status" for part in reminders)
                 assert all(item.healthy for item in snapshot.composition_root.receipt().health if item.owner == "akasha")
                 assert logical_state_sha256(graph) == before
                 assert core.plugin_manager.current_snapshot is root

--- a/tests/test_delivery_policy.py
+++ b/tests/test_delivery_policy.py
@@ -100,8 +100,8 @@ async def test_failed_sink_does_not_cancel_other_sink_and_restart_keeps_original
                         content={"text": lambda part: ContentReferences()})
     message = writer.append("answer", Output((ContentPart("text", "original"),), "complete"))
     selected = (
-        Sink(name="bad", binding_id="bad-A", address="bad-original"),
-        Sink(name="good", binding_id="good-A", address="good-original"),
+        {"name": "bad", "binding_id": "bad-A", "address": "bad-original"},
+        {"name": "good", "binding_id": "good-A", "address": "good-original"},
     )
     watcher = asyncio.create_task(follow(Scope(), log.catalog(), execution, lambda *_: selected))
     try:

--- a/tests/test_durable_deliveries.py
+++ b/tests/test_durable_deliveries.py
@@ -500,7 +500,7 @@ def test_candidate_fence_keeps_akashic_crash_recovery_target(
         return RuntimeSnapshot(
             "candidate",
             {},
-            None,
+            (),
             composition_topology=TopologyView(
                 generation_id="root:candidate",
                 identity="topology:candidate",
@@ -586,7 +586,7 @@ def test_candidate_fence_ignores_nonrecoverable_terminal_rows(
     snapshot = RuntimeSnapshot(
         "candidate",
         {},
-        None,
+        (),
         composition_topology=TopologyView(
             "root:candidate", "topology:candidate", 1, (), (), (), ()
         ),

--- a/tests/test_external_channel_owners.py
+++ b/tests/test_external_channel_owners.py
@@ -20,7 +20,7 @@ from agent.plugin_composition import (
     DeliveryStatus,
     ProviderDeliveryRequest,
 )
-from agent.plugin_composition.channels import ChannelRuntimePorts
+from agent.plugin_composition.channels import ChannelRuntimePorts, ChannelAttachmentReadPort
 from plugins.qq_channel import channel as qq_channel
 from plugins.telegram_channel import channel as telegram_channel
 
@@ -63,7 +63,7 @@ class _ProviderFactory:
         self.client = _ProviderClient()
         self.create_calls = 0
 
-    async def create(self, _credentials: object) -> _ProviderClient:
+    async def create(self, credentials: object) -> _ProviderClient:
         self.create_calls += 1
         return self.client
 
@@ -106,7 +106,7 @@ def _context(
     *,
     config: dict[str, object],
     credentials: dict[str, CredentialRef] | None = None,
-    attachment_read: object | None = None,
+    attachment_read: ChannelAttachmentReadPort | None = None,
 ) -> tuple[ChannelFactoryContext, _Ingress, _ProviderFactory]:
     ingress = _Ingress()
     provider = _ProviderFactory()

--- a/tests/test_installed_reply_delivery.py
+++ b/tests/test_installed_reply_delivery.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 """正式安装的业务组合经真实 HTTP driver/sender 写入最终送达回执。"""
 
 import asyncio
@@ -205,7 +206,9 @@ async def test_installed_reply_reaches_sender_and_durable_receipt(tmp_path, monk
             saved = reopened.owner("plugin:delivery@acceptance").scan(start="delivery:", stop="delivery;")
             assert len(saved) == 1
             assert saved[0][1].value["phase"] == "delivered"
-            assert saved[0][1].value["receipt"]["provider_ids"] == ("731",)
+            receipt = saved[0][1].value["receipt"]
+            assert isinstance(receipt, Mapping)
+            assert receipt["provider_ids"] == ("731",)
         finally:
             reopened.close()
     finally:

--- a/tests/test_message_compaction_records.py
+++ b/tests/test_message_compaction_records.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 import hashlib
 import json
 from contextlib import closing
@@ -203,7 +204,10 @@ async def apply(ctx, config):
             ctx = snapshot.composition_root.context
             async with ctx.require(MATERIALS).bind() as view:
                 prepared = await view.prepare(log.reader("s").snapshot(), "conversation")
-                reference = prepared["summary"]["reference"]
+                summary = prepared["summary"]
+                assert isinstance(summary, Mapping)
+                reference = summary["reference"]
+                assert isinstance(reference, str)
             metadata = ctx.require(BINDINGS).describe(reference, COMPACTION_SUMMARIES)
             assert metadata == {"record_ref": "first", "session_id": "s"}
         writer = log.writer("s", author="assistant", source="conversation", body_types=(Output,),

--- a/tests/test_message_embeddings.py
+++ b/tests/test_message_embeddings.py
@@ -78,10 +78,12 @@ def test_yoyo_embedding_owner_preserves_existing_vectors_and_backs_up_missing_sc
             store.close()
     before = path.read_bytes()
     migration = load_migration_module("20260905_05_message_embeddings")
+    migrate = migration["migrate_message_embeddings"]
+    assert callable(migrate)
     with bind_migration_context(config_path=tmp_path / 'config.toml', workspace=tmp_path):
-        migration["migrate_message_embeddings"](None)
+        migrate(None)
         once = path.read_bytes()
-        migration["migrate_message_embeddings"](None)
+        migrate(None)
     assert path.read_bytes() == once
     with closing(sqlite3.connect(path)) as db:
         assert db.execute('SELECT value FROM unrelated_owner').fetchall() == [('preserved',)]
@@ -104,8 +106,10 @@ def test_yoyo_embedding_owner_rejects_unknown_schema_before_backup(tmp_path):
         db.execute('CREATE TABLE message_embeddings (message_id TEXT)')
     before = path.read_bytes()
     migration = load_migration_module("20260905_05_message_embeddings")
+    migrate = migration["migrate_message_embeddings"]
+    assert callable(migrate)
     with bind_migration_context(config_path=tmp_path / 'config.toml', workspace=tmp_path):
         with pytest.raises(RuntimeError, match='schema lineage'):
-            migration["migrate_message_embeddings"](None)
+            migrate(None)
     assert path.read_bytes() == before
     assert not (tmp_path / 'backups').exists()

--- a/tests/test_message_markdown_memory.py
+++ b/tests/test_message_markdown_memory.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections.abc import Mapping
 from typing import Literal, cast
 import shutil
 from pathlib import Path
@@ -17,11 +18,24 @@ from plugins.content.plugin import check_text
 from plugins.context.api import check_summary
 from plugins.context.plugin import ContextBuilder
 from plugins.context.materials import MATERIALS
-from plugins.markdown_memory._boundaries import COMPACTION_READER, CONTENT, CONTEXT
-from plugins.turn_projection.plugin import TURN_PROJECTION
+from plugins.markdown_memory._boundaries import (
+    COMPACTION_READER,
+    CONTENT,
+    CONTEXT,
+    CompactionReader as MarkdownCompactionReader,
+    TURN_PROJECTION,
+)
 from plugins.markdown_memory.store import MarkdownProfileStore
 from session.log import MessageLog, SessionAttributes
 from session.message import ContentPart, Input, Output
+
+
+def _system_prompt(material: Mapping[str, object]) -> str:
+    """读取并窄化 markdown 材料中的系统提示。"""
+    value = material["system_prompt"]
+    if not isinstance(value, str):
+        raise AssertionError("system_prompt 必须是字符串")
+    return value
 
 
 @asynccontextmanager
@@ -321,7 +335,7 @@ async def test_markdown_replays_output_after_restart_and_does_not_skip_unused_pa
         async with lease_runtime_snapshot(host.snapshot_store) as snapshot:
             async with snapshot.composition_root.context.require(MATERIALS).bind() as materials:
                 prepared = await materials.prepare(log.reader("s").snapshot(), "conversation")
-                assert "fact-two" in prepared["system_prompt"]
+                assert "fact-two" in _system_prompt(prepared)
         await record_use(log, host, used, "duplicate-use", "complete")
     async with application(tmp_path, start=True) as (log, host):
         await wait_applied(tmp_path, host, used.reference)
@@ -545,8 +559,9 @@ async def test_profile_model_work_keeps_materials_readable_and_updates_serial(tm
             async with lease_runtime_snapshot(host.snapshot_store) as snapshot:
                 async with snapshot.composition_root.context.require(MATERIALS).bind() as materials:
                     prepared = await asyncio.wait_for(materials.prepare((), "conversation"), 1)
-                assert before[1].strip() in prepared["system_prompt"]
-                assert "fact-one" not in prepared["system_prompt"]
+                prompt = _system_prompt(prepared)
+                assert before[1].strip() in prompt
+                assert "fact-one" not in prompt
             assert (store.read_memory(), store.read_self(), store.read_writes(None, 100)) == before
             if cancel_first:
                 first.cancel()
@@ -592,7 +607,7 @@ async def test_an_update_lock_alone_does_not_create_a_partial_profile_state(tmp_
         async with lease_runtime_snapshot(host.snapshot_store) as snapshot:
             async with snapshot.composition_root.context.require(MATERIALS).bind() as materials:
                 prepared = await materials.prepare((), "conversation")
-        assert "# Akashic 的自我认知" in prepared["system_prompt"]
+        assert "# Akashic 的自我认知" in _system_prompt(prepared)
         assert tuple(path.parent.iterdir()) == (path,)
 
 
@@ -821,12 +836,12 @@ async def test_profile_batches_keep_whole_turns_and_write_only_after_all_succeed
             with pytest.raises(TransportError, match="second batch"):
                 await prepare_profile_draft(
                     groups, before[0], before[1], models,
-                    compaction=compaction, is_user_input=is_user_input,
+                    compaction=cast(MarkdownCompactionReader, compaction), is_user_input=is_user_input,
                 )
         else:
             draft = await prepare_profile_draft(
                 groups, before[0], before[1], models,
-                compaction=compaction, is_user_input=is_user_input,
+                compaction=cast(MarkdownCompactionReader, compaction), is_user_input=is_user_input,
             )
             assert draft["memory_before"] == before[0]
             assert isinstance(draft["memory"], str)

--- a/tests/test_message_react.py
+++ b/tests/test_message_react.py
@@ -99,14 +99,14 @@ async def runtime(tmp_path, complete, invoke, *, max_steps=4, authorize_hook=Non
                 return ToolCallDecode(None, {}, {"name": call.name, "arguments": call.arguments, "error": decoded})
             return ToolCallDecode("tool", decoded[1])
 
-        def name(self, binding: str) -> str:
-            assert binding == "tool"
+        def name(self, binding_id: str) -> str:
+            assert binding_id == "tool"
             return "example"
 
-        async def execute(self, ref: CallRef) -> Result:
+        async def execute(self, call: CallRef) -> Result:
             return await execution.execute_call(MessageReply(
-                "result:" + ref.message_id + ":" + str(ref.part_index), ref,
-                log.reader("s"), writer(ToolResult, ref), self.check_start,
+                "result:" + call.message_id + ":" + str(call.part_index), call,
+                log.reader("s"), writer(ToolResult, call), self.check_start,
             ))
 
         def check_start(self) -> None:
@@ -485,7 +485,9 @@ async def test_react_reduces_one_prepared_request_and_bounds_provider_retry(tmp_
         assert materials["system_prompt"] == "fixed prompt"
         reductions.append(force)
         if case == "no_progress" or (case in {"provider", "second_overflow"} and not force):
-            return materials["summary"]
+            summary = materials["summary"]
+            assert summary is None or isinstance(summary, Mapping)
+            return summary
         summary = Summary("published", ("old-user", "old-reply"), "durable old history")
         state.transact(lambda tx: tx.save("published", {"summary": summary.content}, expected_version=None))
         return {"reference": summary.reference, "source_message_ids": summary.source_message_ids, "content": summary.content}

--- a/tests/test_message_view.py
+++ b/tests/test_message_view.py
@@ -199,7 +199,9 @@ async def test_runtime_display_discovers_new_kind_and_releases_each_generation(s
             rows = await reader(page, display_only=True)
             expected = {"kind": "example.fact", "display": "unavailable"} if label is None else {
                 "kind": "example.fact", "value": {"label": label}}
-            assert rows[0]["body"]["parts"] == [expected]
+            body = rows[0]["body"]
+            assert isinstance(body, Mapping)
+            assert body["parts"] == [expected]
             assert selected.lease_count == 0
     finally:
         await store.close()

--- a/tests/test_migration_runner.py
+++ b/tests/test_migration_runner.py
@@ -161,9 +161,9 @@ def _catalog(root: Path, migration_ids: tuple[str, ...]) -> Path:
     external_ids = tuple(
         migration_id for migration_id in migration_ids if migration_id != _ORIGIN_ID
     )
+    bundle = root / "plugins" / "legacy_upgrade"
+    migration_root = bundle / "legacy_upgrade_migrations"
     if external_ids:
-        bundle = root / "plugins" / "legacy_upgrade"
-        migration_root = bundle / "legacy_upgrade_migrations"
         migration_root.mkdir(parents=True)
         shutil.copy2(
             _PROJECT_ROOT / "plugins/legacy_upgrade/legacy_upgrade_migrations/__init__.py",

--- a/tests/test_mobile_input_migration.py
+++ b/tests/test_mobile_input_migration.py
@@ -55,7 +55,9 @@ def current_storage(path):
     """旧迁移完成后应用当前失败合同，再交给当前运行时读取。"""
     from tests.test_execution_failure_migration import load_migration
     module = load_migration()
-    module['_migrate'](path, 'mobile_command_receipts', module['_MOBILE_OLD'], module['_MOBILE_NEW'], path.parent / 'failure-backups')
+    migrate = module["_migrate"]
+    assert callable(migrate)
+    migrate(path, 'mobile_command_receipts', module['_MOBILE_OLD'], module['_MOBILE_NEW'], path.parent / 'failure-backups')
     return MobileRealtimeStorage(path)
 
 
@@ -120,8 +122,12 @@ def test_yoyo_uses_the_configured_mobile_database(tmp_path, monkeypatch):
     monkeypatch.setattr(yoyo, 'step', lambda callback: callback)
     from tests.legacy_migration_loader import load_migration_module
     module = load_migration_module("20260906_05_mobile_input_rejections")
+    steps = module["steps"]
+    assert isinstance(steps, list)
+    migrate = steps[0]
+    assert callable(migrate)
     with bind_migration_context(config_path=config, workspace=workspace):
-        module['steps'][0](None)
+        migrate(None)
     with closing(current_storage(path)) as storage:
         assert storage.pending_message_rejections()
     assert list((workspace / 'backups/mobile-input-rejections').glob('*/custom-mobile.db'))

--- a/tests/test_model_call_records.py
+++ b/tests/test_model_call_records.py
@@ -236,7 +236,9 @@ def test_migration_preserves_registry_and_lost_ack_preserves_real_call(
     run_timing_migration(timing_migration, store.path.parent)
     from tests.test_execution_failure_migration import load_migration
     failure = load_migration()
-    failure["_migrate"](store.path, "model_calls", failure["_MODEL_OLD"], failure["_MODEL_NEW"], store.path.parent / "failure-backups")
+    migrate_failure = failure["_migrate"]
+    assert callable(migrate_failure)
+    migrate_failure(store.path, "model_calls", failure["_MODEL_OLD"], failure["_MODEL_NEW"], store.path.parent / "failure-backups")
     call_id = store.start_call(descriptor, ModelRequest(()))
     # 模拟 provider 已接到请求，进程在收到响应前崩溃；不会重放或把费用补成零。
     reopened = ModelsStore(store.path, store.backup_dir)
@@ -244,7 +246,7 @@ def test_migration_preserves_registry_and_lost_ack_preserves_real_call(
     assert reopened.read_call(call_id)["state"] == "started"
     assert reopened.read_call(call_id)["usage"] is None
     after = dump(store.path)
-    failure["_migrate"](store.path, "model_calls", failure["_MODEL_OLD"], failure["_MODEL_NEW"], store.path.parent / "failure-backups")
+    migrate_failure(store.path, "model_calls", failure["_MODEL_OLD"], failure["_MODEL_NEW"], store.path.parent / "failure-backups")
     assert dump(store.path) == after
     assert store.read_snapshot().revision == 0
 

--- a/tests/test_model_call_stats.py
+++ b/tests/test_model_call_stats.py
@@ -1,4 +1,6 @@
 from dataclasses import asdict
+from collections.abc import Mapping
+from typing import cast
 
 import httpx
 import pytest
@@ -16,6 +18,7 @@ from agent.plugins.model_control import RuntimeModelControl
 from agent.plugins.snapshot import RuntimeSnapshotCompiler, RuntimeSnapshotStore
 from plugins.models.selection import MODEL_SELECTION, SelectionOwner
 from plugins.models.model_settings_http import (
+    ModelControl,
     create_model_settings_router,
     rpc_methods,
 )
@@ -103,7 +106,8 @@ async def test_http_and_mobile_read_same_call_without_receipts_or_credentials(st
     control = RuntimeModelControl(snapshots)
     channel.bind_model_stats(control.call_stats)
     app = FastAPI()
-    app.include_router(create_model_settings_router(control))
+    # 此夹具只请求 call stats 路由，其他设置方法不在本用例范围内。
+    app.include_router(create_model_settings_router(cast(ModelControl, control)))
     before = dump(store.path), dump(runtime.storage.db_path)
     try:
         async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url='http://test') as client:
@@ -143,11 +147,11 @@ async def test_chat_model_route_dispatches_plugin_rpc_under_one_snapshot_lease(
     root = CompositionRoot("rpc")
 
     class Control:
-        async def call_stats(self, requested: str):
-            return store.read_call_stats(requested)
+        async def call_stats(self, call_id: str):
+            return store.read_call_stats(call_id)
 
     async def plugin(ctx):
-        for name, operation in rpc_methods(Control()).items():
+        for name, operation in rpc_methods(cast(ModelControl, Control())).items():
             await ctx.provide(rpc_method_key(name), operation)
 
     await root.mount(plugin, name="models")
@@ -199,7 +203,7 @@ async def test_chat_model_route_does_not_hide_provider_programming_errors():
 
     class BrokenControl:
         async def invoke_rpc(
-            self, method: str, params: dict[str, object]
+            self, method: str, params: Mapping[str, object]
         ) -> object:
             del method, params
             raise ValueError("provider invariant broken")

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -74,6 +74,10 @@ def test_distribution_installs_isolated_git_sources_and_refuses_overwrite(
                     "-c", "commit.gpgSign=false", "commit", "-m", "source"], check=True, capture_output=True)
     output = tmp_path / "release"
     report = build(source, "HEAD", output)
+    plugins = report["plugins"]
+    wiring = report["runtime_wiring"]
+    assert isinstance(plugins, list)
+    assert isinstance(wiring, list)
     with tarfile.open(fileobj=io.BytesIO((output / "core.tar").read_bytes())) as archive:
         assert set(archive.getnames()) == {
             "config.example.toml", "main.py", "runtime-dependencies.json",
@@ -84,8 +88,8 @@ def test_distribution_installs_isolated_git_sources_and_refuses_overwrite(
         }
         assert not any(name == "plugins" or name.startswith("plugins/") for name in archive.getnames())
         assert not any(name == "memory2" or name.startswith("memory2/") for name in archive.getnames())
-    assert {row["name"] for row in report["plugins"]} == {"one", "two", "unused"}
-    one_row = next(row for row in report["plugins"] if row["name"] == "one")
+    assert {row["name"] for row in plugins} == {"one", "two", "unused"}
+    one_row = next(row for row in plugins if row["name"] == "one")
     repository_cwd = Path.cwd()
     monkeypatch.chdir(tmp_path)
     _preflight_bundle(
@@ -94,7 +98,7 @@ def test_distribution_installs_isolated_git_sources_and_refuses_overwrite(
         source_commit=str(report["source_commit"]),
     )
     monkeypatch.chdir(repository_cwd)
-    assert {row["path"] for row in report["runtime_wiring"]} == {
+    assert {row["path"] for row in wiring} == {
         "Dockerfile.distribution",
         "distribution-entrypoint.sh",
     }
@@ -235,9 +239,11 @@ def test_distribution_installs_isolated_git_sources_and_refuses_overwrite(
     ], check=True, capture_output=True)
     output_v2 = tmp_path / "release-v2"
     report_v2 = build(source, "HEAD", output_v2)
+    plugins_v2 = report_v2["plugins"]
+    assert isinstance(plugins_v2, list)
     assert report_v2["source_commit"] != report["source_commit"]
     replacement_row = next(
-        row for row in report_v2["plugins"] if row["name"] == "replacement"
+        row for row in plugins_v2 if row["name"] == "replacement"
     )
     installed_alias = install_git_plugin(
         workspace=tmp_path / "profile-workspace",
@@ -293,7 +299,7 @@ def test_distribution_installs_isolated_git_sources_and_refuses_overwrite(
             config_path=config,
             receipt_path=invalid_receipt,
         )
-    for row in report["plugins"]:
+    for row in plugins:
         installed = install_git_plugin(workspace=tmp_path / "workspace", plugins_home=tmp_path / "home",
             source=str(output / row["file"]), marketplace="distribution")
         assert installed.source_revision == row["source_revision"]

--- a/tests/test_plugin_inventory.py
+++ b/tests/test_plugin_inventory.py
@@ -17,8 +17,14 @@ def test_inventory_includes_support_packages_and_uses_frozen_boundary_rules(tmp_
     subprocess.run(["git", "init", str(tmp_path)], check=True, capture_output=True)
     subprocess.run(["git", "-C", str(tmp_path), "add", "."], check=True, capture_output=True)
     report = build_inventory(tmp_path)
-    assert {item["package"] for item in report["packages"]} == {"one", "two"}
-    assert report["summary"]["support_package_count"] == 2
-    assert {item["kind"] for item in report["static_boundary_violations"]} == {
+    packages = report["packages"]
+    summary = report["summary"]
+    violations = report["static_boundary_violations"]
+    assert isinstance(packages, list)
+    assert isinstance(summary, dict)
+    assert isinstance(violations, list)
+    assert {item["package"] for item in packages} == {"one", "two"}
+    assert summary["support_package_count"] == 2
+    assert {item["kind"] for item in violations} == {
         "R1", "R2", "R3", "not_installable_artifact"}
     assert report["core_consumer_imports"] == [{"file": "bootstrap/app.py", "target": "plugins.two.impl"}]

--- a/tests/test_plugin_rpc.py
+++ b/tests/test_plugin_rpc.py
@@ -1,6 +1,7 @@
 """外部 RPC 的方法、参数和生命周期由实际 provider 拥有。"""
 import asyncio
 import json
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from typing import cast
@@ -38,7 +39,7 @@ async def test_connection_uses_current_plugin_schema_and_keeps_inflight_method()
     current = RpcMethod(FirstParams, first)
 
     @asynccontextmanager
-    async def resolve(name):
+    async def resolve(name: str) -> AsyncIterator[RpcMethod | None]:
         selected = current if name == "example/inspect" else None
         marker = "first" if selected is not None and selected.params is FirstParams else "second"
         active.append(marker)

--- a/tests/test_plugin_setup_declaration.py
+++ b/tests/test_plugin_setup_declaration.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import json
 import os
+from collections.abc import Mapping
 from pathlib import Path
 import subprocess
 
@@ -162,7 +163,9 @@ def test_setup_runner_passes_plugin_data_boundary(tmp_path: Path, monkeypatch) -
     lines = config.read_text(encoding="utf-8").splitlines()
     assert lines[0] == "fixture_setup@lab"
     record = python_environments.archive.read_descriptor(environment_ref)
-    archived_code = python_environments.archive.open(record["input"]["code"])
+    descriptor_input = record["input"]
+    assert isinstance(descriptor_input, Mapping)
+    archived_code = python_environments.archive.open(descriptor_input["code"])
     environment_root = python_environments.open(
         environment_ref,
         archived_code,

--- a/tests/test_proactive_feedback_emotion_interop.py
+++ b/tests/test_proactive_feedback_emotion_interop.py
@@ -389,6 +389,8 @@ async def test_installed_manager_message_append_reaches_pf_and_emotion(
             )
         else:
             assert first_import[0][2] == "topic_follow"
+            assert isinstance(first_import[0][3], (int, float))
+            assert isinstance(first_import[0][4], (int, float))
             assert first_import[0][3] > 0.0
             assert first_import[0][4] > 0.0
         assert _count(emotion_db, "SELECT count(*) FROM emotion_feedback_samples") == 1
@@ -465,12 +467,16 @@ async def test_installed_manager_message_append_reaches_pf_and_emotion(
             ) == 2
         else:
             assert [row[2] for row in imported] == ["topic_follow", "topic_follow"]
-            assert all(row[3] > 0.0 and row[4] > 0.0 for row in imported)
+            for row in imported:
+                assert isinstance(row[3], (int, float)) and isinstance(row[4], (int, float))
+                assert row[3] > 0.0 and row[4] > 0.0
         state = _rows(
             emotion_db,
             "SELECT valence, dominance FROM emotion_state WHERE id=1",
         )
         assert len(state) == 1
+        assert isinstance(state[0][0], (int, float))
+        assert isinstance(state[0][1], (int, float))
         assert state[0][0] > 0.0
         assert state[0][1] > 0.0
         assert _count(emotion_db, "SELECT count(*) FROM emotion_feedback_samples") == 2

--- a/tests/test_prompt_materials.py
+++ b/tests/test_prompt_materials.py
@@ -26,6 +26,29 @@ from session.artifact_store import ArtifactStore
 from session.message import ContentPart, Input, Output, ToolResult
 
 
+def _system_prompt(material: Mapping[str, object]) -> str:
+    """读取并窄化 prompt 材料中的系统提示。"""
+    value = material["system_prompt"]
+    if not isinstance(value, str):
+        raise AssertionError("system_prompt 必须是字符串")
+    return value
+
+
+def _environment_reminder(material: Mapping[str, object]) -> str:
+    """读取并窄化 prompt 材料中的 environment 提醒。"""
+    reminders = material["reminders"]
+    if not isinstance(reminders, (list, tuple)):
+        raise AssertionError("reminders 必须是列表")
+    for reminder in reminders:
+        if not isinstance(reminder, Mapping) or reminder.get("name") != "environment":
+            continue
+        value = reminder.get("text")
+        if not isinstance(value, str):
+            raise AssertionError("environment reminder 文本必须是字符串")
+        return value
+    raise AssertionError("缺少 environment reminder")
+
+
 def prompt_sources(sources):
     for name in ("prompt", "standard_tools"):
         shutil.copytree(
@@ -109,24 +132,26 @@ async def test_prompt_reads_veda_and_fixed_input_time_without_rewriting_messages
                 first = await view.prepare(original, source)
                 second = await view.prepare(original, source)
                 assert first == second
-                assert "唯一人格甲" in first["system_prompt"]
-                assert "load_skill" not in first["system_prompt"]
-                assert ("Telegram 渲染限制" in first["system_prompt"]) == (channel == "telegram_bot")
-                environment = next(part["text"] for part in first["reminders"] if part["name"] == "environment")
+                first_prompt = _system_prompt(first)
+                assert "唯一人格甲" in first_prompt
+                assert "load_skill" not in first_prompt
+                assert ("Telegram 渲染限制" in first_prompt) == (channel == "telegram_bot")
+                environment = _environment_reminder(first)
                 assert accepted.recorded_at.astimezone().isoformat() in environment
                 assert "input_id: input" in environment
                 assert "time_basis" in environment
                 assert ("channel_origin" in environment) == (channel is not None)
                 assert "Client Surface" not in str(first)
-                assert "example" in first["system_prompt"]
+                assert "example" in first_prompt
                 assert "非插件技能" not in str(first)
-                base_directory = next(line.removeprefix("资源目录：") for line in first["system_prompt"].splitlines()
+                base_directory = next(line.removeprefix("资源目录：") for line in first_prompt.splitlines()
                                       if line.startswith("资源目录："))
                 assert (Path(base_directory) / "resource.txt").read_text() == "resource-a"
-                assert "读取 resource.txt" in first["system_prompt"]
+                assert "读取 resource.txt" in first_prompt
                 (tmp_path / "workspace/memory/VEDA.md").write_text("唯一人格乙")
                 third = await view.prepare(original, source)
-                assert "唯一人格乙" in third["system_prompt"] and "唯一人格甲" in first["system_prompt"]
+                third_prompt = _system_prompt(third)
+                assert "唯一人格乙" in third_prompt and "唯一人格甲" in first_prompt
                 assert log.reader("s").snapshot() == original
 
 
@@ -231,7 +256,9 @@ async def test_load_skill_reopens_original_tree_after_source_removal_and_restart
         bindings = Bindings(log, host._archive, host.open_binding)
         async with bindings.open(replacement, TOOLS) as (tools, metadata):
             async with tools.open(metadata) as tool:
-                newer = await tool.invoke("new", await tool.prepare({"skill": "example"}))
+                newer_arguments = await tool.prepare({"skill": "example"})
+                assert isinstance(newer_arguments, Mapping)
+                newer = await tool.invoke("new", newer_arguments)
                 current = cast(Mapping[str, object], json.loads(cast(str, newer.parts[0].value)))
                 assert current["instructions"] == "新版指令"
                 assert (Path(cast(str, current["base_directory"])) / "resource.txt").read_text() == "resource-b"
@@ -239,13 +266,16 @@ async def test_load_skill_reopens_original_tree_after_source_removal_and_restart
             assert "fixture_skills" not in get_current_runtime_snapshot().generations
             async with tools.open(metadata) as tool:
                 arguments = await tool.prepare({"skill": "example"})
+                assert isinstance(arguments, Mapping)
                 result = await tool.invoke("original", arguments)
                 assert result.outcome == "success"
                 value = cast(Mapping[str, object], json.loads(cast(str, result.parts[0].value)))
                 root = Path(cast(str, value["base_directory"]))
                 assert (root / "resource.txt").read_text() == "resource-a"
                 assert value["source_id"] == "fixture_skills"
-                assert (await tool.invoke("unknown", await tool.prepare({"skill": "unmanaged"}))).outcome == "error"
+                unmanaged = await tool.prepare({"skill": "unmanaged"})
+                assert isinstance(unmanaged, Mapping)
+                assert (await tool.invoke("unknown", unmanaged)).outcome == "error"
                 # 损坏已发布树必须报错；不能从安装路径补齐或伪造成功。
                 (root / "resource.txt").chmod(0o600)
                 (root / "resource.txt").write_text("tampered")

--- a/tests/test_reply_preview.py
+++ b/tests/test_reply_preview.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections.abc import Mapping
 from datetime import UTC, datetime
 
 import pytest
@@ -36,6 +37,7 @@ async def test_preview_commit_uses_allocated_id_and_slow_readers_get_current_sna
         items = await asyncio.wait_for(anext(follower), 3)
         assert len(items) == 1 and items[0]['handle'] == task.handle and items[0]['active']
         draft = items[0]['preview']
+        assert isinstance(draft, Mapping)
         assert draft['text'] == '第一段第二段' and draft['thinking'] == '思考'
         assert log.reader('s').get(draft['message_id']) is None
         assert state.read.snapshot('another-session') == ()

--- a/tests/test_runtime_inspection_plugin.py
+++ b/tests/test_runtime_inspection_plugin.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -14,6 +15,25 @@ from plugins.runtime_inspection.inspection import (
     SCHEDULER_INSPECTION,
     SKILL_INSPECTION,
 )
+
+
+def _payload(value: object) -> Mapping[str, object]:
+    """窄化 inspection RPC 的结构化返回值。"""
+    if not isinstance(value, Mapping):
+        raise AssertionError("inspection RPC 必须返回对象")
+    return cast(Mapping[str, object], value)
+
+
+def _rows(value: object) -> tuple[Mapping[str, object], ...]:
+    """窄化 inspection RPC 中的列表行。"""
+    if not isinstance(value, (list, tuple)):
+        raise AssertionError("inspection RPC rows 必须是列表")
+    rows: list[Mapping[str, object]] = []
+    for row in value:
+        if not isinstance(row, Mapping):
+            raise AssertionError("inspection RPC row 必须是对象")
+        rows.append(cast(Mapping[str, object], row))
+    return tuple(rows)
 
 
 class _Scheduler:
@@ -56,14 +76,18 @@ async def test_runtime_inspection_plugin_owns_documents_and_optional_providers(
     async def call(method, params=None):
         operation = root.context.require(rpc_method_key("inspection/" + method))
         return await operation.invoke(operation.params.model_validate(params or {}), None)
-    assert [item["id"] for item in (await call("documents.list"))["items"]] == [
+    documents = _payload(await call("documents.list"))
+    assert [item["id"] for item in _rows(documents["items"])] == [
         "memory",
         "self",
         "veda",
     ]
-    assert (await call("documents.get", {"document_id": "memory"}))["markdown"] == "# Memory\n"
-    assert (await call("skills.list"))["unavailable"]["code"] == "skills_unavailable"
-    assert (await call("jobs.list"))["unavailable"]["code"] == "scheduler_unavailable"
+    memory = _payload(await call("documents.get", {"document_id": "memory"}))
+    assert memory["markdown"] == "# Memory\n"
+    skills = _payload(await call("skills.list"))
+    assert _payload(skills["unavailable"])["code"] == "skills_unavailable"
+    jobs = _payload(await call("jobs.list"))
+    assert _payload(jobs["unavailable"])["code"] == "scheduler_unavailable"
 
     scheduler = _Scheduler()
     skills = _Skills()
@@ -73,11 +97,15 @@ async def test_runtime_inspection_plugin_owns_documents_and_optional_providers(
         await ctx.provide(SKILL_INSPECTION, skills)
 
     business = await root.mount(mount_business, name="business-providers")
-    assert (await call("jobs.list"))["items"] == [{"id": "external-job", "name": "外部任务"}]
-    assert (await call("skills.list"))["items"] == [{"name": "external-skill", "available": True}]
+    jobs = _payload(await call("jobs.list"))
+    assert tuple(_rows(jobs["items"])) == ({"id": "external-job", "name": "外部任务"},)
+    skills = _payload(await call("skills.list"))
+    assert tuple(_rows(skills["items"])) == ({"name": "external-skill", "available": True},)
     await business.dispose()
-    assert (await call("jobs.list"))["unavailable"]["code"] == "scheduler_unavailable"
-    assert (await call("skills.list"))["unavailable"]["code"] == "skills_unavailable"
+    jobs = _payload(await call("jobs.list"))
+    assert _payload(jobs["unavailable"])["code"] == "scheduler_unavailable"
+    skills = _payload(await call("skills.list"))
+    assert _payload(skills["unavailable"])["code"] == "skills_unavailable"
     await root.dispose()
 
 
@@ -152,7 +180,7 @@ async def test_core_inspection_binds_lease_for_real_skill_projection(tmp_path: P
         service = RuntimeInspectionService(workspace=tmp_path / "workspace", snapshot_store=manager.snapshot_store)
         for _ in range(2):
             result = await service.list_capabilities()
-            assert [item["name"] for item in result["skills"]] == ["probe"]
+            assert [item["name"] for item in _rows(result["skills"])] == ["probe"]
             assert snapshot.lease_count == 0
             assert get_current_runtime_snapshot() is None
     finally:

--- a/tests/test_scheduler_inspection.py
+++ b/tests/test_scheduler_inspection.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -88,12 +89,13 @@ async def test_core_passes_through_scheduler_projection_without_reading_workspac
     from agent.plugin_composition import CompositionRoot
     from agent.plugin_composition.rpc import rpc_method_key
     from plugins.runtime_inspection.rpc import rpc_methods
+    from plugins.runtime_inspection.inspection import RuntimeInspectionProvider
     from agent.plugins.snapshot import RuntimeSnapshotCompiler, RuntimeSnapshotStore, get_current_runtime_snapshot
 
     root = CompositionRoot("scheduler-inspection")
     provider = _Provider()
     async def apply(ctx):
-        for method, operation in rpc_methods(provider).items():
+        for method, operation in rpc_methods(cast(RuntimeInspectionProvider, provider)).items():
             await ctx.provide(rpc_method_key(method), operation)
     await root.mount(apply, name="external-scheduler")
     store = RuntimeSnapshotStore()
@@ -121,6 +123,7 @@ async def test_core_does_not_swallow_scheduler_provider_failure(tmp_path: Path) 
     from agent.plugin_composition import CompositionRoot
     from agent.plugin_composition.rpc import rpc_method_key
     from plugins.runtime_inspection.rpc import rpc_methods
+    from plugins.runtime_inspection.inspection import RuntimeInspectionProvider
     from agent.plugins.snapshot import RuntimeSnapshotCompiler, RuntimeSnapshotStore
 
     class BrokenProvider:
@@ -132,7 +135,7 @@ async def test_core_does_not_swallow_scheduler_provider_failure(tmp_path: Path) 
 
     root = CompositionRoot("scheduler-inspection-failure")
     async def apply(ctx):
-        for method, operation in rpc_methods(BrokenProvider()).items():
+        for method, operation in rpc_methods(cast(RuntimeInspectionProvider, BrokenProvider())).items():
             await ctx.provide(rpc_method_key(method), operation)
     await root.mount(apply, name="external-scheduler")
     store = RuntimeSnapshotStore()

--- a/tests/test_scheduler_messages.py
+++ b/tests/test_scheduler_messages.py
@@ -1,5 +1,5 @@
 import asyncio
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Mapping
 from typing import cast
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -169,6 +169,7 @@ async def test_archived_schedule_tool_recovers_original_operation_after_source_r
             async with open_tool(bindings, tool) as bound:
                 prepared = await bound.prepare({"tier": "instant", "trigger": "after", "when": "1h",
                     "channel": "test", "chat_id": "room", "timezone": "UTC", "message": "original"})
+                assert isinstance(prepared, Mapping)
                 result = await bound.invoke("original-schedule", prepared)
         store = JobStore(tmp_path / "workspace/schedules.json")
         original = store.load()[0]

--- a/tests/test_scheduler_tools.py
+++ b/tests/test_scheduler_tools.py
@@ -1,7 +1,9 @@
 import asyncio
+from collections.abc import Mapping
 from datetime import UTC, datetime
 
 import pytest
+from typing import cast
 
 from agent.plugin_composition.tasks import Tasks
 from plugins.react.plugin import _settle
@@ -23,6 +25,7 @@ async def test_cancel_self_commits_then_lets_original_fire_drain_its_tool(tmp_pa
     tasks = Tasks()
     target = ScheduleTool(store, tasks, "cancel")
     prepared = await target.prepare({"id": job.id})
+    assert isinstance(prepared, Mapping)
     results = []
 
     class Menu(ToolMenu):
@@ -32,7 +35,7 @@ async def test_cancel_self_commits_then_lets_original_fire_drain_its_tool(tmp_pa
         async def execute(self, call: CallRef) -> Result:
             result = await target.invoke("cancel-self", prepared)
             results.append(result)
-            return result
+            return cast(Result, result)
 
     async def run(task):
         await _settle(Menu(), CallRef("call", 0))
@@ -60,11 +63,14 @@ async def test_prepared_schedule_and_cancel_replay_the_original_ids_and_times(tm
     try:
         prepared = await schedule.prepare({"tier": "instant", "trigger": "after", "when": "1h",
             "channel": "test", "chat_id": "room", "timezone": "UTC", "message": "one", "name": "same"})
+        assert isinstance(prepared, Mapping)
         result = await schedule.invoke("create-one", prepared)
         original = store.load()[0]
         cancellation = await cancel.prepare({"name": "same"})
+        assert isinstance(cancellation, Mapping)
         later = await schedule.prepare({"tier": "instant", "trigger": "after", "when": "2h",
             "channel": "test", "chat_id": "room", "timezone": "UTC", "message": "two", "name": "same"})
+        assert isinstance(later, Mapping)
         await schedule.invoke("create-two", later)
         cancelled = await cancel.invoke("cancel-one", cancellation)
         assert await cancel.query("cancel-one") == cancelled

--- a/tests/test_standard_tools.py
+++ b/tests/test_standard_tools.py
@@ -239,7 +239,9 @@ async def test_web_search_only_reports_empty_success_from_confirmed_response(mon
     transport = httpx.MockTransport(lambda request: httpx.Response(200, text=reply, headers={"content-type": media}))
     monkeypatch.setattr(httpx, "AsyncClient", lambda **kwargs: client(transport=transport, **kwargs))
     tool = WebTool(WebSearchTool())
-    result = await tool.invoke("request", await tool.prepare({"query": "test"}))
+    prepared = await tool.prepare({"query": "test"})
+    assert isinstance(prepared, Mapping)
+    result = await tool.invoke("request", prepared)
     assert result.outcome == ("error" if error else "success")
     if not error:
         assert json.loads(cast(str, result.parts[0].value))["result"] == ""

--- a/tests/test_tool_bindings.py
+++ b/tests/test_tool_bindings.py
@@ -1,4 +1,5 @@
 from contextlib import asynccontextmanager
+from collections.abc import Mapping
 from functools import partial
 from pathlib import Path
 import shutil
@@ -343,7 +344,9 @@ async def test_tool_configuration_is_owned_frozen_and_restored_without_recapture
         host = manager(tmp_path, [])
         bindings = Bindings(log, host._archive, host.open_binding)
         async with open_tool(bindings, identity) as target:
-            result = await target.invoke("fixed", await target.prepare({"value": "input"}))
+            prepared = await target.prepare({"value": "input"})
+            assert isinstance(prepared, Mapping)
+            result = await target.invoke("fixed", prepared)
             assert result.parts[0].value == "job-a:restore:input"
     finally:
         await host.terminate_all()

--- a/tests/test_tool_program_factory.py
+++ b/tests/test_tool_program_factory.py
@@ -1,12 +1,16 @@
 from collections.abc import Callable, Mapping
+from typing import cast
 
 import pytest
 
+from agent.plugin_composition import Context
 from agent.plugin_composition.bindings import BINDINGS
-from agent.plugin_composition.messages import MESSAGE_WRITERS
+from agent.plugin_composition.messages import MESSAGE_WRITERS, MessageReader
+from agent.plugin_composition.tasks import ExternalRootPermit
 from agent.plugin_contracts import CallRef, ContentPart, ContentReferences
 from agent.plugin_composition.models import ToolCall as ModelToolCall
 from plugins.tools.menu import ToolMenu
+from plugins.tools.plugin import ToolCatalog
 from plugins.tools.program import ToolProgramFactory
 
 
@@ -79,11 +83,22 @@ def _check_text(part: ContentPart) -> ContentReferences:
     return ContentReferences()
 
 
+def _fake_child_permit() -> ExternalRootPermit:
+    """测试菜单只需验证 permit 被传递到 catalog。"""
+    return cast(ExternalRootPermit, object())
+
+
+async def _reject_authorize(_binding_id: str, _arguments: Mapping[str, object]) -> str:
+    return "rejected"
+
+
 def test_factory_returns_real_menu_and_scoped_reply() -> None:
     writers = _Writers()
     catalog = _Catalog()
-    factory = ToolProgramFactory(_Context(writers, _Bindings()), catalog)
-    reader = _Reader()
+    factory = ToolProgramFactory(
+        cast(Context, _Context(writers, _Bindings())), cast(ToolCatalog, catalog),
+    )
+    reader = cast(MessageReader, _Reader())
     check_start = lambda: None
 
     async def authorize(binding_id: str, arguments: Mapping[str, object]):
@@ -96,7 +111,7 @@ def test_factory_returns_real_menu_and_scoped_reply() -> None:
         check_start=check_start,
         authorize=authorize,
         fixed_bindings={"example": "example"},
-        child_permit=lambda: object(),
+        child_permit=_fake_child_permit,
     )
 
     assert menu.names == frozenset({"example"})
@@ -123,7 +138,9 @@ def test_factory_returns_real_menu_and_scoped_reply() -> None:
 def test_menu_keeps_internal_binding_errors_fail_loud() -> None:
     writers = _Writers()
     catalog = _Catalog()
-    factory = ToolProgramFactory(_Context(writers, _Bindings()), catalog)
+    factory = ToolProgramFactory(
+        cast(Context, _Context(writers, _Bindings())), cast(ToolCatalog, catalog),
+    )
 
     class _BrokenPresentation:
         schemas = ()
@@ -136,11 +153,11 @@ def test_menu_keeps_internal_binding_errors_fail_loud() -> None:
             return None
 
     menu = factory.create_menu(
-        _Reader(),
+        cast(MessageReader, _Reader()),
         "conversation",
         content={},
         check_start=lambda: None,
-        authorize=lambda binding_id, arguments: None,  # type: ignore[arg-type]
+        authorize=lambda binding_id, arguments: _reject_authorize(binding_id, arguments),
         fixed_bindings={"example": "example"},
         presentation=_BrokenPresentation(),
     )

--- a/tests/test_tool_views.py
+++ b/tests/test_tool_views.py
@@ -93,7 +93,7 @@ async def test_search_presentation_keeps_fixed_schemas_and_executes_awarded_ref(
             catalog = ctx.require(TOOLS)
             bindings = ctx.require(BINDINGS)
             view = ToolView.combine(
-                ctx.require(ALL_TOOLS)(), ctx.require(TOOL_SEARCH_TOOLS)
+                ctx.require(ALL_TOOLS)(), cast(ToolView, ctx.require(TOOL_SEARCH_TOOLS))
             )
             presentation = ctx.require(TOOL_SEARCH_PRESENTATION)(view)
             menu = ToolMenu(
@@ -111,10 +111,13 @@ async def test_search_presentation_keeps_fixed_schemas_and_executes_awarded_ref(
 
             decoded = menu.decode(ModelToolCall('search', 'tool_search', {'query': 'example'}))
             (search_binding, search_arguments) = decoded.binding_id, decoded.arguments
+            assert search_binding is not None
             async with open_tool(bindings, search_binding) as search:
+                prepared = await search.prepare(search_arguments)
+                assert isinstance(prepared, Mapping)
                 result = await search.invoke(
                     "search",
-                    await search.prepare(search_arguments),
+                    prepared,
                 )
             value = result.parts[0].value
             assert isinstance(value, str)
@@ -137,6 +140,7 @@ async def test_search_presentation_keeps_fixed_schemas_and_executes_awarded_ref(
 
             decoded = menu.decode(ModelToolCall('call', 'tool_call', {'name': 'example', 'arguments': {'value': ' ok '}}))
             (binding, arguments) = decoded.binding_id, decoded.arguments
+            assert binding is not None
             executed = await catalog.execution(
                 lambda identity, final: _allow()
             ).execute("valid", binding, arguments)
@@ -156,10 +160,12 @@ async def test_search_presentation_keeps_fixed_schemas_and_executes_awarded_ref(
             assert not rejected.accepted
             assert rejected.rejection is not None
             assert rejected.rejection["name"] == "tool_call"
-            assert "获授 view" in rejected.rejection["error"]
+            rejection_error = rejected.rejection["error"]
+            assert isinstance(rejection_error, str)
+            assert "获授 view" in rejection_error
             narrow = ToolView.combine(
                 catalog.view(view.select("example")),
-                ctx.require(TOOL_SEARCH_TOOLS),
+                cast(ToolView, ctx.require(TOOL_SEARCH_TOOLS)),
             )
             narrow_menu = ToolMenu(
                 catalog,
@@ -179,7 +185,9 @@ async def test_search_presentation_keeps_fixed_schemas_and_executes_awarded_ref(
             assert not rejected.accepted
             assert rejected.rejection is not None
             assert rejected.rejection["name"] == "tool_call"
-            assert "获授 view" in rejected.rejection["error"]
+            rejection_error = rejected.rejection["error"]
+            assert isinstance(rejection_error, str)
+            assert "获授 view" in rejection_error
     finally:
         await host.terminate_all()
         log.close()
@@ -198,7 +206,9 @@ async def test_standard_web_is_directly_callable_without_search(tmp_path):
         async with lease_runtime_snapshot(host.snapshot_store) as snapshot:
             ctx = snapshot.composition_root.context
             catalog = ctx.require(TOOLS)
-            view = ToolView.combine(ctx.require(ALL_TOOLS)(), ctx.require(TOOL_SEARCH_TOOLS))
+            view = ToolView.combine(
+                ctx.require(ALL_TOOLS)(), cast(ToolView, ctx.require(TOOL_SEARCH_TOOLS)),
+            )
             menu = ToolMenu(catalog, ctx.require(BINDINGS),
                            catalog.execution(lambda binding, arguments: _allow()), _unexpected_reply,
                            view=view, presentation=ctx.require(TOOL_SEARCH_PRESENTATION)(view))
@@ -209,6 +219,7 @@ async def test_standard_web_is_directly_callable_without_search(tmp_path):
                                     ("web_search", {"query": "weather"})):
                 decoded = menu.decode(ModelToolCall('direct', name, arguments))
                 (binding, _) = decoded.binding_id, decoded.arguments
+                assert binding is not None
                 async with open_tool(ctx.require(BINDINGS), binding) as tool:
                     assert await tool.prepare(arguments) == arguments
     finally:
@@ -273,6 +284,7 @@ async def test_fixed_bindings_use_archived_schema_without_rebinding_current_prov
                 assert parameters["required"] == ()
             decoded = menu.decode(ModelToolCall('old', 'example', {'value': 'old'}))
             (identity, arguments) = decoded.binding_id, decoded.arguments
+            assert identity is not None
             assert identity == old
             result = await ctx.require(TOOLS).execution(
                 lambda binding, final: _allow()

--- a/tests/test_wake_messages.py
+++ b/tests/test_wake_messages.py
@@ -435,6 +435,39 @@ async def test_runtime_timer_captures_original_drift_and_records_real_completion
 
 
 @pytest.mark.asyncio
+async def test_runtime_rebuilds_cross_generation_config_values(tmp_path):
+    from pydantic import BaseModel, ConfigDict
+    from typing import cast
+    from plugins.wake.runtime import Runtime
+
+    class PreviousDeliveryTarget(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+        channel: str
+        recipient: str
+        session_id: str
+
+    class PreviousConfig(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+        delivery: PreviousDeliveryTarget | None = None
+        timezone: str = "Asia/Shanghai"
+
+    async with application(tmp_path) as (host, log, ctx, source, control):
+        now = datetime.now(timezone.utc)
+        ctx.require(DRIFT_PROPOSALS).propose("duty", "1", {"summary": "old generation"}, now)
+        previous = PreviousConfig(
+            delivery=PreviousDeliveryTarget(
+                channel="test", recipient="room", session_id="test:room"
+            )
+        )
+        runtime = Runtime(ctx, cast(Config, previous))
+        original = runtime.capture("d" * 32, await runtime.duties.check(now), now)
+        assert original is not None
+        assert type(runtime.config) is Config
+        assert type(runtime.config.delivery) is DeliveryTarget
+        assert original.target == runtime.config.delivery
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("failure", ["authentication", "rate_limit", "budget"])
 async def test_model_failure_keeps_real_control_and_original_retry_classification(tmp_path, failure):
     from agent.plugin_composition.models import AuthenticationError, RateLimitError


### PR DESCRIPTION
本地插件回归中的只读结构与测试夹具沿用旧接口，Wake 在重载后还会把旧 generation 的 DeliveryTarget 交给当前 Request，导致主动执行失败。本层对齐公开类型，并在 Wake Runtime 入口重建当前代配置值。

依赖 #648，head `5cb8e8bb`。change_type=fix；semantic_delta=compatible；capability_owner=plugin；consumer_scope=本地插件及测试；runtime_patch=none。持久消息、数据库和外部发送语义保持不变，无部署或数据改写；可回退本层提交。

验证：Wake 完整用例 39 passed，原五项失败加跨代回归 6 passed；独立类型夹具组 139 passed；根类型修复组首次 295 passed、1 failed、2 skipped，修复 Mapping 断言后对应组 7 passed；Restart/Computer/Reply follow 23 passed、1 skipped。类型与全栈 Gate 将在后续 yoyo 退役和本地组合收束后统一复核；当前不宣称全栈验收完成。独立概念 Gate 同样待最终栈顶执行。