### PR TITLE
[codex] migrate client tests to plugin protocol types

### DIFF
--- a/tests/mobile_realtime/test_channel.py
+++ b/tests/mobile_realtime/test_channel.py
@@ -8,11 +8,12 @@ import json
 import logging
 import sqlite3
 from collections.abc import Mapping
-from dataclasses import replace
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
+from collections.abc import Callable
 from uuid import uuid4
 
 import pytest
@@ -32,6 +33,7 @@ from agent.plugin_composition import (
 from agent.plugin_composition.channels import (
     AttachmentKind as V3AttachmentKind,
     AttachmentRef,
+    ChannelDurableInboundPort,
     ChannelCommitRole,
     ChannelFactoryContext,
     ChannelRuntimePorts,
@@ -40,6 +42,8 @@ from agent.plugin_composition.channels import (
     RawInbound,
 )
 from plugins.akashic_clients.services import (
+    ArtifactStorePort,
+    MessageCatalogPort,
     ModelCatalogUnavailable,
     RuntimeInspectionService,
 )
@@ -52,13 +56,73 @@ from bus.events import (
     TurnTerminalStatus,
     channel_message_from_outbound,
 )
-from bus.events_lifecycle import (
-    StreamDeltaReady,
-    ToolCallCompleted,
-    ToolCallStarted,
-    TurnOutputCompleted,
-    TurnStarted,
-)
+@dataclass
+class TurnStarted:
+    """测试用的正式客户端事件投影。"""
+
+    session_key: str
+    channel: str
+    chat_id: str
+    content: str
+    timestamp: object
+    turn_id: str = ""
+    control_turn_id: str = ""
+    client_message_id: str = ""
+
+
+@dataclass
+class StreamDeltaReady:
+    """测试用的正式客户端增量事件投影。"""
+
+    session_key: str
+    channel: str
+    chat_id: str
+    turn_id: str = ""
+    content_delta: str = ""
+    thinking_delta: str = ""
+
+
+@dataclass
+class TurnOutputCompleted:
+    """测试用的正式客户端完成事件投影。"""
+
+    session_key: str
+    channel: str
+    chat_id: str
+    turn_id: str = ""
+    client_message_id: str = ""
+
+
+@dataclass
+class ToolCallStarted:
+    """测试用的正式客户端工具开始事件投影。"""
+
+    session_key: str
+    channel: str
+    chat_id: str
+    iteration: int
+    call_id: str
+    tool_name: str
+    arguments: dict[str, object]
+    turn_id: str = ""
+
+
+@dataclass
+class ToolCallCompleted:
+    """测试用的正式客户端工具完成事件投影。"""
+
+    session_key: str
+    channel: str
+    chat_id: str
+    iteration: int
+    call_id: str
+    tool_name: str
+    arguments: dict[str, object]
+    final_arguments: dict[str, object]
+    status: str
+    result_preview: str
+    runtime_provenance: dict[str, str] = field(default_factory=dict)
+    turn_id: str = ""
 from plugins.akashic_clients.attachments import AttachmentStore
 from infra.channels.artifacts import ChannelAttachmentArtifactStore
 from plugins.akashic_clients.mobile_realtime.attachments import attachment_descriptor
@@ -72,6 +136,9 @@ from plugins.akashic_clients.mobile_realtime.protocol import (
     parse_frame,
 )
 from plugins.akashic_clients.message_types import (
+    AttachmentKind as PluginAttachmentKind,
+    ChannelAttachment as PluginChannelAttachment,
+    ChannelMessage as PluginChannelMessage,
     TurnTerminalStatus as PluginTurnTerminalStatus,
 )
 from plugins.akashic_clients.mobile_realtime.remote_media import RemoteMediaError, RemoteMediaSnapshot
@@ -86,6 +153,18 @@ from session.log import MessageLog
 from session.message import ContentPart, ContentReferences, Output
 
 
+def _message_catalog_port(log: MessageLog) -> MessageCatalogPort:
+    """把 MessageLog 的具体 catalog 交给插件窄 Protocol。"""
+
+    return cast(MessageCatalogPort, log.catalog())
+
+
+def _artifact_store_port(store: ChannelAttachmentArtifactStore) -> ArtifactStorePort:
+    """把 Core artifact owner 交给插件窄 Protocol。"""
+
+    return cast(ArtifactStorePort, store)
+
+
 @pytest.fixture(autouse=True)
 def _bind_real_mobile_message_log(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """给插件测试夹具接入真实消息目录与正式 v3 channel ports。"""
@@ -95,49 +174,19 @@ def _bind_real_mobile_message_log(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
 
     async def start_with_message_log(
         channel: MobileRealtimeChannel,
-        ctx: Any | None = None,
         *,
-        host_boot_id: str | None = None,
-        durable_inbound: Any | None = None,
-        attachment_store: Any | None = None,
+        host_boot_id: str,
+        durable_inbound: ChannelDurableInboundPort,
+        attachment_store: AttachmentStore,
     ) -> None:
         if channel._message_scope is None:
             log = MessageLog(tmp_path / f"sessions-{len(logs)}.db")
-            channel.bind_messages(log.catalog())
+            channel.bind_messages(_message_catalog_port(log))
             channel._test_message_log = log
             logs.append(log)
-        if ctx is not None:
-            bus = getattr(ctx, "bus", None)
-            if not isinstance(bus, _Bus):
-                raise TypeError("Mobile 测试上下文缺少 _Bus durable ingress")
-            port = _DurablePort(bus)
-            await original_start(
-                channel,
-                host_boot_id=host_boot_id or f"test-boot-{id(channel)}",
-                durable_inbound=port,
-                attachment_store=ctx.attachment_store,
-            )
-            channel._attach_v3_inbound(
-                ChannelRuntimePorts(
-                    snapshot_id="test-snapshot",
-                    generation_id="test-generation",
-                    binding_token=f"test-binding-{id(channel)}",
-                    ingress=bus,
-                    identity=None,
-                    attachment_import=None,
-                    durable_inbound=port,
-                )
-            )
-            channel._open_v3_inbound()
-            command_catalog_provider = getattr(ctx, "command_catalog_provider", None)
-            if command_catalog_provider is not None:
-                channel.bind_command_catalog(command_catalog_provider)
-            return
-        if durable_inbound is None or attachment_store is None:
-            raise TypeError("Mobile 测试启动缺少正式 durable port 或 attachment store")
         await original_start(
             channel,
-            host_boot_id=host_boot_id or f"test-boot-{id(channel)}",
+            host_boot_id=host_boot_id,
             durable_inbound=durable_inbound,
             attachment_store=attachment_store,
         )
@@ -320,7 +369,7 @@ class _Bus:
                 ingress=self,
                 identity=None,
                 attachment_import=None,
-                recovery_ingress=self,
+                durable_inbound=_DurablePort(self),
             )
         )
         channel._open_v3_inbound()
@@ -413,6 +462,37 @@ class _DurablePort:
 
     async def recover(self, raw: RawInbound) -> bool:
         return await self._bus.recover(raw)
+
+
+async def _start_test_channel(
+    channel: MobileRealtimeChannel,
+    *,
+    bus: _Bus,
+    attachment_store: AttachmentStore,
+    command_catalog_provider: Callable[[], tuple[tuple[str, str], ...]] | None = None,
+) -> None:
+    """通过正式 durable inbound port 启动 Mobile 测试 channel。"""
+
+    durable = _DurablePort(bus)
+    await channel.start(
+        host_boot_id=f"test-boot-{id(channel)}",
+        durable_inbound=durable,
+        attachment_store=attachment_store,
+    )
+    channel._attach_v3_inbound(
+        ChannelRuntimePorts(
+            snapshot_id="test-snapshot",
+            generation_id="test-generation",
+            binding_token=f"test-binding-{id(channel)}",
+            ingress=bus,
+            identity=None,
+            attachment_import=None,
+            durable_inbound=durable,
+        )
+    )
+    channel._open_v3_inbound()
+    if command_catalog_provider is not None:
+        channel.bind_command_catalog(command_catalog_provider)
 
 
 class _GatedReserveBus(_Bus):
@@ -533,17 +613,10 @@ async def _started_native_mobile_channel(
     channel = MobileRealtimeChannel(
         cast(MobileGatewayRuntime, runtime or _Runtime(storage))
     )
-    await channel.start(
-        cast(
-            Any,
-            SimpleNamespace(
-                bus=_Bus(),
-                session_manager=SimpleNamespace(),
-                event_bus=_EventBus(),
-                push_tool=_PushTool(),
-                attachment_store=AttachmentStore(tmp_path / "uploads"),
-            ),
-        )
+    await _start_test_channel(
+        channel,
+        bus=_Bus(),
+        attachment_store=AttachmentStore(tmp_path / "uploads"),
     )
     manager = _NativeMessageManager(cast(MessageLog, channel._test_message_log))
     return channel, storage, manager
@@ -577,25 +650,51 @@ def _native_ref(data: bytes, *, artifact_id: str = "core-artifact-1") -> Attachm
     )
 
 
+def _to_plugin_channel_message(message: ChannelMessage) -> PluginChannelMessage:
+    """把 bus outbound fixture 转为插件自己的 channel message 类型。"""
+
+    terminal_status = message.terminal_status
+    return PluginChannelMessage(
+        channel=message.channel,
+        chat_id=message.chat_id,
+        content=message.content,
+        attachments=tuple(
+            PluginChannelAttachment(
+                kind=PluginAttachmentKind(attachment.kind.value),
+                source=attachment.source,
+                filename=attachment.filename,
+            )
+            for attachment in message.attachments
+        ),
+        attachment_refs=message.attachment_refs,
+        thinking=message.thinking,
+        reply_to=message.reply_to,
+        metadata=dict(message.metadata),
+        session_message_id=message.session_message_id,
+        control_turn_id=message.control_turn_id,
+        execution_attempt_id=message.execution_attempt_id,
+        terminal_status=(
+            PluginTurnTerminalStatus(terminal_status.value)
+            if terminal_status is not None
+            else None
+        ),
+    )
+
+
 def _provider_delivery(channel: MobileRealtimeChannel):
     """把测试 outbound 映射为正式 Channel provider callback。"""
 
     async def deliver(message: OutboundMessage | ChannelMessage):
         if isinstance(message, ChannelMessage):
-            return await channel._deliver_message(message)
+            return await channel._deliver_message(_to_plugin_channel_message(message))
         if message.execution_attempt_id is None:
             message = replace(
                 message,
                 execution_attempt_id=message.control_turn_id,
             )
-        channel_message = channel_message_from_outbound(message)
-        if channel_message.terminal_status is not None:
-            channel_message = replace(
-                channel_message,
-                terminal_status=PluginTurnTerminalStatus(
-                    channel_message.terminal_status.value
-                ),
-            )
+        channel_message = _to_plugin_channel_message(
+            channel_message_from_outbound(message)
+        )
         metadata = dict(channel_message.metadata)
         metadata["_channel_commit_role"] = "passive"
         return await channel._deliver_message(
@@ -616,17 +715,10 @@ async def test_mobile_message_send_uses_exact_v3_ingress_without_legacy_bus(
     channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, runtime))
     bus = _Bus()
     manager = SessionManager(tmp_path / "workspace")
-    await channel.start(
-        cast(
-            Any,
-            SimpleNamespace(
-                bus=bus,
-                session_manager=manager,
-                event_bus=_EventBus(),
-                push_tool=_PushTool(),
-                attachment_store=AttachmentStore(tmp_path / "uploads"),
-            ),
-        )
+    await _start_test_channel(
+        channel,
+        bus=bus,
+        attachment_store=AttachmentStore(tmp_path / "uploads"),
     )
     session_id = f"akashic:{uuid4()}"
     reply = await channel.handle_command(
@@ -659,17 +751,10 @@ async def test_mobile_captured_callback_blocks_drain_through_preprocessing(
     channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, _Runtime(storage)))
     bus = _GatedReserveBus()
     manager = SessionManager(tmp_path / "workspace")
-    await channel.start(
-        cast(
-            Any,
-            SimpleNamespace(
-                bus=bus,
-                session_manager=manager,
-                event_bus=_EventBus(),
-                push_tool=_PushTool(),
-                attachment_store=AttachmentStore(tmp_path / "uploads"),
-            ),
-        )
+    await _start_test_channel(
+        channel,
+        bus=bus,
+        attachment_store=AttachmentStore(tmp_path / "uploads"),
     )
     session_id = f"akashic:{uuid4()}"
     sending = asyncio.create_task(
@@ -716,17 +801,10 @@ async def test_mobile_exact_ingress_false_never_commits_success_receipt(
     channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, _Runtime(storage)))
     bus = _RejectingIngressBus()
     manager = SessionManager(tmp_path / "workspace")
-    await channel.start(
-        cast(
-            Any,
-            SimpleNamespace(
-                bus=bus,
-                session_manager=manager,
-                event_bus=_EventBus(),
-                push_tool=_PushTool(),
-                attachment_store=AttachmentStore(tmp_path / "uploads"),
-            ),
-        )
+    await _start_test_channel(
+        channel,
+        bus=bus,
+        attachment_store=AttachmentStore(tmp_path / "uploads"),
     )
     frame = _message_frame(
         frame_id="01ARZ3NDEKTSV4RRFFQ69G5FAC",
@@ -857,17 +935,10 @@ async def test_native_v3_mobile_adapter_reports_unknown_if_durable_call_raises(
     channel = MobileRealtimeChannel(
         cast(MobileGatewayRuntime, _FailingRuntime(storage))
     )
-    await channel.start(
-        cast(
-            Any,
-            SimpleNamespace(
-                bus=_Bus(),
-                session_manager=manager,
-                event_bus=_EventBus(),
-                push_tool=_PushTool(),
-                attachment_store=AttachmentStore(tmp_path / "uploads"),
-            ),
-        )
+    await _start_test_channel(
+        channel,
+        bus=_Bus(),
+        attachment_store=AttachmentStore(tmp_path / "uploads"),
     )
     adapter = channel.build_v3_adapter(_native_context())
     await adapter.start()
@@ -1376,7 +1447,7 @@ async def test_model_catalog_returns_bound_registry_and_session_selection(
             return read_saved(metadata)
 
         channel.bind_model_selection(read_selection)
-        channel.bind_messages(log.catalog())
+        channel.bind_messages(_message_catalog_port(log))
 
         reply = await channel.handle_command(
             device_id=device_id,
@@ -1899,22 +1970,15 @@ async def test_mobile_restart_never_publishes_source_drift_after_handoff_reserve
         media_type="application/octet-stream",
     )
     bus.pending_refs = (expected,)
-    context = cast(
-        Any,
-        SimpleNamespace(
-            bus=bus,
-            session_manager=manager,
-            event_bus=_EventBus(),
-            push_tool=_PushTool(),
-            attachment_store=legacy_store,
-        ),
-    )
-
     source.write_bytes(b"changed after durable reserve")
     failed = MobileRealtimeChannel(cast(MobileGatewayRuntime, runtime))
-    failed.bind_channel_attachment_store(artifact_store)
+    failed.bind_channel_attachment_store(_artifact_store_port(artifact_store))
     with pytest.raises(ValueError, match="durable ref 不一致"):
-        await failed.start(context)
+        await _start_test_channel(
+            failed,
+            bus=bus,
+            attachment_store=legacy_store,
+        )
     assert metadata_store.get_attachment(mapping.artifact_id) is None
     assert artifact_store.audit_orphan_artifact_ids() == ()
     assert storage.list_attachment_imports(
@@ -1925,8 +1989,12 @@ async def test_mobile_restart_never_publishes_source_drift_after_handoff_reserve
 
     source.write_bytes(original)
     restarted = MobileRealtimeChannel(cast(MobileGatewayRuntime, runtime))
-    restarted.bind_channel_attachment_store(artifact_store)
-    await restarted.start(context)
+    restarted.bind_channel_attachment_store(_artifact_store_port(artifact_store))
+    await _start_test_channel(
+        restarted,
+        bus=bus,
+        attachment_store=legacy_store,
+    )
     assert artifact_store.resolve_refs((mapping.artifact_id,)) == (expected,)
     assert storage.list_attachment_imports(
         session_id=session_id,
@@ -1951,17 +2019,10 @@ async def test_message_send_keeps_unknown_outcome_without_persisted_user(
     channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, runtime))
     bus = _Bus()
     manager = SessionManager(tmp_path / "workspace")
-    await channel.start(
-        cast(
-            Any,
-            SimpleNamespace(
-                bus=bus,
-                session_manager=manager,
-                event_bus=_EventBus(),
-                push_tool=_PushTool(),
-                attachment_store=AttachmentStore(tmp_path / "uploads"),
-            ),
-        )
+    await _start_test_channel(
+        channel,
+        bus=bus,
+        attachment_store=AttachmentStore(tmp_path / "uploads"),
     )
     session_id = f"akashic:{uuid4()}"
     frame = _message_frame(
@@ -2049,17 +2110,10 @@ async def test_message_send_keeps_current_owner_when_receipt_completion_fails(
     channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, runtime))
     bus = _Bus()
     manager = SessionManager(tmp_path / "workspace")
-    await channel.start(
-        cast(
-            Any,
-            SimpleNamespace(
-                bus=bus,
-                session_manager=manager,
-                event_bus=_EventBus(),
-                push_tool=_PushTool(),
-                attachment_store=AttachmentStore(tmp_path / "uploads"),
-            ),
-        )
+    await _start_test_channel(
+        channel,
+        bus=bus,
+        attachment_store=AttachmentStore(tmp_path / "uploads"),
     )
     frame = _message_frame(
         frame_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
@@ -2113,17 +2167,10 @@ async def test_remote_outbound_media_keeps_response_filename(
     channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, runtime))
     store = AttachmentStore(tmp_path / "uploads")
     manager = SessionManager(tmp_path / "workspace")
-    await channel.start(
-        cast(
-            Any,
-            SimpleNamespace(
-                bus=_Bus(),
-                session_manager=manager,
-                event_bus=_EventBus(),
-                push_tool=_PushTool(),
-                attachment_store=store,
-            ),
-        )
+    await _start_test_channel(
+        channel,
+        bus=_Bus(),
+        attachment_store=store,
     )
 
     async def snapshot(*args: object, **kwargs: object) -> RemoteMediaSnapshot:
@@ -2164,17 +2211,10 @@ async def test_remote_media_failure_keeps_final_text(
     runtime = _Runtime(storage)
     manager = SessionManager(tmp_path / "workspace")
     channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, runtime))
-    await channel.start(
-        cast(
-            Any,
-            SimpleNamespace(
-                bus=_Bus(),
-                session_manager=manager,
-                event_bus=_EventBus(),
-                push_tool=_PushTool(),
-                attachment_store=AttachmentStore(tmp_path / "uploads"),
-            ),
-        )
+    await _start_test_channel(
+        channel,
+        bus=_Bus(),
+        attachment_store=AttachmentStore(tmp_path / "uploads"),
     )
     session_id = f"akashic:{uuid4()}"
     media = ["https://expired.example/reaction.gif"]
@@ -2340,17 +2380,10 @@ async def test_control_reply_never_reuses_previous_message_id(tmp_path: Path) ->
     session.add_message("assistant", "相同的固定回复")
     manager.save(session)
     channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, runtime))
-    await channel.start(
-        cast(
-            Any,
-            SimpleNamespace(
-                bus=_Bus(),
-                session_manager=manager,
-                event_bus=_EventBus(),
-                push_tool=_PushTool(),
-                attachment_store=AttachmentStore(tmp_path / "uploads"),
-            ),
-        )
+    await _start_test_channel(
+        channel,
+        bus=_Bus(),
+        attachment_store=AttachmentStore(tmp_path / "uploads"),
     )
 
     await _provider_delivery(channel)(
@@ -2386,18 +2419,11 @@ async def test_command_list_uses_active_channel_catalog_without_stop(
         ("emoji", "😀" * 129),
         ("stop", "中断当前回复"),
     ]
-    await channel.start(
-        cast(
-            Any,
-            SimpleNamespace(
-                bus=_Bus(),
-                session_manager=manager,
-                event_bus=_EventBus(),
-                push_tool=_PushTool(),
-                attachment_store=AttachmentStore(tmp_path / "uploads"),
-                command_catalog_provider=lambda: tuple(active_catalog),
-            ),
-        )
+    await _start_test_channel(
+        channel,
+        bus=_Bus(),
+        attachment_store=AttachmentStore(tmp_path / "uploads"),
+        command_catalog_provider=lambda: tuple(active_catalog),
     )
 
     reply = await channel.handle_command(
@@ -2443,18 +2469,11 @@ async def test_message_send_preserves_mobile_slash_command_for_bus(
     channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, runtime))
     manager = SessionManager(tmp_path / "workspace")
     bus = _Bus()
-    await channel.start(
-        cast(
-            Any,
-            SimpleNamespace(
-                bus=bus,
-                session_manager=manager,
-                event_bus=_EventBus(),
-                push_tool=_PushTool(),
-                attachment_store=AttachmentStore(tmp_path / "uploads"),
-                command_catalog_provider=lambda: (("undo", "撤销上一轮对话"),),
-            ),
-        )
+    await _start_test_channel(
+        channel,
+        bus=bus,
+        attachment_store=AttachmentStore(tmp_path / "uploads"),
+        command_catalog_provider=lambda: (("undo", "撤销上一轮对话"),),
     )
     session_id = f"akashic:{uuid4()}"
 
@@ -2822,17 +2841,10 @@ async def test_stream_deltas_batch_within_transport_window_and_flush_before_tool
     runtime = _Runtime(storage)
     channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, runtime))
     manager = SessionManager(tmp_path / "workspace")
-    await channel.start(
-        cast(
-            Any,
-            SimpleNamespace(
-                bus=_Bus(),
-                session_manager=manager,
-                event_bus=_EventBus(),
-                push_tool=_PushTool(),
-                attachment_store=AttachmentStore(tmp_path / "uploads"),
-            ),
-        )
+    await _start_test_channel(
+        channel,
+        bus=_Bus(),
+        attachment_store=AttachmentStore(tmp_path / "uploads"),
     )
     session_id = f"akashic:{uuid4()}"
     storage.claim_session(
@@ -2996,17 +3008,10 @@ async def test_first_delta_orders_received_then_publish_then_published(
     runtime = _GatedPublishRuntime(storage)
     channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, runtime))
     manager = SessionManager(tmp_path / "workspace")
-    await channel.start(
-        cast(
-            Any,
-            SimpleNamespace(
-                bus=_Bus(),
-                session_manager=manager,
-                event_bus=_EventBus(),
-                push_tool=_PushTool(),
-                attachment_store=AttachmentStore(tmp_path / "uploads"),
-            ),
-        )
+    await _start_test_channel(
+        channel,
+        bus=_Bus(),
+        attachment_store=AttachmentStore(tmp_path / "uploads"),
     )
     session_id = f"akashic:{uuid4()}"
     turn_id = "turn-1"
@@ -3104,17 +3109,10 @@ async def test_dual_field_delta_accepts_thinking_and_answer_without_short_circui
     session_id = f"akashic:{uuid4()}"
     turn_id = "turn-dual"
     manager.save(manager.get_or_create(session_id))
-    await channel.start(
-        cast(
-            Any,
-            SimpleNamespace(
-                bus=_Bus(),
-                session_manager=manager,
-                event_bus=_EventBus(),
-                push_tool=_PushTool(),
-                attachment_store=AttachmentStore(tmp_path / "uploads"),
-            ),
-        )
+    await _start_test_channel(
+        channel,
+        bus=_Bus(),
+        attachment_store=AttachmentStore(tmp_path / "uploads"),
     )
     await channel._on_turn_started(
         TurnStarted(
@@ -3248,17 +3246,10 @@ async def test_interrupted_terminal_flushes_pending_delta_before_terminal_event(
         created_at=datetime.now(timezone.utc),
     )
     manager.save(manager.get_or_create(session_id))
-    await channel.start(
-        cast(
-            Any,
-            SimpleNamespace(
-                bus=_Bus(),
-                session_manager=manager,
-                event_bus=_EventBus(),
-                push_tool=_PushTool(),
-                attachment_store=AttachmentStore(tmp_path / "uploads"),
-            ),
-        )
+    await _start_test_channel(
+        channel,
+        bus=_Bus(),
+        attachment_store=AttachmentStore(tmp_path / "uploads"),
     )
     await channel._on_turn_started(
         TurnStarted(
@@ -3382,17 +3373,10 @@ async def test_terminal_barrier_flushes_accepted_deltas_then_terminal_and_drops_
     manager = SessionManager(tmp_path / "workspace")
     session_id = f"akashic:{uuid4()}"
     turn_id = uuid4().hex
-    await channel.start(
-        cast(
-            Any,
-            SimpleNamespace(
-                bus=_Bus(),
-                session_manager=manager,
-                event_bus=_EventBus(),
-                push_tool=_PushTool(),
-                attachment_store=AttachmentStore(tmp_path / "uploads"),
-            ),
-        )
+    await _start_test_channel(
+        channel,
+        bus=_Bus(),
+        attachment_store=AttachmentStore(tmp_path / "uploads"),
     )
     await channel._on_turn_started(
         TurnStarted(
@@ -3555,17 +3539,10 @@ async def test_terminal_and_late_delta_queued_on_same_lock_release_terminal_then
     manager = SessionManager(tmp_path / "workspace")
     session_id = f"akashic:{uuid4()}"
     turn_id = uuid4().hex
-    await channel.start(
-        cast(
-            Any,
-            SimpleNamespace(
-                bus=_Bus(),
-                session_manager=manager,
-                event_bus=_EventBus(),
-                push_tool=_PushTool(),
-                attachment_store=AttachmentStore(tmp_path / "uploads"),
-            ),
-        )
+    await _start_test_channel(
+        channel,
+        bus=_Bus(),
+        attachment_store=AttachmentStore(tmp_path / "uploads"),
     )
     await channel._on_turn_started(
         TurnStarted(
@@ -3658,17 +3635,10 @@ async def _race_channel(
     manager = SessionManager(tmp_path / "workspace")
     session_id = f"akashic:{uuid4()}"
     turn_id = uuid4().hex
-    await channel.start(
-        cast(
-            Any,
-            SimpleNamespace(
-                bus=_Bus(),
-                session_manager=manager,
-                event_bus=_EventBus(),
-                push_tool=_PushTool(),
-                attachment_store=AttachmentStore(tmp_path / "uploads"),
-            ),
-        )
+    await _start_test_channel(
+        channel,
+        bus=_Bus(),
+        attachment_store=AttachmentStore(tmp_path / "uploads"),
     )
     await channel._on_turn_started(
         TurnStarted(
@@ -4108,17 +4078,10 @@ async def test_late_a_final_keeps_b_active_and_identity(
     session_id = f"akashic:{uuid4()}"
     turn_a = "turn-A"
     turn_b = "turn-B"
-    await channel.start(
-        cast(
-            Any,
-            SimpleNamespace(
-                bus=_Bus(),
-                session_manager=manager,
-                event_bus=_EventBus(),
-                push_tool=_PushTool(),
-                attachment_store=AttachmentStore(tmp_path / "uploads"),
-            ),
-        )
+    await _start_test_channel(
+        channel,
+        bus=_Bus(),
+        attachment_store=AttachmentStore(tmp_path / "uploads"),
     )
     await channel._on_turn_started(
         TurnStarted(
@@ -4377,17 +4340,10 @@ async def test_send_and_turn_started_bind_each_client_message_id_per_session(
     channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, runtime))
     bus = _Bus()
     manager = SessionManager(tmp_path / "workspace")
-    await channel.start(
-        cast(
-            Any,
-            SimpleNamespace(
-                bus=bus,
-                session_manager=manager,
-                event_bus=_EventBus(),
-                push_tool=_PushTool(),
-                attachment_store=AttachmentStore(tmp_path / "uploads"),
-            ),
-        )
+    await _start_test_channel(
+        channel,
+        bus=bus,
+        attachment_store=AttachmentStore(tmp_path / "uploads"),
     )
     session_id = f"akashic:{uuid4()}"
     first_id = "01ARZ3NDEKTSV4RRFFQ69G5FAA"
@@ -4484,17 +4440,10 @@ async def test_terminal_final_publish_fail_once_is_retryable_without_fake_succes
     manager = SessionManager(tmp_path / "workspace")
     session_id = f"akashic:{uuid4()}"
     turn_id = uuid4().hex
-    await channel.start(
-        cast(
-            Any,
-            SimpleNamespace(
-                bus=_Bus(),
-                session_manager=manager,
-                event_bus=_EventBus(),
-                push_tool=_PushTool(),
-                attachment_store=AttachmentStore(tmp_path / "uploads"),
-            ),
-        )
+    await _start_test_channel(
+        channel,
+        bus=_Bus(),
+        attachment_store=AttachmentStore(tmp_path / "uploads"),
     )
     await channel._on_turn_started(
         TurnStarted(
@@ -4594,17 +4543,10 @@ async def test_terminal_failure_after_batch_flush_retry_does_not_duplicate_delta
     manager = SessionManager(tmp_path / "workspace")
     session_id = f"akashic:{uuid4()}"
     turn_id = uuid4().hex
-    await channel.start(
-        cast(
-            Any,
-            SimpleNamespace(
-                bus=_Bus(),
-                session_manager=manager,
-                event_bus=_EventBus(),
-                push_tool=_PushTool(),
-                attachment_store=AttachmentStore(tmp_path / "uploads"),
-            ),
-        )
+    await _start_test_channel(
+        channel,
+        bus=_Bus(),
+        attachment_store=AttachmentStore(tmp_path / "uploads"),
     )
     await channel._on_turn_started(
         TurnStarted(
@@ -4700,17 +4642,10 @@ async def test_late_delta_queued_during_terminal_failure_gap_accepted_then_retry
     manager = SessionManager(tmp_path / "workspace")
     session_id = f"akashic:{uuid4()}"
     turn_id = uuid4().hex
-    await channel.start(
-        cast(
-            Any,
-            SimpleNamespace(
-                bus=_Bus(),
-                session_manager=manager,
-                event_bus=_EventBus(),
-                push_tool=_PushTool(),
-                attachment_store=AttachmentStore(tmp_path / "uploads"),
-            ),
-        )
+    await _start_test_channel(
+        channel,
+        bus=_Bus(),
+        attachment_store=AttachmentStore(tmp_path / "uploads"),
     )
     await channel._on_turn_started(
         TurnStarted(
@@ -4821,17 +4756,10 @@ async def test_interrupted_terminal_publish_fail_once_is_retryable(
     manager = SessionManager(tmp_path / "workspace")
     session_id = f"akashic:{uuid4()}"
     turn_id = "turn-interrupt-retry"
-    await channel.start(
-        cast(
-            Any,
-            SimpleNamespace(
-                bus=_Bus(),
-                session_manager=manager,
-                event_bus=_EventBus(),
-                push_tool=_PushTool(),
-                attachment_store=AttachmentStore(tmp_path / "uploads"),
-            ),
-        )
+    await _start_test_channel(
+        channel,
+        bus=_Bus(),
+        attachment_store=AttachmentStore(tmp_path / "uploads"),
     )
     await channel._on_turn_started(
         TurnStarted(
@@ -4993,17 +4921,10 @@ async def _fail_delta_channel(
     manager = SessionManager(tmp_path / "workspace")
     session_id = f"akashic:{uuid4()}"
     turn_id = uuid4().hex
-    await channel.start(
-        cast(
-            Any,
-            SimpleNamespace(
-                bus=_Bus(),
-                session_manager=manager,
-                event_bus=_EventBus(),
-                push_tool=_PushTool(),
-                attachment_store=AttachmentStore(tmp_path / "uploads"),
-            ),
-        )
+    await _start_test_channel(
+        channel,
+        bus=_Bus(),
+        attachment_store=AttachmentStore(tmp_path / "uploads"),
     )
     await channel._on_turn_started(
         TurnStarted(

--- a/tests/test_akashic_client_server_lifecycle.py
+++ b/tests/test_akashic_client_server_lifecycle.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
+from typing import cast
 
 import pytest
+import uvicorn
 
 from agent.plugin_composition.channels import StopReceipt
 from plugins.akashic_clients.channel import (
@@ -46,7 +48,7 @@ async def test_start_server_returns_only_after_listener_is_ready() -> None:
     adapter = _adapter()
     server = _FakeServer()
 
-    await adapter._start_server(server, name="test-web")
+    await adapter._start_server(cast(uvicorn.Server, server), name="test-web")
 
     assert server.started is True
     assert len(adapter._servers) == 1
@@ -63,7 +65,7 @@ async def test_start_server_propagates_failure_before_listener_ready() -> None:
     server = _FakeServer(failure=failure)
 
     with pytest.raises(OSError, match="address already in use") as raised:
-        await adapter._start_server(server, name="test-web")
+        await adapter._start_server(cast(uvicorn.Server, server), name="test-web")
 
     assert raised.value is failure
     assert server.should_exit is True
@@ -80,7 +82,7 @@ async def test_start_server_cancels_listener_when_ready_timeout_expires(monkeypa
     )
 
     with pytest.raises(TimeoutError):
-        await adapter._start_server(server, name="test-web")
+        await adapter._start_server(cast(uvicorn.Server, server), name="test-web")
 
     assert server.should_exit is True
     assert adapter._servers == []
@@ -137,7 +139,7 @@ async def test_stop_server_propagates_listener_cleanup_error(
     server.release_cleanup.set()
 
     with pytest.raises(RuntimeError, match="listener cleanup failed"):
-        await _stop_server(server, task)
+        await _stop_server(cast(uvicorn.Server, server), task)
     assert task.done()
 
 
@@ -154,7 +156,7 @@ async def test_stop_server_retains_task_when_cancellation_does_not_settle(
     )
 
     with pytest.raises(TimeoutError, match="did not settle"):
-        await _stop_server(server, task)
+        await _stop_server(cast(uvicorn.Server, server), task)
     assert not task.done()
 
     server.release_cleanup.set()
@@ -167,7 +169,7 @@ async def test_stop_server_preserves_outer_cancellation_after_listener_settles()
     server = _BlockingServer()
     task = asyncio.create_task(server.serve())
     await server.started.wait()
-    stopping = asyncio.create_task(_stop_server(server, task))
+    stopping = asyncio.create_task(_stop_server(cast(uvicorn.Server, server), task))
     await asyncio.sleep(0)
     server.release_cleanup.set()
 

--- a/tests/test_akashic_clients_presentation.py
+++ b/tests/test_akashic_clients_presentation.py
@@ -4,11 +4,14 @@ import asyncio
 from contextlib import asynccontextmanager
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import pytest
+from fastapi import WebSocket
 from starlette.websockets import WebSocketState
 
+from agent.plugin_composition.channels import ProviderClientFactory
+from agent.plugin_composition.context import Context
 from agent.plugin_composition.channels import (
     ChannelCapability,
     ChannelDefinition,
@@ -27,7 +30,7 @@ from plugins.akashic_clients.channel import (
     unregister_generation,
 )
 from plugins.akashic_clients.config import AkashicClientsConfig
-from plugins.akashic_clients.web_chat import WebChatChannel
+from plugins.akashic_clients.web_chat import WebChatChannel, WebNativeChannelAdapter
 
 
 class _Socket:
@@ -148,7 +151,7 @@ class _ApplyContext:
 @pytest.mark.asyncio
 async def test_apply_registers_one_formal_channel_definition() -> None:
     registry = _ChannelRegistry()
-    await plugin.apply(_ApplyContext(registry), AkashicClientsConfig())
+    await plugin.apply(cast(Context, _ApplyContext(registry)), AkashicClientsConfig())
 
     assert registry.definition is not None
     assert registry.definition.name == "akashic"
@@ -178,7 +181,7 @@ def test_same_generation_allows_distinct_binding_tokens(tmp_path: Path) -> None:
                 binding_token=token,
                 config={},
                 credentials={},
-                provider_client_factory=object(),
+                provider_client_factory=cast(ProviderClientFactory, object()),
                 ingress=None,
                 identity=None,
             )
@@ -202,7 +205,7 @@ async def test_web_presents_formal_turn_stream_by_inbound_message_id() -> None:
     channel = WebChatChannel()
     socket = _Socket()
     session_key = "akashic:chat-1"
-    assert await channel._add_connection(session_key, socket) is True
+    assert await channel._add_connection(session_key, cast(WebSocket, socket)) is True
     channel._client_sessions["client-1"] = session_key
     stream = _TurnStream()
     channel.attach_presentation(ChannelPresentationPorts(control=None, turn_stream=stream))
@@ -296,11 +299,11 @@ async def test_web_admission_close_cancels_follow_and_releases_scope() -> None:
     scope = _MessageScope(_FollowingCatalog(reader))
     channel.bind_message_scope(scope)
     socket = _Socket()
-    task = asyncio.create_task(channel._follow(socket, reader.session_id, -1))
+    task = asyncio.create_task(channel._follow(cast(WebSocket, socket), reader.session_id, -1))
     await reader.started.wait()
-    channel._followers[socket] = (reader.session_id, task)
+    channel._followers[cast(WebSocket, socket)] = (reader.session_id, task)
 
-    adapter = SimpleNamespace(binding_token="binding")
+    adapter = cast(WebNativeChannelAdapter, SimpleNamespace(binding_token="binding"))
     channel._v3_adapters["binding"] = adapter
     channel._close_v3_binding(adapter)
     result = await asyncio.wait_for(asyncio.gather(task, return_exceptions=True), timeout=1)

--- a/tests/test_message_follow.py
+++ b/tests/test_message_follow.py
@@ -1,6 +1,7 @@
 import asyncio
 from collections.abc import Mapping
 from contextlib import aclosing, closing, suppress
+from typing import cast
 
 import pytest
 from fastapi.testclient import TestClient
@@ -12,6 +13,7 @@ from bootstrap.reply_status import RuntimeReplyStatus
 from agent.plugin_composition.message_view import follow_messages, message_rows
 from plugins.akashic_clients.chat_api import create_chat_app
 from plugins.akashic_clients.web_chat import WebChatChannel
+from plugins.akashic_clients.services import MessageCatalogPort
 from plugins.reply.status import REPLY_STATUS, ReplyState
 from session.log import MessageLog
 from session.message import ContentPart, ContentReferences, Input, Control, Output
@@ -28,6 +30,10 @@ def page_items(page: Mapping[str, object]) -> list[Mapping[str, object]]:
     assert isinstance(items, list)
     assert all(isinstance(item, Mapping) for item in items)
     return items
+
+
+def _catalog_port(log: MessageLog) -> MessageCatalogPort:
+    return cast(MessageCatalogPort, log.catalog())
 
 
 @pytest.mark.asyncio
@@ -139,7 +145,7 @@ def test_websocket_follow_reads_real_messages_switches_and_disconnects(tmp_path)
         append('akashic:a', 'a1')
         append('akashic:b', 'b0')
         channel = WebChatChannel()
-        app = create_chat_app(workspace=tmp_path, channel=channel, messages=log.catalog())
+        app = create_chat_app(workspace=tmp_path, channel=channel, messages=_catalog_port(log))
         def follow(ws, session, seq):
             ws.send_json({'type': 'session.follow', 'version': 2, 'session_id': session,
                           'after_seq': seq, 'request_id': 'follow'})
@@ -173,7 +179,7 @@ def test_websocket_preview_is_separate_until_same_id_commits(tmp_path):
         state = ReplyState()
         store, tasks = RuntimeSnapshotStore(), Tasks()
         channel = WebChatChannel()
-        app = create_chat_app(workspace=tmp_path, channel=channel, messages=log.catalog(),
+        app = create_chat_app(workspace=tmp_path, channel=channel, messages=_catalog_port(log),
                               reply_status=RuntimeReplyStatus(store).follow)
         with TestClient(app) as client:
             root, snapshot = client.portal.call(status_root, 'socket-reply', state)
@@ -238,7 +244,7 @@ def test_channel_stop_waits_for_active_subscriptions_to_close(tmp_path):
                 await release.wait()
                 finished.set()
         channel = WebChatChannel()
-        app = create_chat_app(workspace=tmp_path, channel=channel, messages=log.catalog(), reply_status=status)
+        app = create_chat_app(workspace=tmp_path, channel=channel, messages=_catalog_port(log), reply_status=status)
         with TestClient(app) as client:
             root, snapshot = client.portal.call(status_root, 'stop', state)
             store.install(snapshot)
@@ -266,7 +272,7 @@ def test_channel_stop_waits_for_active_subscriptions_to_close(tmp_path):
 def test_websocket_follow_rejects_invalid_boundary(tmp_path, changes):
     with closing(MessageLog(tmp_path / 'sessions.db')) as log:
         channel = WebChatChannel()
-        with TestClient(create_chat_app(workspace=tmp_path, channel=channel, messages=log.catalog())) as client:
+        with TestClient(create_chat_app(workspace=tmp_path, channel=channel, messages=_catalog_port(log))) as client:
             with client.websocket_connect('/ws') as ws:
                 ws.send_json({'type': 'session.follow', 'version': 2, 'session_id': 'akashic:new',
                               'after_seq': -1, 'request_id': 'bad', **changes})

--- a/tests/test_mobile_message_follow.py
+++ b/tests/test_mobile_message_follow.py
@@ -24,6 +24,7 @@ from plugins.akashic_clients.mobile_realtime.key_protection import FileMasterKey
 from plugins.akashic_clients.mobile_realtime.message_view import bounded_reply_status, message_json
 from plugins.akashic_clients.mobile_realtime.pairing import PairingService
 from plugins.akashic_clients.mobile_realtime.storage import DeviceRecord, MobileRealtimeStorage
+from plugins.akashic_clients.services import MessageCatalogPort
 from plugins.reply.status import ReplyState
 from session.log import MessageLog
 from session.message import ContentPart, Input, Output, Control
@@ -46,7 +47,7 @@ def gateway(tmp_path):
             authenticator=DeviceAuthenticator(storage, keyset), inbox=DurableInboxManager(storage),
             approvals=PairingApprovalRegistry(loop), keyset=keyset)
         channel = MobileRealtimeChannel(runtime)
-        channel.bind_messages(log.catalog())
+        channel.bind_messages(cast(MessageCatalogPort, log.catalog()))
         runtime.bind_channel(channel)
         with TestClient(create_mobile_gateway_app(runtime)) as client:
             yield log, runtime, client, device, private

--- a/tests/test_mobile_message_input.py
+++ b/tests/test_mobile_message_input.py
@@ -15,6 +15,7 @@ from agent.plugins.manager import PluginManager
 from agent.plugins.snapshot import lease_runtime_snapshot
 from agent.plugin_composition.channels import (
     CHANNEL_INPUT,
+    AttachmentRef,
     ChannelRuntimePorts,
     InboundEnvelope,
     RawInbound,
@@ -29,6 +30,7 @@ from plugins.akashic_clients.mobile_realtime.channel import MobileRealtimeChanne
 from plugins.akashic_clients.mobile_realtime.gateway import MobileGatewayRuntime
 from plugins.akashic_clients.mobile_realtime.protocol import MessageSendCommand
 from plugins.akashic_clients.mobile_realtime.storage import MobileRealtimeStorage
+from plugins.akashic_clients.services import ArtifactStorePort, MessageCatalogPort
 from session.admissions import SessionAdmissions
 from session.identities import ChannelIdentities
 from session.inbound_store import InboundHandoffStore
@@ -147,7 +149,7 @@ class _MessageBusDurablePort:
         *,
         session_key: str,
         provider_message_id: str,
-    ) -> tuple[object, ...] | None:
+    ) -> tuple[AttachmentRef, ...] | None:
         return self._bus.pending_durable_attachment_refs(
             channel="akashic",
             session_key=session_key,
@@ -202,8 +204,8 @@ async def runtime(tmp_path, *, device=None, store_type=InboundHandoffStore):
     bus.bind_session_admission_owner(admissions)
     gateway_runtime = _Runtime(storage)
     channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, gateway_runtime))
-    channel.bind_messages(log.catalog())
-    channel.bind_channel_attachment_store(physical)
+    channel.bind_messages(cast(MessageCatalogPort, log.catalog()))
+    channel.bind_channel_attachment_store(cast(ArtifactStorePort, physical))
     event_bus = EventBus()
     manager = PluginManager([], event_bus=event_bus, workspace=workspace,
         message_log=log, channel_identities=identities, channel_attachment_store=physical,

--- a/tests/test_mobile_message_log.py
+++ b/tests/test_mobile_message_log.py
@@ -22,6 +22,7 @@ from plugins.akashic_clients.mobile_realtime.inbox import DurableInboxManager
 from plugins.akashic_clients.mobile_realtime.key_protection import FileMasterKeyStore, KeysetManager
 from plugins.akashic_clients.mobile_realtime.pairing import PairingService
 from plugins.akashic_clients.mobile_realtime.storage import MobileRealtimeStorage
+from plugins.akashic_clients.services import MessageCatalogPort
 from plugins.models.projection import check_facts, display_facts
 from session.log import MessageLog, SessionAttributes
 from session.message import CallRef, ContentPart, ContentReferences, Control, Input, Output, ToolCall, ToolResult
@@ -36,10 +37,11 @@ def mobile(tmp_path):
         _register_device(storage, device)
         runtime = _Runtime(storage)
         channel = MobileRealtimeChannel(cast(MobileGatewayRuntime, runtime))
-        channel.bind_messages(log.catalog())
+        catalog = cast(MessageCatalogPort, log.catalog())
+        channel.bind_messages(catalog)
         # Private command tests call the handler directly; keep that test-only
         # binding inside the plugin module's explicit direct scope.
-        mobile_channel_module._DIRECT_MESSAGE_CATALOG.set(log.catalog())
+        mobile_channel_module._DIRECT_MESSAGE_CATALOG.set(catalog)
         async def display(page, *, display_only):
             return message_rows(page, display_only=display_only, providers=MessageDisplayProviders(
                 tool_name=lambda binding_id: binding_id,
@@ -284,8 +286,9 @@ async def test_mobile_json_range_authentication_and_reopen(mobile, tmp_path):
     # 重开同一消息库后仍下载同一表示，不依赖内存正文缓存。
     with closing(MessageLog(tmp_path / 'sessions.db')) as reopened:
         channel = MobileRealtimeChannel(runtime)
-        channel.bind_messages(reopened.catalog())
-        mobile_channel_module._DIRECT_MESSAGE_CATALOG.set(reopened.catalog())
+        catalog = cast(MessageCatalogPort, reopened.catalog())
+        channel.bind_messages(catalog)
+        mobile_channel_module._DIRECT_MESSAGE_CATALOG.set(catalog)
         runtime.bind_channel(channel)
         async def receive() -> Message:
             return {'type': 'websocket.disconnect'}

--- a/tests/test_plugin_boundary.py
+++ b/tests/test_plugin_boundary.py
@@ -320,7 +320,7 @@ def test_all_production_python_roots_are_checked() -> None:
     """增加生产包不能让其中的跨插件依赖自动绕过门。"""
     from scripts.measure_production_sloc import PYTHON_DIRECTORY_ROOTS
 
-    for root in set(PYTHON_DIRECTORY_ROOTS) - {"plugins"}:
+    for root in set[str](PYTHON_DIRECTORY_ROOTS) - {"plugins"}:
         assert boundary.check_core_imports_plugin([_import(f"{root}/probe.py", "plugins.alpha")])
         assert boundary.check_plugin_deep_core([_import("plugins/alpha/plugin.py", f"{root}.probe")])
 

--- a/tests/test_web_chat_channel.py
+++ b/tests/test_web_chat_channel.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Mapping
 from contextlib import closing
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
@@ -37,6 +38,10 @@ from agent.plugin_composition.channels import (
     RawInbound,
 )
 from plugins.akashic_clients.services import ModelCatalogUnavailable
+from plugins.akashic_clients.services import (
+    ArtifactStorePort,
+    MessageCatalogPort,
+)
 from plugins.akashic_clients.message_types import (
     AttachmentKind,
     ChannelAttachment,
@@ -45,6 +50,42 @@ from plugins.akashic_clients.message_types import (
 )
 from plugins.akashic_clients.web_chat import UploadTooLargeError, WebChatChannel
 from plugins.models.selection import read_saved
+from session.log import MessageLog
+
+
+@dataclass
+class _TurnStartedEvent:
+    session_key: str
+    channel: str
+    chat_id: str
+    content: str
+    timestamp: object
+    turn_id: str
+    control_turn_id: str
+    client_message_id: str
+
+
+@dataclass
+class _StreamDeltaReadyEvent:
+    session_key: str
+    channel: str
+    chat_id: str
+    turn_id: str
+    content_delta: str
+    thinking_delta: str
+
+
+@dataclass
+class _TurnOutputCompletedEvent:
+    session_key: str
+    channel: str
+    chat_id: str
+    turn_id: str
+    client_message_id: str
+
+
+def _catalog_port(log: MessageLog) -> MessageCatalogPort:
+    return cast(MessageCatalogPort, log.catalog())
 
 
 class _Bus:
@@ -378,7 +419,7 @@ def test_chat_model_catalog_reports_session_override(tmp_path: Path) -> None:
             channel=channel,
             model_catalog_reader=read_catalog,
             model_selection_reader=read_selection,
-            messages=log.catalog(),
+            messages=_catalog_port(log),
         )
 
         response = TestClient(app).get(
@@ -805,7 +846,7 @@ def test_chat_messages_default_to_latest_seq_order(tmp_path: Path) -> None:
         writer = log.writer("akashic:abc", author="user", source="conversation", body_types=(Input,), content={})
         for index in range(52):
             writer.append(str(index), Input(()))
-        app = create_chat_app(workspace=tmp_path, channel=WebChatChannel(), messages=log.catalog())
+        app = create_chat_app(workspace=tmp_path, channel=WebChatChannel(), messages=_catalog_port(log))
         with TestClient(app) as client:
             response = client.get("/api/chat/sessions/akashic:abc/messages")
         payload = response.json()
@@ -830,8 +871,8 @@ def test_chat_messages_project_durable_artifacts_without_paths(tmp_path: Path) -
                    content={"artifact_ref": lambda part: ContentReferences(artifact_ids=(cast(str, part.value),))}).append(
                        "m1", Output((ContentPart("artifact_ref", ref.artifact_id),), "complete"))
         channel = WebChatChannel()
-        channel.bind_artifact_store(store)
-        app = create_chat_app(workspace=tmp_path, channel=channel, messages=log.catalog())
+        channel.bind_artifact_store(cast(ArtifactStorePort, store))
+        app = create_chat_app(workspace=tmp_path, channel=channel, messages=_catalog_port(log))
         with TestClient(app) as client:
             payload = client.get("/api/chat/sessions/akashic:abc/messages").json()
             content = client.get(f"/api/chat/artifacts/{ref.artifact_id}")
@@ -1065,7 +1106,7 @@ async def test_web_turn_lifecycle_projects_server_owned_turn_id() -> None:
     socket = _WebSocket()
     channel._connections["akashic:abc"] = {cast(Any, socket)}
 
-    await channel._on_turn_started(SimpleNamespace(
+    await channel._on_turn_started(_TurnStartedEvent(
         session_key="akashic:abc",
         channel="akashic",
         chat_id="abc",
@@ -1075,7 +1116,7 @@ async def test_web_turn_lifecycle_projects_server_owned_turn_id() -> None:
         control_turn_id="turn:server-owner",
         client_message_id="client-1",
     ))
-    await channel._on_stream_delta(SimpleNamespace(
+    await channel._on_stream_delta(_StreamDeltaReadyEvent(
         session_key="akashic:abc",
         channel="akashic",
         chat_id="abc",
@@ -1083,7 +1124,7 @@ async def test_web_turn_lifecycle_projects_server_owned_turn_id() -> None:
         content_delta="answer",
         thinking_delta="",
     ))
-    await channel._on_output_completed(SimpleNamespace(
+    await channel._on_output_completed(_TurnOutputCompletedEvent(
         session_key="akashic:abc",
         channel="akashic",
         chat_id="abc",
@@ -1106,13 +1147,15 @@ async def test_web_turn_started_rejects_missing_server_turn_id() -> None:
     channel = WebChatChannel()
 
     with pytest.raises(RuntimeError, match="缺少 Server 权威 turn_id"):
-        await channel._on_turn_started(SimpleNamespace(
+        await channel._on_turn_started(_TurnStartedEvent(
             session_key="akashic:abc",
             channel="akashic",
             chat_id="abc",
             content="question",
             timestamp=datetime.now(UTC),
             turn_id="",
+            control_turn_id="",
+            client_message_id="",
         ))
 
 
@@ -1183,7 +1226,7 @@ async def test_web_artifact_api_returns_opaque_upload_and_bounded_readback(
             workspace=tmp_path,
             channel=channel,
             attachment_store=AttachmentStore(tmp_path / "uploads"),
-            artifact_store=artifact_store,
+            artifact_store=cast(ArtifactStorePort, artifact_store),
         )
 
         with TestClient(app) as client:


### PR DESCRIPTION

### One final current-head CI query

At 2026-09-13T06:03:08Z, gh pr checks 669 returned plugin-boundary SUCCESS. No other check was returned, so this is not a claim that the full required CI matrix passed.
