### PR TITLE
[codex] installed client channel recovery and listener cleanup

### DIFF
--- a/agent/plugins/manager.py
+++ b/agent/plugins/manager.py
@@ -287,6 +287,7 @@ class _ChannelPublicationState:
     changed: bool
     old_closed: bool = False
     old_stopped: bool = False
+    old_reopened: bool = False
     new_runtime: ChannelGeneration | None = None
 
 
@@ -920,14 +921,17 @@ class PluginManager:
         self,
         state: _ChannelPublicationState,
     ) -> None:
-        """Restore one old binding through an exact closed-snapshot lease."""
+        """Rebuild one old binding while its exact snapshot stays closed.
+
+        Admission and durable recovery are opened by the surrounding
+        publication transaction only after snapshot, pointer, endpoint, and
+        Root ownership have all been settled.
+        """
 
         snapshot = state.previous
         if snapshot is None:
-            self._reopen_restored_channel_publication(state)
             return
         startup_lease: RuntimeSnapshotLease | None = None
-        resumed = False
         try:
             if state.old_stopped:
                 if self._snapshot_store.current is not snapshot:
@@ -941,19 +945,35 @@ class PluginManager:
                     state,
                     startup_snapshot_lease=startup_lease,
                 )
-            if self._snapshot_store.current is snapshot and not snapshot.accepting_leases:
-                await self._snapshot_store.resume(snapshot)
-                resumed = True
-            self._reopen_restored_channel_publication(state)
-            if state.old_runtime is not None:
-                await self._channel_generation_host.recover_durable_inbounds()
-        except BaseException:
-            if resumed and self._snapshot_store.current is snapshot:
-                self._snapshot_store.pause_admission()
-            raise
         finally:
             if startup_lease is not None:
                 await startup_lease.release()
+
+    async def _finish_restored_channel_publication(
+        self,
+        state: _ChannelPublicationState,
+    ) -> None:
+        """Open and recover an old binding after its snapshot is public again."""
+
+        if not state.changed or state.old_reopened:
+            return
+        snapshot = state.previous
+        if snapshot is None:
+            state.old_reopened = True
+            return
+        if self._snapshot_store.current is not snapshot or not snapshot.accepting_leases:
+            raise RuntimeError(
+                "旧 Channel binding 只能在 exact previous snapshot reopened 后开放"
+            )
+        self._reopen_restored_channel_publication(state)
+        try:
+            if state.old_runtime is not None:
+                await self._channel_generation_host.recover_durable_inbounds()
+        except BaseException:
+            if state.old_runtime is not None:
+                state.old_runtime.close_admission()
+            raise
+        state.old_reopened = True
 
     async def _start_channel_with_recovery_lease(
         self,
@@ -2476,6 +2496,7 @@ class PluginManager:
                     and not channel_state.old_stopped
                 ):
                     await self._restore_old_channel_after_failure(channel_state)
+                    await self._finish_restored_channel_publication(channel_state)
                 await self._dispose_unreferenced_composition_root(snapshot)
             if self._endpoint_resumer is not None and exclusive_endpoint_changed:
                 await self._endpoint_resumer()
@@ -2818,6 +2839,18 @@ class PluginManager:
                     keep_candidate_latest=promote_latest,
                     reopen_previous=(reopen_previous_on_failure and not rollback_errors),
                 )
+            if (
+                channel_state is not None
+                and not rollback_errors
+                and channel_state.previous is self.current_snapshot
+                and channel_state.previous is not None
+                and channel_state.previous.accepting_leases
+            ):
+                try:
+                    await self._finish_restored_channel_publication(channel_state)
+                except BaseException as caught:
+                    rollback_errors.append(caught)
+                    channel_cleanup_failed = True
             self._abort_channel_boot_transactions(
                 provisional.candidate,
                 publication_error,
@@ -3050,6 +3083,11 @@ class PluginManager:
                         )
                     if gated_runtime_error is None:
                         await self._snapshot_store.resume(quiesced_snapshot)
