### PR TITLE
[codex] client CLI/docs 与 C9 coverage follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,24 +104,37 @@ uv run python main.py setup    # 交互向导
 uv run python main.py init     # 非交互，CI/自动化用
 ```
 
-终端初始化只创建 Core、渠道和 workspace 配置；模型仍在 2236 的“模型”页添加。
-`config.toml` 不再接受 `[llm]` 或 `[memory]`。手动 Core 配置的最小示例：
+终端初始化只创建 Core 和 workspace 配置；模型仍在 2236 的“模型”页添加。
+根 `config.toml` 只接受 Core 中立设置，最小示例：
 
 ```toml
 [runtime]
 workspace = "~/.akashic/workspace"
 
-[agent.context.compaction]
-keep_recent_tokens = 20000
-
-[channels.telegram]
-token = "123456:ABC..."
-allow_from = ["your_username"]
-
-[channels.chat]
+[app_server]
 enabled = true
-channel_name = "web"
+listen = ""
+max_connections = 32
+ingress_queue_size = 128
+outbound_queue_size = 512
 ```
+
+安装 `akashic_clients` 正式插件后，在其安装身份对应的 workspace data root
+（默认为 `<workspace>/plugin-data/akashic_clients-release/config.local.toml`）配置 Web/Mobile：
+
+```toml
+enabled = true
+
+[web]
+enabled = true
+
+[mobile_realtime]
+enabled = false
+```
+
+Telegram、QQ 和其他业务配置同样由各自已安装插件的 `config.local.toml` 拥有；Core 不读取
+`[channels.*]`、`[mobile_realtime]` 或模型业务表。若安装市场身份不是 `release`，以安装清单给出的
+`plugin-data/<name>-<marketplace>/` 为准。
 
 当前状态作为新的迁移基线，历史兼容脚本已经退役；Yoyo 保留用于未来升级。
 Core 只加载自有迁移和正式安装插件声明的 bundle，以 `<workspace>/migrations.sqlite3`
@@ -241,7 +254,7 @@ supervisor；需要直接调试 child 时把程序参数设为 `gateway`。也�
 Akashic Mobile 是一个通过独立实时网关连接 Akashic Agent 的 Android 客户端。远程接入推荐使用 Cloudflare Tunnel：Web Chat 和模型设置继续留在本机 `127.0.0.1:2236`，Tunnel 只转发由 Akashic 设备认证保护的 `6323` 端口。
 
 ```text
-1. 在 config.toml 启用 [mobile_realtime]
+1. 在已安装 akashic_clients 的 config.local.toml 启用 [mobile_realtime]
 2. 用 Cloudflare Tunnel 把一个公共域名转到 https://127.0.0.1:6323
 3. 在本机 Web Chat 点击“连接手机”，用 Akashic Mobile 扫描二维码
 4. 两端核对六位确认码，在电脑上批准设备

--- a/_handbook/mobile-access.md
+++ b/_handbook/mobile-access.md
@@ -44,18 +44,22 @@ http://127.0.0.1:2236
 
 ## 3. 启用移动实时网关
 
-修改配置前先保留恢复点：
+客户端配置属于已安装的 `akashic_clients` 插件。修改前先保留恢复点：
 
 ```bash
-cp --preserve=all --no-clobber config.toml config.toml.before-mobile
+WORKSPACE="${AKASHIC_WORKSPACE:-$HOME/.akashic/workspace}"
+CLIENT_CONFIG="$WORKSPACE/plugin-data/akashic_clients-release/config.local.toml"
+cp --preserve=all --no-clobber "$CLIENT_CONFIG" "$CLIENT_CONFIG.before-mobile"
 ```
 
