### PR TITLE
修复历史迁移源退休后已落账安装包阻断启动

### DIFF
--- a/agent/migrations/bundles.py
+++ b/agent/migrations/bundles.py
@@ -412,12 +412,14 @@ def validate_bundle_dependencies(
     *,
     core_migration_ids: Sequence[str],
     requirements: Sequence[MigrationRequirement] = (),
+    applied_ids: Sequence[str] = (),
     require_missing_bundles: bool = True,
 ) -> None:
-    """在 Yoyo 执行前拒绝缺失 owner、重复元数据和断裂依赖。"""
+    """在 Yoyo 执行前拒绝待执行迁移的缺失 owner 和断裂依赖。"""
 
     available_ids = set(core_migration_ids)
     available_ids.update(item.migration_id for bundle in bundles for item in bundle.migrations)
+    applied = set(applied_ids)
     bundle_by_id = {bundle.bundle_id: bundle for bundle in bundles}
     for requirement in requirements:
         if (
@@ -426,15 +428,22 @@ def validate_bundle_dependencies(
             and not require_missing_bundles
         ):
             continue
-        missing_requirements = tuple(
-            sorted(dependency for dependency in requirement.depends if dependency not in available_ids)
-        )
-        if missing_requirements:
-            raise MigrationBundleBlocked(
-                bundle_id=requirement.bundle_id or "core",
-                migration_ids=(requirement.migration_id,),
-                missing_dependencies=missing_requirements,
+        # 已落账迁移不再需要历史源码或依赖闭包；artifact 仍在上面完成
+        # 完整性校验，待执行迁移则必须在当前 Core/bundle 源码中找到全部依赖。
+        if requirement.migration_id not in applied:
+            missing_requirements = tuple(
+                sorted(
+                    dependency
+                    for dependency in requirement.depends
+                    if dependency not in available_ids
+                )
             )
+            if missing_requirements:
+                raise MigrationBundleBlocked(
+                    bundle_id=requirement.bundle_id or "core",
+                    migration_ids=(requirement.migration_id,),
+                    missing_dependencies=missing_requirements,
+                )
         if requirement.migration_id not in available_ids:
             continue
         if requirement.bundle_id is None:
@@ -465,6 +474,8 @@ def validate_bundle_dependencies(
     for bundle in bundles:
         missing: set[str] = set()
         for spec in bundle.migrations:
+            if spec.migration_id in applied:
+                continue
             missing.update(dep for dep in spec.depends if dep not in available_ids)
         if missing:
             raise MigrationBundleBlocked(

--- a/agent/migrations/runner.py
+++ b/agent/migrations/runner.py
@@ -96,6 +96,7 @@ class MigrationRunner:
                 installed_cache_root=self.installed_cache_root,
             )
             requirements = load_migration_requirements(self.migration_catalog)
+            applied_ids = _read_applied_ids(self.ledger_path)
             core_ids = tuple(migration.id for migration in core_migrations)
             bundle_ids = tuple(
                 migration_id
@@ -111,12 +112,13 @@ class MigrationRunner:
                 bundles,
                 core_migration_ids=core_ids,
                 requirements=requirements,
+                applied_ids=applied_ids,
                 require_missing_bundles=False,
             )
             validate_pending_requirements(
                 applicable,
                 loaded_ids=core_ids + bundle_ids,
-                applied_ids=_read_applied_ids(self.ledger_path),
+                applied_ids=applied_ids,
                 bundles=bundles,
             )
             if fresh and baseline is not None:

--- a/tests/test_migration_runner.py
+++ b/tests/test_migration_runner.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 import toml
 
+from agent.plugins.artifacts import relative_artifact_pointer, write_pointers
 from agent.migrations.bundles import MigrationBundleBlocked, MigrationBundleError
 from agent.migrations.runner import MigrationRunner
 from bootstrap.init_workspace import init_workspace
@@ -50,6 +51,31 @@ def _write_core_step(
         f"__depends__ = {set(depends)!r}\n"
         "__transactional__ = False\n"
         "steps = [step('SELECT 1', 'SELECT 1')]\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _write_core_marker_step(
+    repo: Path,
+    migration_id: str,
+    dependency: str,
+    marker: Path,
+) -> Path:
+    """Add a Core step that records execution after its bundle dependency."""
+
+    path = repo / "migrations/core" / f"{migration_id}.py"
+    path.write_text(
+        "from pathlib import Path\n"
+        "from yoyo import step\n"
+        f"__depends__ = {{{dependency!r}}}\n"
+        "__transactional__ = False\n"
+        "\n"
+        "def apply(connection):\n"
+        "    _ = connection\n"
+        f"    Path({str(marker)!r}).write_text('applied', encoding='utf-8')\n"
+        "\n"
+        "steps = [step(apply)]\n",
         encoding="utf-8",
     )
     return path
@@ -141,6 +167,7 @@ def _write_bundle(
     *,
     bundle_id: str = "future_plugin",
     package_name: str = "future_migrations",
+    manifest_name: str | None = None,
 ) -> Path:
     """Write a complete synthetic v3 artifact accepted by the real loader."""
 
@@ -195,7 +222,7 @@ def _write_bundle(
         toml.dumps(
             {
                 "schema_version": 1,
-                "name": bundle_id,
+                "name": manifest_name or bundle_id,
                 "version": "1.0.0",
                 "api_version": 3,
                 "entrypoint": "plugin.py",
@@ -224,6 +251,97 @@ def test_empty_core_and_catalog_establish_current_baseline(tmp_path: Path) -> No
     assert (second.state, second.migrations) == ("current", ())
     assert _baseline_ids(runner.ledger_path) == ()
     assert _applied_ids(runner.ledger_path) == ()
+
+
+def test_stable_installed_cache_pointer_is_loaded_without_plugin_dir(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "state"
+    repo = _empty_repo(tmp_path)
+    plugin_base = root / "plugin-cache/marketplace/installed_plugin"
+    artifacts = plugin_base / ".artifacts"
+    stable = _write_bundle(
+        artifacts,
+        {
+            "stable_step": (
+                (),
+                _migration_source(tmp_path / "stable.marker"),
+            )
+        },
+        bundle_id="stable_release",
+        package_name="stable_migrations",
+        manifest_name="installed_plugin",
+    )
+    candidate = _write_bundle(
+        artifacts,
+        {
+            "candidate_step": (
+                (),
+                _migration_source(tmp_path / "candidate.marker"),
+            )
+        },
+        bundle_id="candidate_release",
+        package_name="candidate_migrations",
+        manifest_name="installed_plugin",
+    )
+    write_pointers(
+        plugin_base,
+        stable=relative_artifact_pointer(plugin_base, stable),
+        latest=relative_artifact_pointer(plugin_base, candidate),
+    )
+
+    outcome = _runner(root, repo).run()
+
+    assert outcome.migrations == ("stable_step",)
+    assert (tmp_path / "stable.marker").read_text(encoding="utf-8") == "attempted"
+    assert not (tmp_path / "candidate.marker").exists()
+    assert _runner(root, repo).run().state == "current"
+
+
+def test_future_core_step_runs_after_installed_bundle_is_applied(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "state"
+    repo = _empty_repo(tmp_path)
+    plugin_base = root / "plugin-cache/marketplace/installed_plugin"
+    artifacts = plugin_base / ".artifacts"
+    bundle = _write_bundle(
+        artifacts,
+        {
+            "installed_step": (
+                (),
+                _migration_source(tmp_path / "bundle.marker"),
+            )
+        },
+        bundle_id="installed_release",
+        package_name="installed_migrations",
+        manifest_name="installed_plugin",
+    )
+    write_pointers(
+        plugin_base,
+        stable=relative_artifact_pointer(plugin_base, bundle),
+        latest=relative_artifact_pointer(plugin_base, bundle),
+    )
+    runner = _runner(root, repo)
+    assert runner.run().migrations == ("installed_step",)
+    before_ledger = _ledger_rows(runner.ledger_path)
+    bundle_marker = (tmp_path / "bundle.marker").read_bytes()
+    core_marker = tmp_path / "core.marker"
+    _write_core_marker_step(
+        repo,
+        "future_core_step",
+        "installed_step",
+        core_marker,
+    )
+
+    outcome = runner.run()
+
+    assert outcome.migrations == ("future_core_step",)
+    assert core_marker.read_text(encoding="utf-8") == "applied"
+    assert (tmp_path / "bundle.marker").read_bytes() == bundle_marker
+    after_ledger = _ledger_rows(runner.ledger_path)
+    old_row = next(row for row in before_ledger if row[1] == "installed_step")
+    assert next(row for row in after_ledger if row[1] == "installed_step") == old_row
 
 
 def test_applied_bundle_with_retired_core_dependency_does_not_block(

--- a/tests/test_migration_runner.py
+++ b/tests/test_migration_runner.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import pytest
 import toml
 
-from agent.migrations.bundles import MigrationBundleBlocked
+from agent.migrations.bundles import MigrationBundleBlocked, MigrationBundleError
 from agent.migrations.runner import MigrationRunner
 from bootstrap.init_workspace import init_workspace
 from bootstrap.workspace_lock import WorkspaceInstanceLock
@@ -34,6 +34,25 @@ def _empty_repo(root: Path) -> Path:
         encoding="utf-8",
     )
     return repo
+
+
+def _write_core_step(
+    repo: Path,
+    migration_id: str,
+    *,
+    depends: Sequence[str] = (),
+) -> Path:
+    """Add a minimal Core migration used only to establish an old source ID."""
+
+    path = repo / "migrations/core" / f"{migration_id}.py"
+    path.write_text(
+        "from yoyo import step\n"
+        f"__depends__ = {set(depends)!r}\n"
+        "__transactional__ = False\n"
+        "steps = [step('SELECT 1', 'SELECT 1')]\n",
+        encoding="utf-8",
+    )
+    return path
 
 
 def _runner(
@@ -205,6 +224,207 @@ def test_empty_core_and_catalog_establish_current_baseline(tmp_path: Path) -> No
     assert (second.state, second.migrations) == ("current", ())
     assert _baseline_ids(runner.ledger_path) == ()
     assert _applied_ids(runner.ledger_path) == ()
+
+
+def test_applied_bundle_with_retired_core_dependency_does_not_block(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "state"
+    repo = _empty_repo(tmp_path)
+    core_path = _write_core_step(repo, "retired_core_origin")
+    plugin_root = tmp_path / "plugins"
+    _write_bundle(
+        plugin_root,
+        {
+            "retired_step": (
+                ("retired_core_origin",),
+                _migration_source(
+                    tmp_path / "retired.marker",
+                    depends=("retired_core_origin",),
+                ),
+            )
+        },
+        bundle_id="retired_plugin",
+        package_name="retired_migrations",
+    )
+    runner = _runner(root, repo, plugin_dirs=(plugin_root,))
+    first = runner.run()
+    assert set(first.migrations) == {"retired_core_origin", "retired_step"}
+
+    core_path.unlink()
+
+    second = runner.run()
+
+    assert second.state == "current"
+    assert second.migrations == ()
+
+
+def test_applied_bundle_still_requires_artifact_digest(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "state"
+    repo = _empty_repo(tmp_path)
+    _write_core_step(repo, "retired_core_origin")
+    plugin_root = tmp_path / "plugins"
+    artifact = _write_bundle(
+        plugin_root,
+        {
+            "retired_step": (
+                ("retired_core_origin",),
+                _migration_source(
+                    tmp_path / "retired.marker",
+                    depends=("retired_core_origin",),
+                ),
+            )
+        },
+        bundle_id="retired_plugin",
+        package_name="retired_migrations",
+    )
+    runner = _runner(root, repo, plugin_dirs=(plugin_root,))
+    runner.run()
+    step_path = artifact / "retired_migrations/retired_step.py"
+    step_path.write_text(
+        step_path.read_text(encoding="utf-8") + "\n# artifact drift\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(MigrationBundleError, match="digest"):
+        runner.run()
+
+
+def test_pending_bundle_can_depend_on_applied_source_bundle(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "state"
+    repo = _empty_repo(tmp_path)
+    core_path = _write_core_step(repo, "retired_core_origin")
+    old_plugins = tmp_path / "old-plugins"
+    _write_bundle(
+        old_plugins,
+        {
+            "old_step": (
+                ("retired_core_origin",),
+                _migration_source(
+                    tmp_path / "old.marker",
+                    depends=("retired_core_origin",),
+                ),
+            )
+        },
+        bundle_id="old_plugin",
+        package_name="old_migrations",
+    )
+    runner = _runner(root, repo, plugin_dirs=(old_plugins,))
+    assert runner.run().migrations == ("retired_core_origin", "old_step")
+    core_path.unlink()
+
+    new_plugins = tmp_path / "new-plugins"
+    _write_bundle(
+        new_plugins,
+        {
+            "new_step": (
+                ("old_step",),
+                _migration_source(
+                    tmp_path / "new.marker",
+                    depends=("old_step",),
+                ),
+            )
+        },
+        bundle_id="new_plugin",
+        package_name="new_migrations",
+    )
+
+    outcome = _runner(
+        root,
+        repo,
+        plugin_dirs=(old_plugins, new_plugins),
+    ).run()
+
+    assert outcome.migrations == ("new_step",)
+
+
+def test_pending_bundle_dependency_only_in_ledger_is_blocked(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "state"
+    repo = _empty_repo(tmp_path)
+    _write_core_step(repo, "retired_core_origin")
+    old_plugins = tmp_path / "old-plugins"
+    _write_bundle(
+        old_plugins,
+        {
+            "old_step": (
+                ("retired_core_origin",),
+                _migration_source(
+                    tmp_path / "old.marker",
+                    depends=("retired_core_origin",),
+                ),
+            )
+        },
+        bundle_id="old_plugin",
+        package_name="old_migrations",
+    )
+    runner = _runner(root, repo, plugin_dirs=(old_plugins,))
+    runner.run()
+    before = _ledger_rows(runner.ledger_path)
+
+    new_plugins = tmp_path / "new-plugins"
+    _write_bundle(
+        new_plugins,
+        {
+            "new_step": (
+                ("old_step",),
+                _migration_source(
+                    tmp_path / "new.marker",
+                    depends=("old_step",),
+                ),
+            )
+        },
+        bundle_id="new_plugin",
+        package_name="new_migrations",
+    )
+
+    with pytest.raises(MigrationBundleBlocked) as raised:
+        _runner(root, repo, plugin_dirs=(new_plugins,)).run()
+
+    assert raised.value.bundle_id == "new_plugin"
+    assert raised.value.migration_ids == ("new_step",)
+    assert raised.value.missing_dependencies == ("old_step",)
+    assert _ledger_rows(runner.ledger_path) == before
+
+
+def test_pending_dependency_closure_requires_a_current_core_source(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "state"
+    repo = _empty_repo(tmp_path)
+    plugin_root = tmp_path / "plugins"
+    _write_bundle(
+        plugin_root,
+        {
+            "intermediate_step": (
+                ("future_core_step",),
+                _migration_source(
+                    tmp_path / "intermediate.marker",
+                    depends=("future_core_step",),
+                ),
+            ),
+            "leaf_step": (
+                ("intermediate_step",),
+                _migration_source(
+                    tmp_path / "leaf.marker",
+                    depends=("intermediate_step",),
+                ),
+            ),
+        },
+        bundle_id="future_plugin",
+        package_name="future_migrations",
+    )
+
+    with pytest.raises(MigrationBundleBlocked) as raised:
+        _runner(root, repo, plugin_dirs=(plugin_root,)).run()
+
+    assert raised.value.missing_dependencies == ("future_core_step",)
+    assert not (root / "workspace/migrations.sqlite3").exists()
 
 
 def test_existing_ledger_rows_for_deleted_sources_are_preserved(


### PR DESCRIPTION
## 问题与结果

堆叠在 #651。稳定安装缓存中的旧 bundle 全部执行完成后，其已退休 Core 依赖仍被无条件校验，导致当前 workspace 无法启动。runner 现在只要求待执行步骤的依赖有当前源码；已落账步骤仍校验 artifact/catalog/source digest，旧账本保留。

新的待执行步骤可以依赖仍安装且已应用的 bundle；只有 ledger 而无源码的依赖仍明确拒绝。未来 Core、跨 bundle、同 bundle 的依赖继续使用同一执行路径。

## Change intent

- change_type: fix；semantic_delta: compatible；capability_owner: core。
- consumer_scope: 通用迁移 runner 和已安装 bundle；runtime_patch: required。
- runtime_patch_reason: 历史兼容源退休不能让全已应用的缓存包阻断当前启动。
- authoritative_state_owner: Yoyo ledger 与每个迁移自己的状态 owner。
- client_only_alternative: 不适用；concept_gate: required。
- protected_state: 旧账本行、Message、配置、备份；无正式 workspace 写入。
- 允许副作用：源码和隔离测试；无合并或部署。
- 关联不变量：0066、MIG-001/002。

## 改动与恢复

runner 复用一次 applied IDs 读取；依赖校验保留 pending 的缺依赖错误，不按插件名称特判。
恢复点 0172c0037434456c33247ee8a296e4557e89b99f，无 schema identity 变化。

## 验证

- runner/bundle/append-only 集成 36 passed。
- 新增 stable 指针、候选不参与和 Core 依赖 installed bundle 两项，副手 runner 19 passed，栈顶重复验证进行中。
- 实际 CI tests pyright 0 errors（两项追加测试前）。
- 实际执行后核对旧 ledger 行与 marker 保持不变，漂移 artifact 明确拒绝。
- 完整 Gate、CI、制品和最终概念 Gate 在栈顶汇总，当前无 sourceDigest/planDigest。

## 正交性与概念完整性

修复独立 terra_local_final_review / gpt-5.6-terra / xhigh 对 5cb8e8bb 加 #651 diff 的启动 blocker。最终 head 尚待独立复核；Mobile 正式断链和业务归属继续后续层处理。无新增业务中央目录或插件 ID 特判。

## 工作手册

遵循 0066 的当前基线和保留未来 Yoyo 约束；整体 NOW 事项尚未完成，保留。