+                        if channel_state is not None:
+                            try:
+                                await self._finish_restored_channel_publication(channel_state)
+                            except BaseException as error:
+                                gated_runtime_error = error
                     if (
                         gated_runtime_error is None
                         and exclusive_endpoint_changed
@@ -3913,6 +3951,7 @@ class PluginManager:
                 ):
                     try:
                         await self._restore_old_channel_after_failure(channel_state)
+                        await self._finish_restored_channel_publication(channel_state)
                     except BaseException as recovery_error:
                         raise BaseExceptionGroup(
                             "endpoint quiesce 与旧 Channel 恢复失败",
@@ -4054,6 +4093,17 @@ class PluginManager:
                     reopen_previous=not runtime_restore_uncertain,
                 )
                 if (
+                    stable_recovery_error is None
+                    and channel_state is not None
+                    and channel_state.previous is self.current_snapshot
+                    and channel_state.previous is not None
+                    and channel_state.previous.accepting_leases
+                ):
+                    try:
+                        await self._finish_restored_channel_publication(channel_state)
+                    except BaseException as recovery_error:
+                        stable_recovery_error = recovery_error
+                if (
                     self._endpoint_resumer is not None
                     and exclusive_endpoint_changed
                     and not runtime_restore_uncertain
@@ -4166,6 +4216,11 @@ class PluginManager:
                 )
             ):
                 await self._snapshot_store.resume(quiesced_snapshot)
