### PR TITLE
[codex] 由宿主显式绑定客户端 CLI 的 Core identity

### DIFF
--- a/bootstrap/tools.py
+++ b/bootstrap/tools.py
@@ -120,6 +120,9 @@ def build_core_runtime(
     from agent.plugins.manager import PluginManager
     from infra.channels.artifacts import ChannelAttachmentArtifactStore
 
+    # 插件子进程只能使用宿主明确绑定的 Core；不能让普通插件从自身路径猜测。
+    os.environ["AKASHIC_CORE_ROOT"] = str(Path(__file__).resolve().parents[1])
+
     # 1. MessageLog 先核对 schema，旧库不能借普通启动绕过 yoyo。
     bus = MessageBus()
     event_bus = EventBus()

--- a/plugins/akashic_clients/mobile_webui/auto_publish.py
+++ b/plugins/akashic_clients/mobile_webui/auto_publish.py
@@ -51,7 +51,7 @@ def auto_publish_webui(
     environment = os.environ.copy()
     environment.pop("PYTHONPATH", None)
     environment.pop("AKASHIC_EXTRA_PLUGIN_DIRS", None)
-    environment["AKASHIC_CORE_ROOT"] = str(_running_core_root())
+    environment["AKASHIC_CORE_ROOT"] = str(_configured_core_root())
     command = [
         sys.executable,
         str(publisher),
@@ -90,26 +90,18 @@ def auto_publish_webui(
     return True
 
 
-def _running_core_root() -> Path:
-    """Resolve the one Core root already hosting this plugin runtime."""
+def _configured_core_root() -> Path:
+    """读取宿主明确绑定的 Core root，不从插件反向导入宿主。"""
 
-    import agent
-
-    locations = tuple(
-        Path(path).resolve(strict=True)
-        for path in getattr(agent, "__path__", ())
-    )
-    candidates = tuple(
-        location.parent
-        for location in locations
-        if (location / "plugin_composition").is_dir()
-    )
-    if len(candidates) != 1:
+    configured = os.environ.get("AKASHIC_CORE_ROOT", "").strip()
+    if not configured:
         raise RuntimeError(
-            "客户端自动发布需要唯一的运行中 Core root，"
-            f"实际发现 {len(candidates)} 个: {candidates}"
+            "客户端自动发布需要宿主显式设置 AKASHIC_CORE_ROOT"
         )
-    return candidates[0]
+    root = Path(configured).expanduser().resolve(strict=True)
+    if not (root / "agent" / "plugin_composition").is_dir():
+        raise RuntimeError(f"AKASHIC_CORE_ROOT 缺少 agent/plugin_composition: {root}")
+    return root
 
 
 def _current_stable_matches_head(workspace: Path, *, server_id: str, head: str) -> bool:


### PR DESCRIPTION
## 问题与结果

- 解决的问题：客户端 WebUI release CLI 仍可能依赖插件自身路径推断 Core root；在独立安装、多个 checkout 或不同宿主布局下，这会让发布来源和宿主身份混淆。
- 用户可见结果：正式 Core host 显式注入 AKASHIC_CORE_ROOT，客户端 release CLI 只读取宿主绑定并校验 agent/plugin_composition，缺少或错误绑定会 fail-loud。
- 本 PR 不处理：完整 Gate、CI、真实安装/替换、Mobile/Web/Pixel 客户端最终验收和正式 workspace 验证。

## Change intent

- change_type：fix
- semantic_delta：compatible
- capability_owner：mixed
- consumer_scope：bootstrap/tools.py、plugins/akashic_clients/mobile_webui/auto_publish.py。
- runtime_patch：required
- runtime_patch_reason：宿主必须拥有 Core identity，普通插件不能从自身路径反向导入或猜测宿主。
- authoritative_state_owner：Core host 负责绑定 AKASHIC_CORE_ROOT；插件只消费已验证路径；artifact provenance 仍由 release owner 持有。
- client_only_alternative：客户端只读取宿主显式绑定，不访问 agent package path 推断运行时。
- concept_gate：required
- concept_gate_reason：Terra 已在累计审查 head `d6cd185da0c9acc1af479c0a0ec5d2189d411dfd` 完成静态语义审查；六层结构符合目标，但审查 head 仍有 P0（CLI 生成 `.pyc` 写入 artifact）和 P1（README 旧根配置），后续候选修复尚未复审。
- 关联不变量：installed artifact provenance、Core tree identity、插件子进程隔离和 fail-loud 配置错误。
- protected_state：正式 workspace、已发布 artifact identity、Message/Session、客户端 delivery receipts。
- 允许的副作用：宿主进程环境变量和插件 release CLI 的路径校验。
- 禁止的副作用：不执行 deploy，不修改正式 workspace，不从插件路径加载 Core，不伪造客户端验收。

## 改动范围

- 主要文件：bootstrap/tools.py、plugins/akashic_clients/mobile_webui/auto_publish.py。
- 配置或迁移影响：无数据库或正式 workspace migration。
- 已知 schema lineage 与最终 schema identity：不改变。
- 协议 source、runtime、provider 与 scenario revision：base b80f4c4fee31cb777d9a80f8df610b45929a2d11，head d6cd185da0c9acc1af479c0a0ec5d2189d411dfd。
- 回滚方式：回滚至 b80f4c4fee31cb777d9a80f8df610b45929a2d11，不触碰正式 workspace 或已发布 artifact。

## 验证

- [ ] targeted tests/typecheck：本次发布未重跑。
- [ ] python docker/debug/gate.py run --base origin/main：未运行。
- sourceDigest：未生成。
- planDigest：未生成。
- 真实设备证据：未生成。
- 未运行项与原因：A 最终 head 确认后再查询 CI；全栈 Gate、安装/替换、Mobile/Web/Pixel acceptance 仍未完成。
- 发布前仅核对：d6cd185 为 A 在共享集成分支新增的 clean commit；base/head 相邻 diff 已做静态发布 sanity check，不是概念审查。

## 正交性与概念完整性

- 是否属于架构性 PR 或大改动：yes
- 独立 reviewer / model / reasoning：Terra 静态语义审查已完成（累计 head `d6cd185da0c9acc1af479c0a0ec5d2189d411dfd`）；结论：六层结构符合目标，P0/P1 仍需修复并重新复核。前置上下文为 #654、docs/decisions/0067-clients-are-ordinary-plugin.md 与客户端 adapter 设计。
- 审查 head：本 PR immutable head `d6cd185da0c9acc1af479c0a0ec5d2189d411dfd`；Terra 累计审查 head `d6cd185da0c9acc1af479c0a0ec5d2189d411dfd`。
- 新增概念及其唯一 owner：Core host binding 由 bootstrap/tools.py 拥有；客户端 release CLI 只消费并校验该绑定。
- 无关设计轴的变化传播：路径身份校验不改变 Message/Session、durable inbound 或客户端协议持久事实。
- 最短正常/失败/热更新链路：Core host start → 显式设置 AKASHIC_CORE_ROOT → plugin CLI 读取/校验 → provenance publish；缺失或错误路径立即失败。
- legacy/source-specific 残留扫描：移除 auto_publish 对 agent.__path__ 的反向推断；全仓扫描仍待累计 head。
- must-fix 及处置证据：Terra 在 `d6cd185` 发现并保留两项待复核问题：P0，CLI 生成 `.pyc` 写入 artifact；P1，README 仍有旧根配置。A 已在后续候选 head 修复中，但候选提交尚未重新 Terra 审查；C9 tests/E2E、full Gate、CI、安装/替换和客户端最终验收仍未完成。
- 最终结论：六层静态结构符合 Terra 在 `d6cd185` 的审查目标；P0/P1 的后续修复尚未复审，故本 PR 仍不构成累计栈最终验收。

## Terra 审查账本（累计 head `d6cd185`）

该审查在 `d6cd185da0c9acc1af479c0a0ec5d2189d411dfd` 上完成，确认 #655–#660 六层静态结构符合目标。
- P0（审查 head 状态）：客户端 CLI 生成的 `.pyc` 写入 artifact。
- P1（审查 head 状态）：README 仍引用旧根配置。
A 在共享集成候选 head 上已有后续修复提交，但尚未由 Terra 复审或作为最终发布 tail；C9 tests/E2E、full Gate、CI 与安装/替换验收继续保持未完成。
相邻 `git diff --check` 若出现于发布记录，只是静态 sanity check，不是概念审查。