-在 `config.toml` 中保留 loopback Web Chat，并加入移动网关配置。把示例域名换成自己的 Cloudflare 域名。
+在 `CLIENT_CONFIG` 中保留 Web Chat，并加入移动网关配置。把示例域名换成自己的 Cloudflare 域名。
+若安装市场身份不是 `release`，使用安装清单对应的 `plugin-data/<name>-<marketplace>/config.local.toml`。
 
 ```toml
-[channels.chat]
 enabled = true
-channel_name = "web"
+
+[web]
+enabled = true
 
 [mobile_realtime]
 enabled = true

--- a/plugins/akashic_clients/mobile_realtime/schema_cli.py
+++ b/plugins/akashic_clients/mobile_realtime/schema_cli.py
@@ -44,6 +44,7 @@ def _direct_package_identity() -> str:
 
 
 if not __package__:
+    sys.dont_write_bytecode = True
     _add_explicit_core_root()
     __package__ = f"{_direct_package_identity()}.mobile_realtime"
 

--- a/plugins/akashic_clients/mobile_webui/auto_publish.py
+++ b/plugins/akashic_clients/mobile_webui/auto_publish.py
@@ -51,6 +51,7 @@ def auto_publish_webui(
     environment = os.environ.copy()
     environment.pop("PYTHONPATH", None)
     environment.pop("AKASHIC_EXTRA_PLUGIN_DIRS", None)
+    environment["PYTHONDONTWRITEBYTECODE"] = "1"
     environment["AKASHIC_CORE_ROOT"] = str(_configured_core_root())
     command = [
         sys.executable,

--- a/plugins/akashic_clients/mobile_webui/release_cli.py
+++ b/plugins/akashic_clients/mobile_webui/release_cli.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 if not __package__:
+    sys.dont_write_bytecode = True
     artifact_root = Path(__file__).resolve().parents[1]
     token = hashlib.sha256(str(artifact_root).encode("utf-8")).hexdigest()[:20]
     package_name = f"_akashic_clients_cli_{token}"

--- a/tests/mobile_realtime/test_attachments.py
+++ b/tests/mobile_realtime/test_attachments.py
@@ -9,8 +9,8 @@ from pathlib import Path
 
 import pytest
 
-from infra.channels.base import AttachmentStore
-from infra.mobile_realtime.attachments import (
+from plugins.akashic_clients.attachments import AttachmentStore
+from plugins.akashic_clients.mobile_realtime.attachments import (
     AttachmentChunk,
     AttachmentRequestError,
     AttachmentTransferService,
@@ -18,7 +18,7 @@ from infra.mobile_realtime.attachments import (
     decode_attachment_chunk,
     encode_attachment_chunk,
 )
-from infra.mobile_realtime.storage import (
+from plugins.akashic_clients.mobile_realtime.storage import (
     AttachmentRecord,
     AttachmentStateError,
     DeviceRecord,
@@ -670,9 +670,13 @@ def test_outbound_rejects_symlink_and_persistent_root_failure(
 
     blocker = tmp_path / "not-a-directory"
     blocker.write_text("block", encoding="utf-8")
+    strict_root = tmp_path / "outbound-blocked"
+    strict_store = AttachmentStore(strict_root)
+    strict_root.rmdir()
+    blocker.rename(strict_root)
     strict_service = AttachmentTransferService(
         storage,
-        AttachmentStore(blocker / "outbound"),
+        strict_store,
         max_attachment_bytes=1024,
     )
     with pytest.raises(NotADirectoryError):

--- a/tests/mobile_realtime/test_channel.py
+++ b/tests/mobile_realtime/test_channel.py
@@ -16,11 +16,10 @@ from typing import Any, cast
 from uuid import uuid4
 
 import pytest
-import infra.mobile_realtime.channel as channel_module
-import infra.mobile_realtime.gateway as gateway_module
+import plugins.akashic_clients.mobile_realtime.channel as channel_module
+import plugins.akashic_clients.mobile_realtime.gateway as gateway_module
 
-from agent.config_models import MobileRealtimeConfig
-from agent.control.models import TurnRecord, TurnStatus
+from plugins.akashic_clients.config import MobileRealtimeConfig
 from agent.plugin_composition import (
     CapabilitySources,
     ConnectionDescriptor,
@@ -40,8 +39,10 @@ from agent.plugin_composition.channels import (
     ProviderDeliveryRequest,
     RawInbound,
 )
-from infra.mobile_realtime.runtime_inspection import RuntimeInspectionService
-from agent.plugins.model_catalog import ModelCatalogUnavailable
+from plugins.akashic_clients.services import (
+    ModelCatalogUnavailable,
+    RuntimeInspectionService,
+)
 from bus.events import (
     AttachmentKind,
     ChannelAttachment,
@@ -58,20 +59,23 @@ from bus.events_lifecycle import (
     TurnOutputCompleted,
     TurnStarted,
 )
-from infra.channels.base import AttachmentStore
+from plugins.akashic_clients.attachments import AttachmentStore
 from infra.channels.artifacts import ChannelAttachmentArtifactStore
-from infra.mobile_realtime.attachments import attachment_descriptor
-from infra.mobile_realtime.channel import MobileRealtimeChannel
-from infra.mobile_realtime.gateway import MobileGatewayRuntime
+from plugins.akashic_clients.mobile_realtime.attachments import attachment_descriptor
+from plugins.akashic_clients.mobile_realtime.channel import MobileRealtimeChannel
+from plugins.akashic_clients.mobile_realtime.gateway import MobileGatewayRuntime
 from plugins.models.selection import read_saved
-from infra.mobile_realtime.protocol import (
+from plugins.akashic_clients.mobile_realtime.protocol import (
     GenericCommand,
     MAX_JSON_FRAME_BYTES,
     MessageSendCommand,
     parse_frame,
 )
-from infra.mobile_realtime.remote_media import RemoteMediaError, RemoteMediaSnapshot
-from infra.mobile_realtime.storage import (
+from plugins.akashic_clients.message_types import (
+    TurnTerminalStatus as PluginTurnTerminalStatus,
+)
+from plugins.akashic_clients.mobile_realtime.remote_media import RemoteMediaError, RemoteMediaSnapshot
+from plugins.akashic_clients.mobile_realtime.storage import (
     AttachmentRecord,
     DeviceRecord,
     MobileStorageError,
@@ -79,24 +83,64 @@ from infra.mobile_realtime.storage import (
 )
 from session.manager import SessionManager
 from session.log import MessageLog
+from session.message import ContentPart, ContentReferences, Output
 
 
 @pytest.fixture(autouse=True)
 def _bind_real_mobile_message_log(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """给旧测试夹具接入真实只读 MessageCatalog，避免伪造会话对象。"""
+    """给插件测试夹具接入真实消息目录与正式 v3 channel ports。"""
 
     logs: list[MessageLog] = []
     original_start = MobileRealtimeChannel.start
 
     async def start_with_message_log(
         channel: MobileRealtimeChannel,
-        ctx: Any,
+        ctx: Any | None = None,
+        *,
+        host_boot_id: str | None = None,
+        durable_inbound: Any | None = None,
+        attachment_store: Any | None = None,
     ) -> None:
-        if channel._messages is None:
+        if channel._message_scope is None:
             log = MessageLog(tmp_path / f"sessions-{len(logs)}.db")
             channel.bind_messages(log.catalog())
+            channel._test_message_log = log
             logs.append(log)
-        await original_start(channel, ctx)
+        if ctx is not None:
+            bus = getattr(ctx, "bus", None)
+            if not isinstance(bus, _Bus):
+                raise TypeError("Mobile 测试上下文缺少 _Bus durable ingress")
+            port = _DurablePort(bus)
+            await original_start(
+                channel,
+                host_boot_id=host_boot_id or f"test-boot-{id(channel)}",
+                durable_inbound=port,
+                attachment_store=ctx.attachment_store,
+            )
+            channel._attach_v3_inbound(
+                ChannelRuntimePorts(
+                    snapshot_id="test-snapshot",
+                    generation_id="test-generation",
+                    binding_token=f"test-binding-{id(channel)}",
+                    ingress=bus,
+                    identity=None,
+                    attachment_import=None,
+                    durable_inbound=port,
+                )
+            )
+            channel._open_v3_inbound()
+            command_catalog_provider = getattr(ctx, "command_catalog_provider", None)
+            if command_catalog_provider is not None:
+                channel.bind_command_catalog(command_catalog_provider)
+            return
+        if durable_inbound is None or attachment_store is None:
+            raise TypeError("Mobile 测试启动缺少正式 durable port 或 attachment store")
+        await original_start(
+            channel,
+            host_boot_id=host_boot_id or f"test-boot-{id(channel)}",
+            durable_inbound=durable_inbound,
+            attachment_store=attachment_store,
+        )
 
     monkeypatch.setattr(MobileRealtimeChannel, "start", start_with_message_log)
     try:
@@ -104,6 +148,27 @@ def _bind_real_mobile_message_log(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
     finally:
         for log in logs:
             log.close()
+
+
+def _milestone_fields(record: logging.LogRecord) -> dict[str, object]:
+    """Read the plugin's flat structured-log fields across old test records."""
+
+    nested = getattr(record, "akashic_fields", None)
+    if isinstance(nested, Mapping):
+        return dict(nested)
+    return {
+        name: getattr(record, name)
+        for name in (
+            "event",
+            "session_id",
+            "turn_id",
+            "client_message_id",
+            "duration_ms",
+            "counts",
+            "outcome",
+        )
+        if hasattr(record, name)
+    }
 
 
 class _Runtime:
@@ -135,6 +200,11 @@ class _Runtime:
         capabilities: tuple[str, ...],
     ) -> None:
         self.storage.update_device_capabilities(device_id, capabilities)
+
+    def close_admission(self) -> None:
+        """Provide the gateway lifecycle edge used by the formal channel port."""
+
+        return None
 
 
 class _GatedPublishRuntime(_Runtime):
@@ -296,6 +366,55 @@ class _Bus:
         return self.pending_refs if self.pending_handoff else None
 
 
+class _DurablePort:
+    """把旧测试 bus 的行为接到插件声明的 durable inbound port。"""
+
+    def __init__(self, bus: _Bus) -> None:
+        self._bus = bus
+
+    async def reserve(self, raw: RawInbound) -> bool:
+        return await self._bus.reserve_mobile_channel_handoff(raw)
+
+    async def defer(self, handoff_id: str) -> None:
+        await self._bus.defer_mobile_channel_handoff(handoff_id)
+
+    async def settle_rejected(
+        self,
+        *,
+        session_key: str,
+        provider_message_id: str,
+    ) -> None:
+        await self._bus.settle_rejected_mobile_input(
+            session_key=session_key,
+            client_message_id=provider_message_id,
+        )
+
+    def has_pending(
+        self,
+        *,
+        session_key: str,
+        provider_message_id: str,
+    ) -> bool:
+        return self._bus.has_pending_mobile_handoff(
+            session_key=session_key,
+            client_message_id=provider_message_id,
+        )
+
+    def pending_attachment_refs(
+        self,
+        *,
+        session_key: str,
+        provider_message_id: str,
+    ) -> tuple[AttachmentRef, ...] | None:
+        return self._bus.pending_mobile_attachment_refs(
+            session_key=session_key,
+            client_message_id=provider_message_id,
+        )
+
+    async def recover(self, raw: RawInbound) -> bool:
+        return await self._bus.recover(raw)
+
+
 class _GatedReserveBus(_Bus):
     def __init__(self) -> None:
         super().__init__()
@@ -325,6 +444,44 @@ class _EventBus:
 
 class _PushTool:
     pass
+
+
+class _NativeMessageManager:
+    """Small test owner backed by the current append-only MessageLog."""
+
+    def __init__(self, log: MessageLog) -> None:
+        self._log = log
+
+    async def append_durable_delivery(
+        self,
+        *,
+        session_key: str,
+        content: str,
+        delivery_id: str,
+        control_turn_id: str,
+    ) -> str:
+        _ = delivery_id
+        message_id = uuid4().hex
+        writer = self._log.writer(
+            session_key,
+            author="assistant",
+            source="conversation",
+            body_types=(Output,),
+            content={"text": lambda _: ContentReferences()},
+        )
+        writer.append(
+            message_id,
+            Output(
+                (ContentPart("text", content),),
+                "complete",
+            ),
+        )
+        return message_id
+
+    def close(self) -> None:
+        """The autouse fixture owns the log connection lifecycle."""
+
+        return None
 
 
 class _ProviderFactory:
@@ -366,14 +523,13 @@ async def _started_native_mobile_channel(
     *,
     active_device: bool = True,
     runtime: Any | None = None,
-) -> tuple[MobileRealtimeChannel, MobileRealtimeStorage, SessionManager]:
+) -> tuple[MobileRealtimeChannel, MobileRealtimeStorage, _NativeMessageManager]:
     if runtime is None:
         storage = MobileRealtimeStorage(tmp_path / "mobile.db")
     else:
         storage = cast(MobileRealtimeStorage, runtime.storage)
     if active_device:
         _register_device(storage, "device-1")
-    manager = SessionManager(tmp_path / "workspace")
     channel = MobileRealtimeChannel(
         cast(MobileGatewayRuntime, runtime or _Runtime(storage))
     )
@@ -382,13 +538,14 @@ async def _started_native_mobile_channel(
             Any,
             SimpleNamespace(
                 bus=_Bus(),
-                session_manager=manager,
+                session_manager=SimpleNamespace(),
                 event_bus=_EventBus(),
                 push_tool=_PushTool(),
                 attachment_store=AttachmentStore(tmp_path / "uploads"),
             ),
         )
     )
+    manager = _NativeMessageManager(cast(MessageLog, channel._test_message_log))
     return channel, storage, manager
 
 
@@ -432,6 +589,13 @@ def _provider_delivery(channel: MobileRealtimeChannel):
                 execution_attempt_id=message.control_turn_id,
             )
         channel_message = channel_message_from_outbound(message)
+        if channel_message.terminal_status is not None:
+            channel_message = replace(
+                channel_message,
+                terminal_status=PluginTurnTerminalStatus(
+                    channel_message.terminal_status.value
+                ),
+            )
         metadata = dict(channel_message.metadata)
         metadata["_channel_commit_role"] = "passive"
         return await channel._deliver_message(
@@ -1123,17 +1287,17 @@ def _register_device(storage: MobileRealtimeStorage, device_id: str) -> None:
 
 @pytest.mark.asyncio
 async def test_lazy_mcp_catalog_error_does_not_abort_next_command(tmp_path: Path) -> None:
-    from agent.plugins.snapshot import RuntimeSnapshot
-    from infra.mobile_realtime.runtime_inspection import _mcp_items
-
-    snapshot = RuntimeSnapshot("lazy-mcp", {}, ())
-    snapshot.mcp_server_registry = cast(Any, SimpleNamespace(
-        descriptors=(SimpleNamespace(owner="computer", name="computer"),),
-    ))
-
     class Inspection(_RuntimeInspection):
         async def list_capabilities(self) -> dict[str, object]:
-            return {"mcp_servers": _mcp_items(snapshot)}
+            # MCP schemas are lazy and are not part of the Mobile command's
+            # own provider.  Keep the provider failure explicit so the next
+            # independent command can still run on this connection.
+            from plugins.akashic_clients.runtime_inspection import RuntimeInspectionError
+
+            raise RuntimeInspectionError(
+                "mcp_catalog_unavailable",
+                "MCP 工具目录暂不可用，声明的服务按需启动",
+            )
 
     storage = MobileRealtimeStorage(tmp_path / "mobile.db")
     device_id = uuid4().hex
@@ -1244,10 +1408,11 @@ async def test_model_catalog_returns_bound_registry_and_session_selection(
             }
         ]
         before = log.catalog().snapshot_heads()
-        unknown = await channel._model_catalog(_generic_frame(
-            frame_id="01ARZ3NDEKTSV4RRFFQ69G5FAW", command_type="model.catalog.get",
-            session_id=f"akashic:{uuid4()}",
-        ))
+        async with channel.open_message_scope():
+            unknown = await channel._model_catalog(_generic_frame(
+                frame_id="01ARZ3NDEKTSV4RRFFQ69G5FAW", command_type="model.catalog.get",
+                session_id=f"akashic:{uuid4()}",
+            ))
         assert unknown.payload["selected_runtime_id"] == ""
         assert log.catalog().snapshot_heads() == before
 
@@ -1691,7 +1856,7 @@ async def test_mobile_restart_never_publishes_source_drift_after_handoff_reserve
     workspace = tmp_path / "workspace"
     manager = SessionManager(workspace)
     legacy_store = AttachmentStore(tmp_path / "uploads")
-    legacy_store.root.mkdir(parents=True)
+    legacy_store.root.mkdir(parents=True, exist_ok=True)
     source = legacy_store.root / "upload.bin"
     original = b"reserved attachment bytes"
     source.write_bytes(original)
@@ -1973,7 +2138,10 @@ async def test_remote_outbound_media_keeps_response_filename(
             sha256="f" * 64,
         )
 
-    monkeypatch.setattr("infra.mobile_realtime.channel.snapshot_remote_media", snapshot)
+    monkeypatch.setattr(
+        "plugins.akashic_clients.mobile_realtime.channel.snapshot_remote_media",
+        snapshot,
+    )
     descriptors = await channel._outbound_descriptors(
         f"akashic:{uuid4()}",
         ["https://media.example/reaction"],
@@ -2017,7 +2185,10 @@ async def test_remote_media_failure_keeps_final_text(
     async def fail(*args: object, **kwargs: object) -> RemoteMediaSnapshot:
         raise RemoteMediaError("签名链接已失效")
 
-    monkeypatch.setattr("infra.mobile_realtime.channel.snapshot_remote_media", fail)
+    monkeypatch.setattr(
+        "plugins.akashic_clients.mobile_realtime.channel.snapshot_remote_media",
+        fail,
+    )
     await _provider_delivery(channel)(
         OutboundMessage(
             channel="akashic",
@@ -2081,7 +2252,7 @@ async def test_failed_terminal_accepts_client_message_id_without_user_message_id
     channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, runtime))
     session_id = f"akashic:{uuid4()}"
     turn_id = uuid4().hex
-    with caplog.at_level(logging.INFO, logger="infra.mobile_realtime.channel"):
+    with caplog.at_level(logging.INFO, logger="plugins.akashic_clients.mobile_realtime.channel"):
         await _provider_delivery(channel)(
             OutboundMessage(
                 channel="akashic",
@@ -2111,11 +2282,11 @@ async def test_failed_terminal_accepts_client_message_id_without_user_message_id
     final_records = [
         record
         for record in caplog.records
-        if record.akashic_fields.get("event") == "tl:final.published"
+        if _milestone_fields(record).get("event") == "tl:final.published"
     ]
     assert len(final_records) == 1
-    assert final_records[0].akashic_fields["turn_id"] == turn_id
-    assert final_records[0].akashic_fields["client_message_id"] == "cmid-fail"
+    assert _milestone_fields(final_records[0])["turn_id"] == turn_id
+    assert _milestone_fields(final_records[0])["client_message_id"] == "cmid-fail"
     storage.close()
 
 
@@ -2194,75 +2365,6 @@ async def test_control_reply_never_reuses_previous_message_id(tmp_path: Path) ->
 
     payload = cast(dict[str, object], runtime.events[-1]["payload"])
     assert "message_id" not in payload
-    await channel.stop()
-    manager.close()
-    storage.close()
-
-
-@pytest.mark.asyncio
-async def test_resume_reconciles_recovered_terminal_turn_for_mobile_device(
-    tmp_path: Path,
-) -> None:
-    storage = MobileRealtimeStorage(tmp_path / "mobile.db")
-    device_id = uuid4().hex
-    _register_device(storage, device_id)
-    runtime = _Runtime(storage)
-    channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, runtime))
-    manager = SessionManager(tmp_path / "workspace")
-    session_id = f"akashic:{uuid4()}"
-    turn_id = "01ARZ3NDEKTSV4RRFFQ69G5FAY"
-    storage.claim_session(
-        device_id=device_id,
-        session_id=session_id,
-        created_at=datetime.now(timezone.utc),
-    )
-    manager.save(manager.get_or_create(session_id))
-    manager.control_store.create_turn(
-        TurnRecord(
-            id=turn_id,
-            thread_id=session_id,
-            status=TurnStatus.QUEUED,
-            input="维护前的提问",
-            created_at=datetime.now(timezone.utc),
-        )
-    )
-    manager.control_store.transition_turn(
-        turn_id,
-        expected_status=TurnStatus.QUEUED,
-        status=TurnStatus.CANCELLED,
-    )
-    await channel.start(
-        cast(
-            Any,
-            SimpleNamespace(
-                bus=_Bus(),
-                session_manager=manager,
-                event_bus=_EventBus(),
-                push_tool=_PushTool(),
-                attachment_store=AttachmentStore(tmp_path / "uploads"),
-            ),
-        )
-    )
-
-    await channel.reconcile_active_turns(
-        device_id=device_id,
-        active_turns=(turn_id,),
-    )
-
-    assert runtime.events == [
-        {
-            "event_type": "turn.interrupted",
-            "session_id": session_id,
-            "turn_id": turn_id,
-            "payload": {
-                "status": "cancelled",
-                "message": "服务端已确认本轮生成结束",
-                "control_turn_id": turn_id,
-                "reason": "resume_reconciliation",
-            },
-            "device_id": device_id,
-        }
-    ]
     await channel.stop()
     manager.close()
     storage.close()
@@ -2921,7 +3023,7 @@ async def test_first_delta_orders_received_then_publish_then_published(
     )
 
     # 2. 发布被闸门挂起时：delta 已写入 runtime，received 已打点，published 未打。
-    with caplog.at_level(logging.INFO, logger="infra.mobile_realtime.channel"):
+    with caplog.at_level(logging.INFO, logger="plugins.akashic_clients.mobile_realtime.channel"):
         delta_task = asyncio.create_task(
             channel._on_stream_delta(
                 StreamDeltaReady(
@@ -2939,9 +3041,9 @@ async def test_first_delta_orders_received_then_publish_then_published(
             "react.thinking.delta",
         ]
         milestones = [
-            record.akashic_fields
+            _milestone_fields(record)
             for record in caplog.records
-            if record.akashic_fields.get("event", "").startswith(
+            if _milestone_fields(record).get("event", "").startswith(
                 "tl:delta.first_thinking"
             )
         ]
@@ -2957,9 +3059,9 @@ async def test_first_delta_orders_received_then_publish_then_published(
         runtime.delta_publish_release.set()
         await asyncio.wait_for(delta_task, timeout=5)
         milestones = [
-            record.akashic_fields
+            _milestone_fields(record)
             for record in caplog.records
-            if record.akashic_fields.get("event", "").startswith(
+            if _milestone_fields(record).get("event", "").startswith(
                 "tl:delta.first_thinking"
             )
         ]
@@ -3028,16 +3130,16 @@ async def test_dual_field_delta_accepts_thinking_and_answer_without_short_circui
 
     def _first_milestones() -> list[dict[str, object]]:
         return [
-            record.akashic_fields
+            _milestone_fields(record)
             for record in caplog.records
-            if getattr(record, "akashic_fields", {})
+            if _milestone_fields(record)
             .get("event", "")
             .startswith("tl:delta.first_")
         ]
 
     # 1. 首个双字段事件：两个 helper 各执行一次，state 全量建立，首段即时
     #    flush，wire 严格 react.thinking.delta → answer.delta。
-    with caplog.at_level(logging.INFO, logger="infra.mobile_realtime.channel"):
+    with caplog.at_level(logging.INFO, logger="plugins.akashic_clients.mobile_realtime.channel"):
         await channel._on_stream_delta(
             StreamDeltaReady(
                 session_key=session_id,
@@ -3126,7 +3228,7 @@ async def test_dual_field_delta_accepts_thinking_and_answer_without_short_circui
 
 
 @pytest.mark.asyncio
-async def test_terminal_and_reconcile_flush_pending_delta_before_terminal_event(
+async def test_interrupted_terminal_flushes_pending_delta_before_terminal_event(
     tmp_path: Path,
 ) -> None:
     """终态前必须先 flush 已缓冲 delta；终态后批与定时器消失，无迟到发布。"""
@@ -3212,22 +3314,8 @@ async def test_terminal_and_reconcile_flush_pending_delta_before_terminal_event(
         "message.final",
     ]
 
-    # 3. reconcile 终态同样先 flush 残留批再发布 turn.interrupted。
+    # 3. typed interrupted terminal 同样先 flush 残留批再发布 turn.interrupted。
     second_turn = "01ARZ3NDEKTSV4RRFFQ69G5FAV"
-    manager.control_store.create_turn(
-        TurnRecord(
-            id=second_turn,
-            thread_id=session_id,
-            status=TurnStatus.QUEUED,
-            input="第二问",
-            created_at=datetime.now(timezone.utc),
-        )
-    )
-    manager.control_store.transition_turn(
-        second_turn,
-        expected_status=TurnStatus.QUEUED,
-        status=TurnStatus.CANCELLED,
-    )
     await channel._on_turn_started(
         TurnStarted(
             session_key=session_id,
@@ -3258,9 +3346,16 @@ async def test_terminal_and_reconcile_flush_pending_delta_before_terminal_event(
         )
     )
     events_before = [event["event_type"] for event in runtime.events]
-    await channel.reconcile_active_turns(
-        device_id=device_id,
-        active_turns=(second_turn,),
+    await _provider_delivery(channel)(
+        OutboundMessage(
+            channel="akashic",
+            chat_id=session_id.removeprefix("akashic:"),
+            content="本轮已中断。",
+            metadata={"client_message_id": "cmid-B"},
+            control_turn_id=second_turn,
+            execution_attempt_id=second_turn,
+            terminal_status=TurnTerminalStatus.INTERRUPTED,
+        )
     )
     assert [event["event_type"] for event in runtime.events] == [
         *events_before,
@@ -3329,7 +3424,7 @@ async def test_terminal_barrier_flushes_accepted_deltas_then_terminal_and_drops_
 
     # 1. final 路径：top flush 发布已缓冲 delta → suffix delta → barrier 内发布
     #    message.final；闸门卡住 terminal 发布，让 barrier 临界区真实持锁。
-    with caplog.at_level(logging.INFO, logger="infra.mobile_realtime.channel"):
+    with caplog.at_level(logging.INFO, logger="plugins.akashic_clients.mobile_realtime.channel"):
         final_task = asyncio.create_task(
             _provider_delivery(channel)(
                 OutboundMessage(
@@ -3415,7 +3510,7 @@ async def test_terminal_barrier_flushes_accepted_deltas_then_terminal_and_drops_
     ]
 
     # 6. 收口完成后（maps 已清理）的迟到 delta 仍被拒绝，且不能重建 lock/batch
-    with caplog.at_level(logging.INFO, logger="infra.mobile_realtime.channel"):
+    with caplog.at_level(logging.INFO, logger="plugins.akashic_clients.mobile_realtime.channel"):
         await channel._on_stream_delta(
             StreamDeltaReady(
                 session_key=session_id,
@@ -3431,15 +3526,15 @@ async def test_terminal_barrier_flushes_accepted_deltas_then_terminal_and_drops_
     dropped = [
         record
         for record in caplog.records
-        if record.akashic_fields.get("event") == "tl:turn.late.drop"
+        if _milestone_fields(record).get("event") == "tl:turn.late.drop"
     ]
     assert len(dropped) == 2
-    assert {item.akashic_fields["counts"] for item in dropped} == {
+    assert {_milestone_fields(item)["counts"] for item in dropped} == {
         "event_type=answer.delta",
     }
     assert all(
-        item.akashic_fields["session_id"] == session_id
-        and item.akashic_fields["turn_id"] == turn_id
+        _milestone_fields(item)["session_id"] == session_id
+        and _milestone_fields(item)["turn_id"] == turn_id
         for item in dropped
     )
     await channel.stop()
@@ -3855,7 +3950,7 @@ async def test_post_terminal_flush_duplicate_and_late_events_never_rebuild(
         is False
     )
     # 2. 迟到 delta / tool.started / tool.completed：全部丢弃，无 state 异常。
-    with caplog.at_level(logging.INFO, logger="infra.mobile_realtime.channel"):
+    with caplog.at_level(logging.INFO, logger="plugins.akashic_clients.mobile_realtime.channel"):
         await channel._on_stream_delta(
             StreamDeltaReady(
                 session_key=session_id,
@@ -3906,9 +4001,9 @@ async def test_post_terminal_flush_duplicate_and_late_events_never_rebuild(
     dropped = [
         record
         for record in caplog.records
-        if record.akashic_fields.get("event") == "tl:turn.late.drop"
+        if _milestone_fields(record).get("event") == "tl:turn.late.drop"
     ]
-    assert {item.akashic_fields["counts"] for item in dropped} == {
+    assert {_milestone_fields(item)["counts"] for item in dropped} == {
         "event_type=answer.delta",
         "event_type=react.tool.started",
         "event_type=react.tool.completed",
@@ -4063,7 +4158,7 @@ async def test_late_a_final_keeps_b_active_and_identity(
 
     # 1. 迟到的 A final 通过 execution attempt 归属 A；逻辑 Turn 独立投影。
     logical_turn_a = "turn:logical-A"
-    with caplog.at_level(logging.INFO, logger="infra.mobile_realtime.channel"):
+    with caplog.at_level(logging.INFO, logger="plugins.akashic_clients.mobile_realtime.channel"):
         await _provider_delivery(channel)(
             OutboundMessage(
                 channel="akashic",
@@ -4087,11 +4182,11 @@ async def test_late_a_final_keeps_b_active_and_identity(
     final_records = [
         record
         for record in caplog.records
-        if record.akashic_fields.get("event") == "tl:final.published"
+        if _milestone_fields(record).get("event") == "tl:final.published"
     ]
     assert len(final_records) == 1
-    assert final_records[0].akashic_fields["turn_id"] == turn_a
-    assert final_records[0].akashic_fields["client_message_id"] == "cmid-A"
+    assert _milestone_fields(final_records[0])["turn_id"] == turn_a
+    assert _milestone_fields(final_records[0])["client_message_id"] == "cmid-A"
 
     # 2. A cleanup 只清 A：B 的 active/process/turn/send maps 全部保留。
     assert channel._active_turn_ids == {session_id: turn_b}
@@ -4297,7 +4392,7 @@ async def test_send_and_turn_started_bind_each_client_message_id_per_session(
     session_id = f"akashic:{uuid4()}"
     first_id = "01ARZ3NDEKTSV4RRFFQ69G5FAA"
     second_id = "01ARZ3NDEKTSV4RRFFQ69G5FAB"
-    with caplog.at_level(logging.INFO, logger="infra.mobile_realtime.channel"):
+    with caplog.at_level(logging.INFO, logger="plugins.akashic_clients.mobile_realtime.channel"):
         first = await channel.handle_command(
             device_id=device_id,
             frame=_message_frame(frame_id=first_id, session_id=session_id),
@@ -4340,18 +4435,20 @@ async def test_send_and_turn_started_bind_each_client_message_id_per_session(
     started = [
         record
         for record in caplog.records
-        if record.akashic_fields.get("event") == "tl:turn.started"
+        if _milestone_fields(record).get("event") == "tl:turn.started"
     ]
-    by_cmid = {record.akashic_fields["client_message_id"]: record for record in started}
+    by_cmid = {
+        _milestone_fields(record)["client_message_id"]: record for record in started
+    }
     assert set(by_cmid) == {first_id, second_id}
-    assert by_cmid[first_id].akashic_fields["duration_ms"] == pytest.approx(103_000.0)
-    assert by_cmid[second_id].akashic_fields["duration_ms"] == pytest.approx(193_000.0)
+    assert _milestone_fields(by_cmid[first_id])["duration_ms"] == pytest.approx(103_000.0)
+    assert _milestone_fields(by_cmid[second_id])["duration_ms"] == pytest.approx(193_000.0)
     acks = [
         record
         for record in caplog.records
-        if record.akashic_fields.get("event") == "tl:send.ack"
+        if _milestone_fields(record).get("event") == "tl:send.ack"
     ]
-    assert {record.akashic_fields["client_message_id"] for record in acks} == {
+    assert {_milestone_fields(record)["client_message_id"] for record in acks} == {
         first_id,
         second_id,
     }

--- a/tests/mobile_realtime/test_key_protection.py
+++ b/tests/mobile_realtime/test_key_protection.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 import pytest
 from cryptography.hazmat.primitives.asymmetric import ec
 
-from infra.mobile_realtime.key_protection import (
+from plugins.akashic_clients.mobile_realtime.key_protection import (
     EncryptedKeyBlobCodec,
     FileMasterKeyStore,
     KeyProtectionError,

--- a/tests/mobile_realtime/test_remote_media.py
+++ b/tests/mobile_realtime/test_remote_media.py
@@ -7,8 +7,8 @@ from pathlib import Path
 import httpcore
 import pytest
 
-from infra.channels.base import AttachmentStore
-from infra.mobile_realtime.remote_media import (
+from plugins.akashic_clients.attachments import AttachmentStore
+from plugins.akashic_clients.mobile_realtime.remote_media import (
     PinnedNetworkBackend,
     RemoteMediaError,
     snapshot_remote_media,

--- a/tests/mobile_realtime/test_storage.py
+++ b/tests/mobile_realtime/test_storage.py
@@ -9,9 +9,9 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
-import infra.mobile_realtime.storage as storage_module
+import plugins.akashic_clients.mobile_realtime.storage as storage_module
 
-from infra.mobile_realtime.storage import (
+from plugins.akashic_clients.mobile_realtime.storage import (
     AckOverflowError,
     AckRollbackError,
     AttachmentRecord,

--- a/tests/mobile_webui/test_publication.py
+++ b/tests/mobile_webui/test_publication.py
@@ -13,16 +13,16 @@ from typing import Any, cast
 import pytest
 from cryptography.hazmat.primitives.asymmetric import ec
 
-from infra.mobile_realtime.key_protection import LoadedKeyset
-from infra.mobile_realtime.protocol import (
+from plugins.akashic_clients.mobile_realtime.key_protection import LoadedKeyset
+from plugins.akashic_clients.mobile_realtime.protocol import (
     MobileWebUiContentPrepareCommand,
     MobileWebUiReleaseChangedControl,
     parse_frame,
 )
-from infra.mobile_webui.protocol import PrepareReplyWire, ReleaseViewWire
-from infra.mobile_realtime.storage import DeviceRecord, MobileRealtimeStorage
-from infra.mobile_webui.http import WebUiTicketIssuer, WebUiTicketError, parse_single_range
-from infra.mobile_webui.manifest import (
+from plugins.akashic_clients.mobile_webui.protocol import PrepareReplyWire, ReleaseViewWire
+from plugins.akashic_clients.mobile_realtime.storage import DeviceRecord, MobileRealtimeStorage
+from plugins.akashic_clients.mobile_webui.http import WebUiTicketIssuer, WebUiTicketError, parse_single_range
+from plugins.akashic_clients.mobile_webui.manifest import (
     ManifestError,
     WebUiManifest,
     WebUiFile,
@@ -34,7 +34,7 @@ from infra.mobile_webui.manifest import (
     manifest_from_json,
     validate_manifest,
 )
-from infra.mobile_webui.store import MobileWebUiStore, UnknownReleaseError
+from plugins.akashic_clients.mobile_webui.store import MobileWebUiStore, UnknownReleaseError
 
 
 _SOURCE = {
@@ -61,7 +61,7 @@ def _manifest(root: Path, text: bytes = b"<html>ok</html>\n"):
 
 
 def _kill_backup_before_rename(root: str, destination: str) -> None:
-    from infra.mobile_webui import store as store_module
+    from plugins.akashic_clients.mobile_webui import store as store_module
 
     original_replace = store_module.os.replace
     absolute_destination = os.path.abspath(destination)
@@ -77,7 +77,7 @@ def _kill_backup_before_rename(root: str, destination: str) -> None:
 
 
 def _kill_backup_after_rename(root: str, destination: str) -> None:
-    from infra.mobile_webui import store as store_module
+    from plugins.akashic_clients.mobile_webui import store as store_module
 
     original_replace = store_module.os.replace
     absolute_destination = os.path.abspath(destination)
@@ -113,7 +113,7 @@ def _restore_target_name(target: str) -> str:
 
 
 def _kill_restore_before_old_rename(backup: str, target: str, pre_restore: str) -> None:
-    from infra.mobile_webui import store as store_module
+    from plugins.akashic_clients.mobile_webui import store as store_module
 
     original_replace = store_module.os.replace
     target_name = _restore_target_name(target)
@@ -133,7 +133,7 @@ def _kill_restore_before_old_rename(backup: str, target: str, pre_restore: str) 
 
 
 def _kill_restore_after_old_rename(backup: str, target: str, pre_restore: str) -> None:
-    from infra.mobile_webui import store as store_module
+    from plugins.akashic_clients.mobile_webui import store as store_module
 
     original_replace = store_module.os.replace
     target_name = _restore_target_name(target)
@@ -153,7 +153,7 @@ def _kill_restore_after_old_rename(backup: str, target: str, pre_restore: str) -
 
 
 def _kill_restore_after_new_install(backup: str, target: str, pre_restore: str) -> None:
-    from infra.mobile_webui import store as store_module
+    from plugins.akashic_clients.mobile_webui import store as store_module
 
     original_replace = store_module.os.replace
     absolute_target = os.path.abspath(target)
@@ -173,7 +173,7 @@ def _kill_restore_after_new_install(backup: str, target: str, pre_restore: str) 
 
 
 def _kill_restore_before_new_install_without_old(backup: str, target: str) -> None:
-    from infra.mobile_webui import store as store_module
+    from plugins.akashic_clients.mobile_webui import store as store_module
 
     original_replace = store_module.os.replace
     marker_path = os.path.abspath(store_module.MobileWebUiStore._restore_marker_path(Path(target)))
@@ -316,7 +316,7 @@ def test_manifest_directory_covers_wire_reachable_script_and_binary_mimes(tmp_pa
         "style.css": "text/css",
         "worker.cjs": "text/javascript",
     }
-    from infra.mobile_webui.protocol import WebUiManifestWire, WebUiFileWire
+    from plugins.akashic_clients.mobile_webui.protocol import WebUiManifestWire, WebUiFileWire
 
     WebUiManifestWire.model_validate(manifest.as_json(), strict=True)
     with pytest.raises(ValueError):
@@ -343,7 +343,7 @@ def test_wire_manifest_rejects_ambiguous_digest_size(tmp_path: Path) -> None:
     ]
     payload["file_count"] = 2
     payload["unpacked_size_bytes"] = 3
-    from infra.mobile_webui.protocol import WebUiManifestWire
+    from plugins.akashic_clients.mobile_webui.protocol import WebUiManifestWire
 
     with pytest.raises(ValueError, match="size/mime"):
         WebUiManifestWire.model_validate(payload, strict=True)
@@ -796,7 +796,7 @@ def test_restore_parent_fsync_failure_keeps_marker_for_valid_new_recovery(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from infra.mobile_webui import store as store_module
+    from plugins.akashic_clients.mobile_webui import store as store_module
 
     backup, target, pre_restore, source_manifest, _old_manifest = _restore_fixture(tmp_path)
     original_replace = store_module.os.replace
@@ -846,7 +846,7 @@ def test_restore_recovery_delete_failure_keeps_marker_for_retry(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from infra.mobile_webui import store as store_module
+    from plugins.akashic_clients.mobile_webui import store as store_module
 
     backup, target, pre_restore, source_manifest, _old_manifest = _restore_fixture(tmp_path)
     original_rmtree = store_module.shutil.rmtree
@@ -888,7 +888,7 @@ def test_restore_recovery_delete_fsync_failure_keeps_marker_for_retry(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from infra.mobile_webui import store as store_module
+    from plugins.akashic_clients.mobile_webui import store as store_module
 
     backup, target, pre_restore, source_manifest, _old_manifest = _restore_fixture(tmp_path)
     original_rmtree = store_module.shutil.rmtree
@@ -935,7 +935,7 @@ def test_restore_marker_cleanup_failure_keeps_marker_and_recovers_on_restart(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from infra.mobile_webui import store as store_module
+    from plugins.akashic_clients.mobile_webui import store as store_module
 
     backup, target, pre_restore, source_manifest, _old_manifest = _restore_fixture(tmp_path)
     original_clear = store_module.MobileWebUiStore._clear_restore_marker

--- a/tests/test_mobile_message_input.py
+++ b/tests/test_mobile_message_input.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import hashlib
-import logging
 import sqlite3
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
@@ -13,26 +12,160 @@ import pytest
 from pydantic import ValidationError
 
 from agent.plugins.manager import PluginManager
-from bootstrap.core_channel_adapter import build_core_channel_definition
+from agent.plugins.snapshot import lease_runtime_snapshot
+from agent.plugin_composition.channels import (
+    CHANNEL_INPUT,
+    ChannelRuntimePorts,
+    InboundEnvelope,
+    RawInbound,
+)
 from bus.event_bus import EventBus
 from bus.queue import MessageBus
-from infra.channels.base import AttachmentStore
-from infra.channels.contract import ChannelContext
+from plugins.akashic_clients.attachments import AttachmentStore
 from infra.channels.artifacts import ChannelAttachmentArtifactStore
-from core.net.http import SharedHttpResources
-from infra.mobile_realtime.attachments import AttachmentChunk
+from plugins.akashic_clients.mobile_realtime.attachments import AttachmentChunk
 from session.artifact_store import ArtifactStore
-from infra.mobile_realtime.channel import MobileRealtimeChannel, _command_hash
-from infra.mobile_realtime.gateway import MobileGatewayRuntime
-from infra.mobile_realtime.protocol import MessageSendCommand
-from infra.mobile_realtime.storage import MobileRealtimeStorage
+from plugins.akashic_clients.mobile_realtime.channel import MobileRealtimeChannel, _command_hash
+from plugins.akashic_clients.mobile_realtime.gateway import MobileGatewayRuntime
+from plugins.akashic_clients.mobile_realtime.protocol import MessageSendCommand
+from plugins.akashic_clients.mobile_realtime.storage import MobileRealtimeStorage
 from session.admissions import SessionAdmissions
 from session.identities import ChannelIdentities
 from session.inbound_store import InboundHandoffStore
 from session.log import MessageLog, SessionAttributes
 from session.message import ContentPart, ContentReferences, Control, Input, Output
-from tests.mobile_realtime.test_channel import _Runtime, _register_device
+from tests.akashic_clients_mobile_fixtures import _Runtime, _register_device
 from tests.fixtures.formal_plugins import MINIMAL_MESSAGE_PLUGINS, install_formal_plugins
+
+
+class _TestBinding:
+    """最小 exact binding，仅让 MessageBus 保持正式 envelope 生命周期。"""
+
+    snapshot_lease = object()
+    snapshot_id = "test-snapshot"
+    generation_id = "test-generation"
+    channel_name = "akashic"
+    binding_token = "test-binding"
+    active = True
+
+    async def aclose(self) -> None:
+        return None
+
+
+class _MessageBusIngress:
+    """把插件声明的 inbound port 接到真实 MessageBus/MessageLog owner。"""
+
+    def __init__(
+        self,
+        bus: MessageBus,
+        manager: PluginManager,
+        identities: ChannelIdentities,
+    ) -> None:
+        self._bus = bus
+        self._manager = manager
+        self._identities = identities
+        self._binding = _TestBinding()
+
+    async def reserve(self, raw: RawInbound) -> bool:
+        return await self._bus.reserve_durable_inbound(raw)
+
+    async def admit(self, raw: RawInbound) -> bool:
+        return await self._process(raw)
+
+    async def recover(self, raw: RawInbound) -> bool:
+        return await self._process(raw)
+
+    async def _process(self, raw: RawInbound) -> bool:
+        session_key = raw.message.metadata.get("session_key_override")
+        if not isinstance(session_key, str) or not session_key:
+            raise RuntimeError("测试 ingress 缺少 session_key_override")
+        identity_receipt = None
+        if raw.provider_identity is not None and raw.recipient is not None:
+            identity_receipt = self._identities.remember(
+                "akashic", raw.provider_identity, raw.recipient,
+            )
+        envelope = InboundEnvelope(
+            message_id=raw.message_id,
+            session_key=session_key,
+            snapshot_id=self._binding.snapshot_id,
+            generation_id=self._binding.generation_id,
+            binding_token=self._binding.binding_token,
+            message=raw.message,
+            lease=self._binding,
+        )
+        await self._bus.prepare_channel_input(envelope)
+        try:
+            async with lease_runtime_snapshot(self._manager.snapshot_store) as snapshot:
+                root = snapshot.composition_root
+                if root is None:
+                    raise RuntimeError("测试 ingress 缺少当前 composition snapshot")
+                accept = root.context.require(CHANNEL_INPUT)
+                await accept(session_key, raw.message_id, raw.message)
+            await self._bus.complete_channel_input(envelope)
+            return True
+        except BaseException:
+            if identity_receipt is not None:
+                self._identities.rollback(identity_receipt)
+            await self._bus.retain_channel_input(envelope)
+            raise
+
+
+class _MessageBusDurablePort:
+    """Expose only the formal durable operations required by Mobile."""
+
+    def __init__(self, bus: MessageBus, ingress: _MessageBusIngress) -> None:
+        self._bus = bus
+        self._ingress = ingress
+
+    async def reserve(self, raw: RawInbound) -> bool:
+        return await self._bus.reserve_durable_inbound(raw)
+
+    async def defer(self, handoff_id: str) -> None:
+        _ = await self._bus.defer_durable_inbound(handoff_id)
+
+    async def settle_rejected(
+        self,
+        *,
+        session_key: str,
+        provider_message_id: str,
+    ) -> None:
+        await self._bus.settle_rejected_inbound(
+            channel="akashic",
+            session_key=session_key,
+            provider_message_id=provider_message_id,
+        )
+
+    def has_pending(self, *, session_key: str, provider_message_id: str) -> bool:
+        return self._bus.has_pending_durable_inbound(
+            channel="akashic",
+            session_key=session_key,
+            provider_message_id=provider_message_id,
+        )
+
+    def pending_attachment_refs(
+        self,
+        *,
+        session_key: str,
+        provider_message_id: str,
+    ) -> tuple[object, ...] | None:
+        return self._bus.pending_durable_attachment_refs(
+            channel="akashic",
+            session_key=session_key,
+            provider_message_id=provider_message_id,
+        )
+
+    async def recover(self, raw: RawInbound) -> bool:
+        return await self._ingress.recover(raw)
+
+
+class _ChannelRecovery:
+    """Route durable rows through the plugin command receipt recovery path."""
+
+    def __init__(self, channel: MobileRealtimeChannel) -> None:
+        self._channel = channel
+
+    async def __call__(self, raw: RawInbound) -> bool:
+        return await self._channel._recover_v3_handoff(raw)
 
 
 def command(session: str, number: int = 0, **payload: object) -> MessageSendCommand:
@@ -66,7 +199,7 @@ async def runtime(tmp_path, *, device=None, store_type=InboundHandoffStore):
         _register_device(storage, device)
     bus = MessageBus()
     bus.bind_durable_inbound_store(handoffs)
-    bus.bind_mobile_session_admission_owner(admissions)
+    bus.bind_session_admission_owner(admissions)
     gateway_runtime = _Runtime(storage)
     channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, gateway_runtime))
     channel.bind_messages(log.catalog())
@@ -75,26 +208,35 @@ async def runtime(tmp_path, *, device=None, store_type=InboundHandoffStore):
     manager = PluginManager([], event_bus=event_bus, workspace=workspace,
         message_log=log, channel_identities=identities, channel_attachment_store=physical,
         installed_cache_root=plugin_home / 'cache')
-    manager.channel_generation_host.bind_input_custody(bus)
-    http_resources = SharedHttpResources()
-    context = ChannelContext(
-        bus=bus,
-        event_bus=event_bus,
-        attachment_store=AttachmentStore(tmp_path / 'uploads'),
-        http_resources=http_resources,
-        log=logging.getLogger(__name__),
-    )
+    ingress = _MessageBusIngress(bus, manager, identities)
+    durable = _MessageBusDurablePort(bus, ingress)
+    bus.bind_durable_inbound_recoverer(_ChannelRecovery(channel))
+    attachment_store = AttachmentStore(tmp_path / 'uploads')
     try:
-        await channel.start(context)
         await manager.load_all()
-        await manager.bind_core_channel_definitions((build_core_channel_definition(channel),))
+        await channel.start(
+            host_boot_id=f"test-boot-{uuid4().hex}",
+            durable_inbound=durable,
+            attachment_store=attachment_store,
+        )
+        channel._attach_v3_inbound(
+            ChannelRuntimePorts(
+                snapshot_id="test-snapshot",
+                generation_id="test-generation",
+                binding_token="test-binding",
+                ingress=ingress,
+                identity=None,
+                attachment_import=None,
+                durable_inbound=durable,
+            )
+        )
+        channel._open_v3_inbound()
         yield log, identities, manager, bus, channel, storage, device, handoffs
     finally:
         await manager.terminate_all()
         await channel.stop()
         await bus.aclose()
         await event_bus.aclose()
-        await http_resources.aclose()
         for store in (log, identities, admissions, handoffs, storage, artifacts):
             store.close()
 
@@ -344,7 +486,10 @@ async def test_rejection_cannot_expire_while_cross_database_cleanup_is_pending(t
         future = datetime.now(UTC) + timedelta(days=20)
         assert storage.cleanup_command_receipts(device_id=device, now=future) == 0
         assert storage.read_command(device_id=device, command_id=frame.id).status == 'completed'
-        monkeypatch.setattr('infra.mobile_realtime.channel._utc_now', lambda: future)
+        monkeypatch.setattr(
+            'plugins.akashic_clients.mobile_realtime.channel._utc_now',
+            lambda: future,
+        )
         append(log, session, 'later', Input(()))
         with pytest.raises(OSError):
             await channel.handle_command(device_id=device, frame=frame)

--- a/tests/test_runtime_inspection_plugin.py
+++ b/tests/test_runtime_inspection_plugin.py
@@ -144,15 +144,18 @@ async def test_runtime_inspection_provider_propagates_business_failure(
 
 
 @pytest.mark.asyncio
-async def test_core_inspection_binds_lease_for_real_skill_projection(tmp_path: Path) -> None:
+async def test_client_inspection_binds_lease_for_real_skill_projection(tmp_path: Path) -> None:
     """真实技能 owner 的租约读取经 Web/Mobile 共用的检查入口完成。"""
     import shutil
     from bus.event_bus import EventBus
     from agent.plugins.manager import PluginManager
     from infra.channels.artifacts import ChannelAttachmentArtifactStore
     from session.artifact_store import ArtifactStore
-    from agent.plugins.snapshot import get_current_runtime_snapshot
-    from infra.mobile_realtime.runtime_inspection import RuntimeInspectionService
+    from agent.plugins.snapshot import (
+        get_current_runtime_snapshot,
+        lease_runtime_snapshot,
+    )
+    from plugins.akashic_clients.runtime_inspection import ScopedRpcRuntimeInspection
 
     source = tmp_path / "plugins"
     for name in ("content", "context", "tools", "standard_tools", "runtime_inspection"):
@@ -177,10 +180,20 @@ async def test_core_inspection_binds_lease_for_real_skill_projection(tmp_path: P
         await manager.load_all()
         snapshot = manager.snapshot_store.current
         assert snapshot is not None
-        service = RuntimeInspectionService(workspace=tmp_path / "workspace", snapshot_store=manager.snapshot_store)
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def open_scope():
+            async with lease_runtime_snapshot(manager.snapshot_store) as snapshot:
+                root = snapshot.composition_root
+                if root is None:
+                    raise RuntimeError("inspection fixture 缺少 composition root")
+                yield root.context
+
+        service = ScopedRpcRuntimeInspection(open_scope)
         for _ in range(2):
             result = await service.list_capabilities()
-            assert [item["name"] for item in _rows(result["skills"])] == ["probe"]
+            assert [item["name"] for item in _rows(result["items"])] == ["probe"]
             assert snapshot.lease_count == 0
             assert get_current_runtime_snapshot() is None
     finally:

--- a/tests/test_scheduler_inspection.py
+++ b/tests/test_scheduler_inspection.py
@@ -3,16 +3,15 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import cast
 
 import pytest
 
-from infra.mobile_realtime.runtime_inspection import (
-    RuntimeInspectionError,
-    RuntimeInspectionService,
-)
+from agent.plugins.snapshot import lease_runtime_snapshot
+from plugins.akashic_clients.runtime_inspection import ScopedRpcRuntimeInspection
 from plugins.scheduler.inspection import SchedulerInspectionProvider
 from plugins.scheduler.schedule import ScheduledJob
 from plugins.scheduler.store import JobStore
@@ -37,6 +36,20 @@ def _job(
         name=job_id,
         id=job_id,
     )
+
+
+def _inspection_service(store):
+    """Resolve inspection RPC methods through one current snapshot per call."""
+
+    @asynccontextmanager
+    async def open_scope():
+        async with lease_runtime_snapshot(store) as snapshot:
+            root = snapshot.composition_root
+            if root is None:
+                raise RuntimeError("inspection fixture 缺少 composition root")
+            yield root.context
+
+    return ScopedRpcRuntimeInspection(open_scope)
 
 
 def test_scheduler_provider_projects_only_enabled_jobs(tmp_path: Path) -> None:
@@ -85,7 +98,7 @@ class _Provider:
 
 
 @pytest.mark.asyncio
-async def test_core_passes_through_scheduler_projection_without_reading_workspace(tmp_path: Path) -> None:
+async def test_client_passes_through_scheduler_projection_without_reading_workspace(tmp_path: Path) -> None:
     from agent.plugin_composition import CompositionRoot
     from agent.plugin_composition.rpc import rpc_method_key
     from plugins.runtime_inspection.rpc import rpc_methods
@@ -101,7 +114,7 @@ async def test_core_passes_through_scheduler_projection_without_reading_workspac
     store = RuntimeSnapshotStore()
     snapshot = RuntimeSnapshotCompiler().compile({}, composition_root=root)
     store.install(snapshot)
-    service = RuntimeInspectionService(workspace=tmp_path, snapshot_store=store)
+    service = _inspection_service(store)
     original = provider.list_jobs
     def list_jobs():
         assert get_current_runtime_snapshot() is snapshot
@@ -119,7 +132,7 @@ async def test_core_passes_through_scheduler_projection_without_reading_workspac
 
 
 @pytest.mark.asyncio
-async def test_core_does_not_swallow_scheduler_provider_failure(tmp_path: Path) -> None:
+async def test_client_does_not_swallow_scheduler_provider_failure(tmp_path: Path) -> None:
     from agent.plugin_composition import CompositionRoot
     from agent.plugin_composition.rpc import rpc_method_key
     from plugins.runtime_inspection.rpc import rpc_methods
@@ -141,7 +154,7 @@ async def test_core_does_not_swallow_scheduler_provider_failure(tmp_path: Path) 
     store = RuntimeSnapshotStore()
     snapshot = RuntimeSnapshotCompiler().compile({}, composition_root=root)
     store.install(snapshot)
-    service = RuntimeInspectionService(workspace=tmp_path, snapshot_store=store)
+    service = _inspection_service(store)
     try:
         with pytest.raises(RuntimeError, match="scheduler read failed"):
             await service.list_jobs()
@@ -151,40 +164,75 @@ async def test_core_does_not_swallow_scheduler_provider_failure(tmp_path: Path) 
 
 
 @pytest.mark.asyncio
-async def test_core_reports_scheduler_unavailable_without_provider(tmp_path: Path) -> None:
-    service = RuntimeInspectionService(workspace=tmp_path, snapshot_store=None)
-
-    with pytest.raises(RuntimeInspectionError, match="调度检查服务尚未绑定") as error:
-        await service.list_jobs()
-
-    assert error.value.code == "scheduler_unavailable"
-
-
-@pytest.mark.asyncio
-async def test_core_reports_skills_unavailable_without_provider(tmp_path: Path) -> None:
+async def test_client_reports_scheduler_unavailable_without_provider(tmp_path: Path) -> None:
     from agent.plugin_composition import CompositionRoot
+    from agent.plugin_composition.rpc import rpc_method_key
+    from plugins.runtime_inspection.inspection import RuntimeInspectionProvider
+    from plugins.runtime_inspection.rpc import rpc_methods
     from agent.plugins.snapshot import RuntimeSnapshotCompiler, RuntimeSnapshotStore
 
-    root = CompositionRoot("skill-inspection")
+    root = CompositionRoot("scheduler-inspection-unavailable")
+    provider = RuntimeInspectionProvider(
+        {name: tmp_path / f"{name}.md" for name in ("memory", "self", "veda")}
+    )
+
+    async def apply(ctx):
+        for method, operation in rpc_methods(provider).items():
+            await ctx.provide(rpc_method_key(method), operation)
+
+    await root.mount(apply, name="runtime-inspection")
     store = RuntimeSnapshotStore()
-    snapshot = RuntimeSnapshotCompiler().compile({}, composition_root=root)
-    store.install(snapshot)
-    service = RuntimeInspectionService(workspace=tmp_path, snapshot_store=store)
+    store.install(RuntimeSnapshotCompiler().compile({}, composition_root=root))
+    service = _inspection_service(store)
     try:
-        payload = await service.list_capabilities()
-        assert payload["plugins"] == []
-        assert payload["mcp_servers"] == []
-        assert payload["skills"] == []
-        assert payload["unavailable"] == [
-            {"kind": "skills", "code": "skills_unavailable", "status": "unavailable"}
-        ]
+        assert await service.list_jobs() == {
+            "unavailable": {
+                "code": "scheduler_unavailable",
+                "message": "调度检查服务尚未绑定",
+            }
+        }
     finally:
         await store.close()
         await root.dispose()
 
 
-def test_core_runtime_inspection_has_no_scheduler_implementation_import() -> None:
-    source = (Path(__file__).parents[1] / "infra/mobile_realtime/runtime_inspection.py").read_text(
+@pytest.mark.asyncio
+async def test_client_reports_skills_unavailable_without_provider(tmp_path: Path) -> None:
+    from agent.plugin_composition import CompositionRoot
+    from agent.plugin_composition.rpc import rpc_method_key
+    from plugins.runtime_inspection.inspection import RuntimeInspectionProvider
+    from plugins.runtime_inspection.rpc import rpc_methods
+    from agent.plugins.snapshot import RuntimeSnapshotCompiler, RuntimeSnapshotStore
+
+    root = CompositionRoot("skill-inspection")
+    provider = RuntimeInspectionProvider(
+        {name: tmp_path / f"{name}.md" for name in ("memory", "self", "veda")}
+    )
+
+    async def apply(ctx):
+        for method, operation in rpc_methods(provider).items():
+            await ctx.provide(rpc_method_key(method), operation)
+
+    await root.mount(apply, name="runtime-inspection")
+    store = RuntimeSnapshotStore()
+    snapshot = RuntimeSnapshotCompiler().compile({}, composition_root=root)
+    store.install(snapshot)
+    service = _inspection_service(store)
+    try:
+        payload = await service.list_capabilities()
+        assert payload == {
+            "unavailable": {
+                "code": "skills_unavailable",
+                "message": "技能检查服务尚未绑定",
+            }
+        }
+    finally:
+        await store.close()
+        await root.dispose()
+
+
+def test_client_runtime_inspection_has_no_scheduler_implementation_import() -> None:
+    source = (Path(__file__).parents[1] / "plugins/akashic_clients/runtime_inspection.py").read_text(
         encoding="utf-8"
     )
 


### PR DESCRIPTION
## 问题与结果

- 解决的问题：#660 之后仍有 installed client CLI 可能生成 `.pyc`，客户端配置说明仍指向旧 Core 根路径，移动端覆盖测试和 fixture 还没有完全沿 installed plugin artifact 进入。
- 用户可见结果：CLI 生成过程保持 artifact bytecode-free；README/移动端手册指向插件拥有的配置入口；移动测试、fixture 和 inspection/scheduler 覆盖沿客户端插件路径迁移。
- 本 PR 不处理：manager channel recovery 顺序、fresh owner、正式 workspace、full Gate/CI、最终 E2E 和真实客户端验收。

## Change intent

- `change_type`：`refactor`
- `semantic_delta`：`compatible`
- `capability_owner`：`plugin`
- `consumer_scope`：`plugins/akashic_clients/mobile_*` CLI、客户端文档、移动 realtime/WebUI 测试与 fixtures。
- `runtime_patch`：`required`
- `runtime_patch_reason`：installed artifact 的 CLI 必须在自身边界内完成 bytecode-free 生成并读取 plugin-owned 配置；测试也必须执行真实安装 owner。
- `authoritative_state_owner`：客户端 artifact/provenance 由 `akashic_clients` owner；Message/Session、channel lease 和 workspace 状态 owner 不变。
- `client_only_alternative`：客户端只消费已安装 artifact 和宿主绑定，不恢复 Core facade 或 checkout 路径推断。
- `concept_gate`：`required`
- `concept_gate_reason`：客户端 plugin ownership、artifact provenance 和测试入口继续跨层变化；本层不颁发最终概念通过。
- 关联不变量：artifact tree identity、scope/generation、Message/Session 持久事实和 delivery receipt 不变。
- `protected_state`：正式 workspace、Message/Session、附件、delivery receipts、已发布 artifact identity。
- 允许的副作用：插件 CLI、文档、测试 fixtures 和 coverage 入口变更。
- 禁止的副作用：不写正式 workspace，不迁移历史消息，不宣称 manager recovery 或客户端最终验收。

## 改动范围

- 主要提交：`afdd5a3f`（CLI bytecode）、`210399a4`（配置文档）、`b6e2ca50`（移动覆盖迁移）。
- 主要文件：`plugins/akashic_clients/mobile_*`、`README.md`、`_handbook/mobile-access.md`、移动测试与 runtime/scheduler inspection 测试。
- 配置或迁移影响：无正式 workspace migration；文档改为 plugin-owned 配置来源。
- 已知 schema lineage 与最终 schema identity：不改变。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：base `d6cd185da0c9acc1af479c0a0ec5d2189d411dfd`，head `b6e2ca50cc7d7849f35d7ccda20717e1bf411fee`。
- 回滚方式：回滚本层至 #660 head；不触碰正式 workspace。

## 验证

- [x] 相邻 `git diff --check d6cd185..b6e2ca50` 通过；这只是静态发布检查。
- [ ] targeted tests/typecheck：本次发布未重跑；提交包含测试迁移，不把源码存在写成测试通过。
- [ ] full Gate、CI、E2E、安装/替换和真实客户端验收：未运行。
- 未运行项与原因：等待 manager P0/fresh owner 修复和最终 clean head；按 stacked 发布规则不在本层轮询 CI。

## 正交性与概念完整性

- 是否属于架构性 PR 或大改动：`yes`
- 独立 reviewer / model / reasoning：沿用 Terra `d6cd185` 的静态结构上下文；本层无新的最终 Terra 通过。
- 审查 head：`b6e2ca50cc7d7849f35d7ccda20717e1bf411fee`。
- 新增概念及其唯一 owner：installed client CLI/config/test entrypoint 归 `akashic_clients`；无新的 Core 业务 owner。
- 无关设计轴的变化传播：CLI/docs/test source 变化不改变 durable inbound、Message/Session 或 lease authority。
- 最短正常/失败/热更新链路：installed artifact → plugin-local CLI/fixture → scoped client request → existing receipt/assertion；错误保持 fail-loud。
- legacy/source-specific 残留扫描：本层清理 CLI/docs/test 的旧 checkout 入口；manager final recovery 留在后续层。
- must-fix 及处置证据：CLI/docs 后续修复后 Terra 未发现 source delta 回归，但最终 artifact 全树不变证据仍待；manager 两个 lifecycle P0、C 的 `84e8aaf8` 集成和全量验证仍待。
- 最终结论：`not_applicable`（中间 stacked slice，不代表最终验收）。

## 工作手册

- [x] 已核对项目索引、工作流和 #660 作为 immutable base。
- [x] 本层无正式 workspace 写入。
- [ ] 最终 Gate/CI/E2E 与客户端验收留待累计 clean head。

## 累计栈状态与限制

- 本层是从已发布 #660 `d6cd185da0c9acc1af479c0a0ec5d2189d411dfd` 继续的 draft stacked slice，不代表最终栈验收。
- 当前 manager final recovery 顺序与 fresh owner 语义仍待修复/复核；最新已知 clean 候选仍有 `close-before-lease-wait` 与 `closed startup lease` 两个 lifecycle P0。
- C 的后续提交 [`84e8aaf8`](https://github.com/kachofugetsu09/akashic-agent/commit/84e8aaf813659b28a2e9581409574004677f7f4f) 已独立通过其验证，但尚未集成到本层。
- 完整 Gate、CI、E2E、真实安装/替换、rollback 和客户端最终验收未在本层宣称完成；本次发布只做相邻 `git diff --check`。