+                if channel_state is not None:
+                    try:
+                        await self._finish_restored_channel_publication(channel_state)
+                    except BaseException as error:
+                        runtime_restore_error = error
                 await self.start_runtime()
             participant_restore_error = isinstance(
                 commit_error,

--- a/plugins/akashic_clients/channel.py
+++ b/plugins/akashic_clients/channel.py
@@ -59,6 +59,7 @@ from .scoped_capabilities import (
 
 
 _SERVER_START_TIMEOUT_SECONDS = 10.0
+_SERVER_STOP_TIMEOUT_SECONDS = 10.0
 
 
 class _ChannelArtifactReadLease:
@@ -158,6 +159,27 @@ def _close_children(
         raise BaseExceptionGroup(message, causes)
     if primary is not None:
         raise primary
+
+
+async def _stop_server(server: uvicorn.Server, task: asyncio.Task[Any]) -> None:
+    """Ask Uvicorn to close its listener before cancelling its task."""
+
+    server.should_exit = True
+    if task.done():
+        task.result()
+        return
+    try:
+        await asyncio.wait_for(
+            asyncio.shield(task),
+            timeout=_SERVER_STOP_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+    except asyncio.CancelledError:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+        raise
 
 
 @dataclass(slots=True)
@@ -549,13 +571,8 @@ class _GenerationAkashicAdapter:
     async def _rollback_start(self, primary: BaseException) -> None:
         failures: list[BaseException] = []
         for server, task in reversed(self._servers):
-            server.should_exit = True
-            if not task.done():
-                task.cancel()
             try:
-                await task
-            except asyncio.CancelledError:
-                pass
+                await _stop_server(server, task)
             except BaseException as error:
                 failures.append(error)
         self._servers.clear()
@@ -639,13 +656,8 @@ class _GenerationAkashicAdapter:
         errors: list[BaseException] = []
         remaining_servers: list[tuple[uvicorn.Server, asyncio.Task[None]]] = []
         for server, task in reversed(self._servers):
-            server.should_exit = True
-            if not task.done():
-                task.cancel()
             try:
-                await task
-            except asyncio.CancelledError:
-                pass
+                await _stop_server(server, task)
             except BaseException as error:
                 errors.append(error)
                 remaining_servers.append((server, task))

--- a/plugins/akashic_clients/channel.py
+++ b/plugins/akashic_clients/channel.py
@@ -161,6 +161,27 @@ def _close_children(
         raise primary
 
 
+async def _finish_cancelled_server(task: asyncio.Task[Any]) -> None:
+    """Wait for a cancelled listener without hiding cleanup or a live task."""
+
+    _ = task.cancel()
+    try:
+        await asyncio.wait_for(
+            asyncio.shield(task),
+            timeout=_SERVER_STOP_TIMEOUT_SECONDS,
+        )
+    except asyncio.CancelledError:
+        # A task cancelled by this stop path has completed its cleanup.  A
+        # cancellation of the caller is still raised by _stop_server itself.
+        if task.cancelled():
+            return
+        raise
+    except asyncio.TimeoutError as error:
+        raise TimeoutError(
+            "akashic listener task did not settle after cancellation"
+        ) from error
+
+
 async def _stop_server(server: uvicorn.Server, task: asyncio.Task[Any]) -> None:
     """Ask Uvicorn to close its listener before cancelling its task."""
 
@@ -174,11 +195,17 @@ async def _stop_server(server: uvicorn.Server, task: asyncio.Task[Any]) -> None:
             timeout=_SERVER_STOP_TIMEOUT_SECONDS,
         )
     except asyncio.TimeoutError:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)
-    except asyncio.CancelledError:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)
+        await _finish_cancelled_server(task)
+    except asyncio.CancelledError as cancellation:
+        try:
+            await _finish_cancelled_server(task)
+        except BaseException as cleanup_error:
+            if isinstance(cleanup_error, asyncio.CancelledError):
+                raise
+            raise BaseExceptionGroup(
+                "akashic listener stop cancelled and cleanup failed",
+                (cancellation, cleanup_error),
+            ) from cancellation
         raise
 
 
@@ -570,12 +597,14 @@ class _GenerationAkashicAdapter:
 
     async def _rollback_start(self, primary: BaseException) -> None:
         failures: list[BaseException] = []
+        remaining_servers: list[tuple[uvicorn.Server, asyncio.Task[None]]] = []
         for server, task in reversed(self._servers):
             try:
                 await _stop_server(server, task)
             except BaseException as error:
                 failures.append(error)
-        self._servers.clear()
+                remaining_servers.append((server, task))
+        self._servers = list(reversed(remaining_servers))
         results = await asyncio.gather(
             *(child.stop() for child in reversed(self._started_children)),
             return_exceptions=True,

--- a/tests/fixtures/builtin_process.py
+++ b/tests/fixtures/builtin_process.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime, timezone
 import json
+import logging
 import os
 from pathlib import Path
 import signal
@@ -104,6 +105,11 @@ async def serve(root: Path, endpoint: str) -> None:
             ready.set()
 
     app = AppRuntime(Config(), workspace, readiness=Readiness(workspace, f"fixture-{os.getpid()}"))
+    # stdout is the fixture's one-line connection protocol.  The dashboard
+    # server is real, but its access log must stay on the inherited stderr
+    # side so a request cannot corrupt that protocol.
+    if app.dashboard_server is not None:
+        app.dashboard_server.config.access_log = False
     loop = asyncio.get_running_loop()
     loop.add_signal_handler(signal.SIGTERM, stop.set)
     loop.add_signal_handler(signal.SIGINT, stop.set)
@@ -120,10 +126,16 @@ async def serve(root: Path, endpoint: str) -> None:
         if not ready.is_set():
             raise TimeoutError("App 未发布 readiness")
         assert app.core is not None and app.app_server is not None
+        # The dashboard is created inside App.run, so the construction-time
+        # flag above cannot affect its already configured Uvicorn logger.
+        # Disable the shared access logger before fixture-side HTTP setup;
+        # stdout remains reserved for the JSON connection line.
+        logging.getLogger("uvicorn.access").disabled = True
+        chat_socket = workspace / "runtime" / "chat.sock"
         print(json.dumps({"fixture_ready": True, "pid": os.getpid(),
                           "endpoint": str(app.app_server.endpoint),
                           "dashboard": app.dashboard_server.config.uds,
-                          "chat": app.chat_server.config.uds}), flush=True)
+                          "chat": str(chat_socket)}), flush=True)
         producer = asyncio.create_task(producers(app))
         done, _ = await asyncio.wait((running, stopped, producer), return_when=asyncio.FIRST_COMPLETED)
         if producer in done:

--- a/tests/fixtures/formal_plugins.py
+++ b/tests/fixtures/formal_plugins.py
@@ -22,7 +22,7 @@ MARKETPLACE = "fixture"
 # 需要 Workload Controller 的 computer，以及它们的渠道构造都由专门测试覆盖。
 MINIMAL_MESSAGE_PLUGINS = ("sources", "content", "models", "conversation")
 FULL_RUNTIME_PLUGINS = (
-    "akasha", "akashic_sender", "codex", "compaction", "content", "context",
+    "akasha", "akashic_clients", "akashic_sender", "codex", "compaction", "content", "context",
     "conversation", "conversation_ui", "delivery", "delivery_policy", "drift",
     "eventmail", "markdown_memory", "message_push", "models",
     "openai_compatible", "opencode_go", "plugin_update", "programmatic", "prompt",

--- a/tests/test_akashic_client_server_lifecycle.py
+++ b/tests/test_akashic_client_server_lifecycle.py
@@ -10,6 +10,7 @@ import pytest
 from plugins.akashic_clients.channel import (
     _GenerationAkashicAdapter,
     _SERVER_START_TIMEOUT_SECONDS,
+    _stop_server,
 )
 
 
@@ -82,3 +83,102 @@ async def test_start_server_cancels_listener_when_ready_timeout_expires(monkeypa
 
     assert server.should_exit is True
     assert adapter._servers == []
+
+
+class _BlockingServer:
+    def __init__(self, *, cleanup_error: BaseException | None = None) -> None:
+        self.should_exit = False
+        self.started = asyncio.Event()
+        self.release_cleanup = asyncio.Event()
+        self.cleanup_error = cleanup_error
+
+    async def serve(self) -> None:
+        self.started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            await self.release_cleanup.wait()
+            if self.cleanup_error is not None:
+                raise self.cleanup_error
+            raise
+
+
+@pytest.mark.asyncio
+async def test_stop_server_propagates_listener_cleanup_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server = _BlockingServer(cleanup_error=RuntimeError("listener cleanup failed"))
+    task = asyncio.create_task(server.serve())
+    await server.started.wait()
+    monkeypatch.setattr(
+        "plugins.akashic_clients.channel._SERVER_STOP_TIMEOUT_SECONDS",
+        0.01,
+    )
+    server.release_cleanup.set()
+
+    with pytest.raises(RuntimeError, match="listener cleanup failed"):
+        await _stop_server(server, task)
+    assert task.done()
+
+
+@pytest.mark.asyncio
+async def test_stop_server_retains_task_when_cancellation_does_not_settle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server = _BlockingServer()
+    task = asyncio.create_task(server.serve())
+    await server.started.wait()
+    monkeypatch.setattr(
+        "plugins.akashic_clients.channel._SERVER_STOP_TIMEOUT_SECONDS",
+        0.01,
+    )
+
+    with pytest.raises(TimeoutError, match="did not settle"):
+        await _stop_server(server, task)
+    assert not task.done()
+
+    server.release_cleanup.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_stop_server_preserves_outer_cancellation_after_listener_settles() -> None:
+    server = _BlockingServer()
+    task = asyncio.create_task(server.serve())
+    await server.started.wait()
+    stopping = asyncio.create_task(_stop_server(server, task))
+    await asyncio.sleep(0)
+    server.release_cleanup.set()
+
+    stopping.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await stopping
+    assert task.done() and task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_start_rollback_retains_listener_owner_after_stop_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _adapter()
+    adapter._started_children = []
+    adapter._web = None
+    adapter._mobile_runtime = None
+    adapter._stopping = True
+    server = _BlockingServer()
+    task = asyncio.create_task(server.serve())
+    await server.started.wait()
+    adapter._servers = [(server, task)]
+    monkeypatch.setattr(
+        "plugins.akashic_clients.channel._SERVER_STOP_TIMEOUT_SECONDS",
+        0.01,
+    )
+
+    with pytest.raises(BaseExceptionGroup, match="start rollback"):
+        await adapter._rollback_start(RuntimeError("start failed"))
+    assert adapter._servers == [(server, task)]
+
+    server.release_cleanup.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task

--- a/tests/test_message_app.py
+++ b/tests/test_message_app.py
@@ -1,7 +1,4 @@
 """临时 workspace 中运行真正 App 装配和控制 socket。"""
-from typing import cast
-
-from fastapi import FastAPI
 import httpx
 import pytest
 
@@ -9,14 +6,19 @@ from akashic_sdk import AsyncAkashic
 from agent.config_models import Config
 from bootstrap.app import AppRuntime
 from session.log import MessageLog
-from tests.fixtures.formal_plugins import MINIMAL_MESSAGE_PLUGINS, install_formal_plugins
+from tests.fixtures.formal_plugins import FULL_RUNTIME_PLUGINS, install_formal_plugins
 
 
 @pytest.mark.asyncio
 async def test_app_starts_web_and_control_with_message_owners(tmp_path, monkeypatch):
     workspace = tmp_path / "workspace"
     workspace.mkdir()
-    plugin_home, _ = install_formal_plugins(tmp_path, MINIMAL_MESSAGE_PLUGINS)
+    plugin_home, _ = install_formal_plugins(
+        tmp_path,
+        FULL_RUNTIME_PLUGINS,
+        configure_materials=True,
+        initialize_persona=True,
+    )
     monkeypatch.setenv("AKASHIC_PLUGIN_HOME", str(plugin_home))
     app = AppRuntime(Config(), workspace)
     try:
@@ -26,11 +28,10 @@ async def test_app_starts_web_and_control_with_message_owners(tmp_path, monkeypa
             await client.message_send(session, "App 实际输入", message_id="app-input")
             page = await client.message_read(session)
             assert page["items"][0]["id"] == "app-input"
-        assert app.web_chat_channel is not None
-        assert app.channel_host.channels
-        chat_app = cast(FastAPI, app.chat_server.config.app)
+        chat_socket = workspace / "runtime" / "chat.sock"
+        assert chat_socket.is_socket()
         async with httpx.AsyncClient(
-            transport=httpx.ASGITransport(app=chat_app),
+            transport=httpx.AsyncHTTPTransport(uds=str(chat_socket)),
             base_url="http://testserver",
         ) as web:
             sessions = await web.get("/api/chat/sessions")


### PR DESCRIPTION
## 问题与结果

- 解决的问题：installed client channel 的 runtime fixture、transaction recovery 和 listener cleanup 仍未完整沿 plugin-owned channel 生命周期运行；恢复后 channel 可能未重新开放，失败 cleanup 也可能丢失 dependency owner。
- 用户可见结果：正式 fixture 从 installed client plugin 启动 channel；transaction recovery 后重新开放 exact channel；失败 listener cleanup 保留可恢复 owner，并有生命周期回归覆盖。
- 本 PR 不处理：manager final recovery/fresh owner、C 后续 `84e8aaf8` 的独立提交集成、正式 workspace、full Gate/CI/E2E 和最终验收。

## Change intent

- `change_type`：`fix`
- `semantic_delta`：`compatible`
- `capability_owner`：`plugin`
- `consumer_scope`：`plugins/akashic_clients/channel.py`、正式 plugin fixtures、Message app 与 client server lifecycle tests。
- `runtime_patch`：`required`
- `runtime_patch_reason`：installed client channel 必须在真实 artifact fixture 下保留 recovery owner、reopen 顺序和失败 cleanup。
- `authoritative_state_owner`：`akashic_clients` 持有 client channel behavior；Plugin Manager/Channel Host 持有 generation/lease；Message/Session owner 不变。
- `client_only_alternative`：客户端 plugin 只能维护自己的 listener/channel cleanup，不能接管 Core snapshot publication。
- `concept_gate`：`required`
- `concept_gate_reason`：runtime fixture 与 recovery lifecycle 跨 installed plugin、manager 和 channel owner；本层仍是中间验证层。
- 关联不变量：installed artifact identity、channel generation、listener dependency owner、transaction recovery 和 delivery receipt 顺序。
- `protected_state`：正式 workspace、Message/Session、handoff/receipt、generation lease。
- 允许的副作用：plugin channel runtime fixture、recovery cleanup 和生命周期测试。
- 禁止的副作用：不改正式 workspace，不宣称 C 后续提交已集成，不把定向通过写成全栈通过。

## 改动范围

- 主要提交：`48a266f5`、`57f10366`、`5fe69c66`。
- 主要文件：`plugins/akashic_clients/channel.py`、fixtures、`tests/test_message_app.py`、`tests/test_akashic_client_server_lifecycle.py` 与 manager recovery 接线。
- 配置或迁移影响：无数据库/正式 workspace migration。
- 已知 schema lineage 与最终 schema identity：不改变。
- 协议 source、runtime、provider 与 scenario 的不可变 revision：base `25f4567e700733df01131f9bfe9f42a40aaa13ff`，head `5fe69c66844990233fb60824fb7dc8009434480f`。
- 回滚方式：回滚本层至 `25f4567e`；不触碰正式 workspace。

## 验证

- [x] 相邻 `git diff --check 25f4567e..5fe69c66` 通过；这只是静态发布检查。
- [ ] targeted tests/typecheck：本次发布未重跑；提交包含生命周期测试，不把测试文件存在写成通过。
- [ ] full Gate、CI、E2E、安装/替换和真实客户端验收：未运行。
- 未运行项与原因：C 的 `84e8aaf8` 独立验证尚待集成，manager final recovery/fresh owner 仍待修复；按指令不轮询 CI。

## 正交性与概念完整性

- 是否属于架构性 PR 或大改动：`yes`
- 独立 reviewer / model / reasoning：待最终累计 clean head 的 Terra/架构复核。
- 审查 head：`5fe69c66844990233fb60824fb7dc8009434480f`。
- 新增概念及其唯一 owner：installed client channel runtime 与 listener cleanup 归 client plugin；不新增 Core 业务 owner。
- 无关设计轴的变化传播：fixture/recovery 变化不改变 Message/Session authority；manager publication 顺序留在下一层。
- 最短正常/失败/热更新链路：installed artifact → channel start → transaction recovery → exact reopen → listener cleanup/receipt；失败保留 owner 并 fail-loud。
- legacy/source-specific 残留扫描：本层迁移正式 fixture 和 client channel cleanup；C 的 `84e8aaf8` 尚未集成。
- must-fix 及处置证据：C 后续 `84e8aaf8` 已独立通过但未集成；当前 manager 两个 lifecycle P0、fresh owner 和最终全量验收仍待。
- 最终结论：`not_applicable`（中间 stacked slice，不代表最终验收）。

## 工作手册

- [x] 已核对项目索引、工作流和前层 immutable head。
- [x] 本层无正式 workspace 写入。
- [ ] 最终 Gate/CI/E2E、C 集成和客户端验收留待累计 clean head。

## 累计栈状态与限制

- 本层是从已发布 #660 `d6cd185da0c9acc1af479c0a0ec5d2189d411dfd` 继续的 draft stacked slice，不代表最终栈验收。
- 当前 manager final recovery 顺序与 fresh owner 语义仍待修复/复核；最新已知 clean 候选仍有 `close-before-lease-wait` 与 `closed startup lease` 两个 lifecycle P0。
- C 的后续提交 [`84e8aaf8`](https://github.com/kachofugetsu09/akashic-agent/commit/84e8aaf813659b28a2e9581409574004677f7f4f) 已独立通过其验证，但尚未集成到本层。
- 完整 Gate、CI、E2E、真实安装/替换、rollback 和客户端最终验收未在本层宣称完成；本次发布只做相邻 `git diff --check`。
